### PR TITLE
Add support for creating ALTs for price feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - cli: Added the `treasury batch-withdraw` subcommand.
+- cli: Added `--authority` option for the `inspect price-feed` subcommand.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - cli: Added the `treasury batch-withdraw` subcommand.
 - cli: Added `--authority` option for the `inspect price-feed` subcommand.
+- cli: Introduced a new ALT type `PriceFeed` for the `alt extend` subcommand.
 
 ### Changed
 

--- a/crates/gmsol/src/chainlink/pull_oracle/pull_oracle_impl.rs
+++ b/crates/gmsol/src/chainlink/pull_oracle/pull_oracle_impl.rs
@@ -103,6 +103,16 @@ impl ChainlinkPullOracleFactory {
             self.feeds.write().unwrap().insert(feed_id, address);
         }
 
+        let feeds = self
+            .feeds
+            .read()
+            .unwrap()
+            .values()
+            .copied()
+            .collect::<Vec<_>>();
+
+        tracing::info!("Using custom feeds: {feeds:#?}");
+
         Ok(txs)
     }
 

--- a/crates/gmsol/src/cli/alt.rs
+++ b/crates/gmsol/src/cli/alt.rs
@@ -1,6 +1,8 @@
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use gmsol::{
-    alt::AddressLookupTableOps, types::TokenMapAccess, utils::instruction::InstructionSerialization,
+    alt::AddressLookupTableOps,
+    types::{PriceProviderKind, TokenMapAccess},
+    utils::instruction::InstructionSerialization,
 };
 
 use crate::GMSOLClient;
@@ -24,6 +26,15 @@ enum Command {
         /// The address of the ALT to extend.
         #[arg(long, group = "alt_input")]
         address: Option<Pubkey>,
+        /// The authority of the price feed.
+        #[arg(long, required_if_eq("kind", "price-feed"))]
+        price_feed_authority: Option<Pubkey>,
+        /// The index of the price feed.
+        #[arg(long, required_if_eq("kind", "price-feed"))]
+        price_feed_index: Option<u16>,
+        /// The provider kind of the price feed.
+        #[arg(long, required_if_eq("kind", "price-feed"))]
+        price_feed_provider: Option<PriceProviderKind>,
         /// Custom addresses to extend.
         custom_addresses: Vec<Pubkey>,
     },
@@ -37,6 +48,8 @@ enum AltKind {
     Common,
     /// Include market related addresses.
     Market,
+    /// Price Feed.
+    PriceFeed,
 }
 
 impl Args {
@@ -52,6 +65,9 @@ impl Args {
                 init,
                 address,
                 custom_addresses,
+                price_feed_authority,
+                price_feed_index,
+                price_feed_provider,
             } => {
                 let mut txns = client.bundle();
 
@@ -61,6 +77,16 @@ impl Args {
                     }
                     AltKind::Common => common_addresses(client, store).await?,
                     AltKind::Market => market_addresses(client, store).await?,
+                    AltKind::PriceFeed => {
+                        price_feed_addresses(
+                            client,
+                            store,
+                            price_feed_authority.expect("must be provided"),
+                            price_feed_index.expect("must be provided"),
+                            price_feed_provider.expect("must be provided"),
+                        )
+                        .await?
+                    }
                 };
 
                 new_addresses.append(&mut custom_addresses.clone());
@@ -75,6 +101,7 @@ impl Args {
                 }
 
                 if !new_addresses.is_empty() {
+                    tracing::info!("extending ALT with addresses: {new_addresses:#?}");
                     let extend_txns = client.extend_alt(&alt, new_addresses.clone(), None)?;
                     txns.append(extend_txns, false)?;
                 }
@@ -90,7 +117,7 @@ impl Args {
                             if let Some(err) = err {
                                 tracing::error!(%err, "some txns are failed");
                             }
-                            tracing::info!(?new_addresses, "successful txns: {signatures:#?}");
+                            tracing::info!("successful txns: {signatures:#?}");
                             println!("{alt}");
                             Ok(())
                         },
@@ -140,6 +167,27 @@ async fn market_addresses(client: &GMSOLClient, store: &Pubkey) -> gmsol::Result
         let market_token = market.meta().market_token_mint;
         addresses.push(market_token);
         addresses.push(client.find_market_vault_address(store, &market_token));
+    }
+
+    Ok(addresses)
+}
+
+async fn price_feed_addresses(
+    client: &GMSOLClient,
+    store: &Pubkey,
+    authority: Pubkey,
+    index: u16,
+    provider: PriceProviderKind,
+) -> gmsol::Result<Vec<Pubkey>> {
+    let mut addresses = vec![authority];
+
+    if let Some(token_map) = client.authorized_token_map_address(store).await? {
+        let token_map = client.token_map(&token_map).await?;
+        for token in token_map.tokens() {
+            let feed_address =
+                client.find_price_feed_address(store, &authority, index, provider, &token);
+            addresses.push(feed_address);
+        }
     }
 
     Ok(addresses)

--- a/programs/gmsol-store/src/states/oracle/feed.rs
+++ b/programs/gmsol-store/src/states/oracle/feed.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use bytemuck::Zeroable;
 use gmsol_utils::InitSpace;
 
 use crate::{
@@ -19,7 +20,8 @@ pub struct PriceFeed {
     pub(crate) index: u16,
     padding_0: [u8; 12],
     pub(crate) store: Pubkey,
-    pub(crate) authority: Pubkey,
+    /// Authority.
+    pub authority: Pubkey,
     pub(crate) token: Pubkey,
     pub(crate) feed_id: Pubkey,
     last_published_at_slot: u64,
@@ -34,6 +36,12 @@ impl InitSpace for PriceFeed {
 
 impl Seed for PriceFeed {
     const SEED: &'static [u8] = b"price_feed";
+}
+
+impl Default for PriceFeed {
+    fn default() -> Self {
+        Zeroable::zeroed()
+    }
 }
 
 impl PriceFeed {


### PR DESCRIPTION
- **chainlink: add log to print the used custom feeds**
- **cli: add `--authority` for the `inspect price-feed` command**
- **cli: introduce a new ALT type `PriceFeed` for the `alt extend`**
