### PR TITLE
Ensure all commands respect the `--priority-lamports` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - programs: Renamed `mock_chainlink_verifier` to `gmsol_mock_chainlink_verifier`.
+- sdk: Added `compute_unit_min_priority_lamports` to `SendBundleOptions`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - programs: Renamed `mock_chainlink_verifier` to `gmsol_mock_chainlink_verifier`.
 - sdk: Added `compute_unit_min_priority_lamports` to `SendBundleOptions`.
+- sdk: Boxed `ClientError` in the `Error` definition.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - cli: Allowed the `migrate referral-code` subcommand to accept multiple addresses and allow the use of user account addresses or owner account addresses.
+- cli: Ensured all commands respect the `--priority-lamports` option.
 
 ## [0.4.0] - 2025-03-08
 

--- a/crates/gmsol/src/cli/admin.rs
+++ b/crates/gmsol/src/cli/admin.rs
@@ -67,14 +67,21 @@ impl AdminArgs {
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         let store = client.find_store_address(store_key);
         match &self.command {
             Command::InitRoles(args) => {
                 crate::utils::instruction_buffer_not_supported(ctx)?;
-                args.run(client, store_key, serialize_only, max_transaction_size)
-                    .await?
+                args.run(
+                    client,
+                    store_key,
+                    serialize_only,
+                    max_transaction_size,
+                    priority_lamports,
+                )
+                .await?
             }
             Command::CreateStore {} => {
                 tracing::info!(
@@ -87,6 +94,7 @@ impl AdminArgs {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("initialized a new data store at tx {signature}");
                         println!("{store}");
@@ -107,6 +115,7 @@ impl AdminArgs {
                         ctx,
                         serialize_only,
                         skip_preflight,
+                        Some(priority_lamports),
                         |signature| {
                             tracing::info!(
                             "transferred store authority to `{new_authority}` at tx {signature}"
@@ -136,6 +145,7 @@ impl AdminArgs {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("accepted store authority at tx {signature}");
                         Ok(())
@@ -155,6 +165,7 @@ impl AdminArgs {
                         ctx,
                         serialize_only,
                         skip_preflight,
+                        Some(priority_lamports),
                         |signature| {
                             tracing::info!(
                                 "transferred receiver authority to `{new_receiver}` at tx {signature}"
@@ -184,6 +195,7 @@ impl AdminArgs {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("enabled role `{role}` at tx {signature}");
                         Ok(())
@@ -198,6 +210,7 @@ impl AdminArgs {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("disabled role `{role}` at tx {signature}");
                         Ok(())
@@ -212,6 +225,7 @@ impl AdminArgs {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("granted a role for user {authority} at tx {signature}");
                         Ok(())
@@ -226,6 +240,7 @@ impl AdminArgs {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("revoked a role for user {authority} at tx {signature}");
                         Ok(())
@@ -269,6 +284,7 @@ impl InitializeRoles {
         store_key: &str,
         serialize_only: Option<InstructionSerialization>,
         max_transaction_size: Option<usize>,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         let store = client.find_store_address(store_key);
 
@@ -361,6 +377,7 @@ impl InitializeRoles {
             None,
             serialize_only,
             self.skip_preflight,
+            Some(priority_lamports),
             |signatures, error| {
                 println!("{signatures:#?}");
                 match error {

--- a/crates/gmsol/src/cli/alt.rs
+++ b/crates/gmsol/src/cli/alt.rs
@@ -58,6 +58,7 @@ impl Args {
         client: &GMSOLClient,
         store: &Pubkey,
         serialize_only: Option<InstructionSerialization>,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         match &self.command {
             Command::Extend {
@@ -113,6 +114,7 @@ impl Args {
                         None,
                         serialize_only,
                         true,
+                        Some(priority_lamports),
                         |signatures, err| {
                             if let Some(err) = err {
                                 tracing::error!(%err, "some txns are failed");

--- a/crates/gmsol/src/cli/controller.rs
+++ b/crates/gmsol/src/cli/controller.rs
@@ -39,6 +39,7 @@ impl ControllerArgs {
         client: &GMSOLClient,
         store: &Pubkey,
         serialize_only: Option<InstructionSerialization>,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         match &self.command {
             Command::InsertAmount { amount, key } => {
@@ -48,6 +49,7 @@ impl ControllerArgs {
                     None,
                     serialize_only,
                     true,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -62,6 +64,7 @@ impl ControllerArgs {
                     None,
                     serialize_only,
                     true,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -76,6 +79,7 @@ impl ControllerArgs {
                     None,
                     serialize_only,
                     true,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())

--- a/crates/gmsol/src/cli/exchange.rs
+++ b/crates/gmsol/src/cli/exchange.rs
@@ -377,6 +377,7 @@ impl ExchangeArgs {
         instruction_buffer: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         let nonce = self.nonce.map(|nonce| nonce.to_bytes());
@@ -872,6 +873,7 @@ impl ExchangeArgs {
             instruction_buffer,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
         )
         .await?;
 

--- a/crates/gmsol/src/cli/feature_keeper.rs
+++ b/crates/gmsol/src/cli/feature_keeper.rs
@@ -37,6 +37,7 @@ impl Args {
         client: &GMSOLClient,
         store: &Pubkey,
         serialize_only: Option<InstructionSerialization>,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         match self.command {
             Command::Toggle {
@@ -55,6 +56,7 @@ impl Args {
                     None,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         let msg = if enable { "enabled" } else { "disabled" };
                         tracing::info!("{msg} feature: {}", display_feature(domain, action));

--- a/crates/gmsol/src/cli/glv.rs
+++ b/crates/gmsol/src/cli/glv.rs
@@ -245,7 +245,7 @@ impl Args {
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         let selected = &self.glv_token;
-        let mut rpc = match &self.command {
+        let rpc = match &self.command {
             Command::Init { market_tokens } => {
                 let Some(index) = selected.index else {
                     return Err(gmsol::Error::invalid_argument(
@@ -304,6 +304,7 @@ impl Args {
                             ctx,
                             serialize_only,
                             skip_preflight,
+                            Some(priority_lamports),
                             |signatures, err| {
                                 tracing::info!("{signatures:#?}");
                                 match err {
@@ -353,6 +354,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                 )
                 .await;
             }
@@ -372,6 +374,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                 )
                 .await;
             }
@@ -508,15 +511,13 @@ impl Args {
             }
         };
 
-        rpc.compute_budget_mut()
-            .set_min_priority_lamports(Some(priority_lamports));
-
         crate::utils::send_or_serialize_transaction(
             store,
             rpc,
             ctx,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
             |signature| {
                 tracing::info!("{signature}");
                 Ok(())

--- a/crates/gmsol/src/cli/gt.rs
+++ b/crates/gmsol/src/cli/gt.rs
@@ -81,6 +81,7 @@ impl Args {
         timelock: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         match &self.command {
             Command::Status { debug } => {
@@ -133,6 +134,7 @@ impl Args {
                     timelock,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -163,6 +165,7 @@ impl Args {
                     timelock,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -178,6 +181,7 @@ impl Args {
                     timelock,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -218,6 +222,7 @@ impl Args {
                             timelock,
                             serialize_only,
                             skip_preflight,
+                            Some(priority_lamports),
                             |signature| {
                                 println!("{signature}");
                                 Ok(())
@@ -235,6 +240,7 @@ impl Args {
                             timelock,
                             serialize_only,
                             skip_preflight,
+                            Some(priority_lamports),
                             |signature| {
                                 println!("{signature}");
                                 Ok(())

--- a/crates/gmsol/src/cli/main.rs
+++ b/crates/gmsol/src/cli/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::rc::Rc;
 
 use admin::AdminArgs;
@@ -298,6 +300,7 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                     self.max_transaction_size,
                 )
                 .await?
@@ -309,6 +312,7 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                     self.max_transaction_size,
                 )
                 .await?
@@ -320,14 +324,21 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                     self.max_transaction_size,
                 )
                 .await?
             }
             Command::Timelock(args) => {
                 crate::utils::instruction_buffer_not_supported(instruction_buffer_ctx)?;
-                args.run(&client, &store, self.serialize_only, self.skip_preflight)
-                    .await?
+                args.run(
+                    &client,
+                    &store,
+                    self.serialize_only,
+                    self.skip_preflight,
+                    self.priority_lamports,
+                )
+                .await?
             }
             Command::Inspect(args) => args.run(&client, &store).await?,
             Command::Exchange(args) => {
@@ -337,6 +348,7 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                     self.max_transaction_size,
                 )
                 .await?
@@ -348,13 +360,20 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                     self.max_transaction_size,
                 )
                 .await?
             }
             Command::Market(args) => {
-                args.run(&client, &store, instruction_buffer_ctx, self.serialize_only)
-                    .await?
+                args.run(
+                    &client,
+                    &store,
+                    instruction_buffer_ctx,
+                    self.serialize_only,
+                    self.priority_lamports,
+                )
+                .await?
             }
             Command::Glv(args) => {
                 args.run(
@@ -375,20 +394,24 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                 )
                 .await?
             }
             Command::Controller(args) => {
                 crate::utils::instruction_buffer_not_supported(instruction_buffer_ctx)?;
-                args.run(&client, &store, self.serialize_only).await?
+                args.run(&client, &store, self.serialize_only, self.priority_lamports)
+                    .await?
             }
             Command::Feature(args) => {
                 crate::utils::instruction_buffer_not_supported(instruction_buffer_ctx)?;
-                args.run(&client, &store, self.serialize_only).await?
+                args.run(&client, &store, self.serialize_only, self.priority_lamports)
+                    .await?
             }
             Command::Alt(args) => {
                 crate::utils::instruction_buffer_not_supported(instruction_buffer_ctx)?;
-                args.run(&client, &store, self.serialize_only).await?
+                args.run(&client, &store, self.serialize_only, self.priority_lamports)
+                    .await?
             }
             Command::Other(args) => {
                 args.run(
@@ -397,6 +420,7 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                     self.max_transaction_size,
                 )
                 .await?
@@ -409,6 +433,7 @@ impl Cli {
                     instruction_buffer_ctx,
                     self.serialize_only,
                     self.skip_preflight,
+                    self.priority_lamports,
                     self.max_transaction_size,
                 )
                 .await?

--- a/crates/gmsol/src/cli/market_keeper.rs
+++ b/crates/gmsol/src/cli/market_keeper.rs
@@ -346,6 +346,7 @@ impl Args {
         store: &Pubkey,
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         match &self.command {
             Command::InitOracle {
@@ -375,6 +376,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("initialized an oracle buffer account at tx {signature}");
                         println!("{oracle}");
@@ -397,6 +399,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("created token config map {map} at tx {signature}");
                         println!("{map}");
@@ -412,6 +415,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("set new token map at {signature}");
                         Ok(())
@@ -451,6 +455,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     *skip_preflight,
+                    priority_lamports,
                     *set_token_map,
                     *max_transaction_size,
                     &configs,
@@ -523,6 +528,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -538,6 +544,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -553,6 +560,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -568,6 +576,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("created a new vault {vault} at tx {signature}");
                         println!("{vault}");
@@ -594,7 +603,7 @@ impl Args {
                         None,
                     )
                     .await?;
-                crate::utils::send_or_serialize_transaction(store, request, ctx, serialize_only, false,|signature| {
+                crate::utils::send_or_serialize_transaction(store, request, ctx, serialize_only, false,Some(priority_lamports),|signature| {
                     tracing::info!(
                         "created a new market with {market_token} as its token address at tx {signature}"
                     );
@@ -615,6 +624,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     *skip_preflight,
+                    priority_lamports,
                     *enable,
                     *max_transaction_size,
                     &markets,
@@ -648,6 +658,7 @@ impl Args {
                         ctx,
                         serialize_only,
                         false,
+                        priority_lamports,
                         None,
                         receiver.as_ref(),
                         !*keep_buffer,
@@ -665,6 +676,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!(
                             "market config flag is updated to {value} at tx {signature}"
@@ -689,6 +701,7 @@ impl Args {
                         ctx,
                         serialize_only,
                         *skip_preflight,
+                        priority_lamports,
                         *max_transaction_size,
                         receiver.as_ref(),
                         !*keep_buffers,
@@ -705,6 +718,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     true,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!(
                             "market set to be {} at tx {signature}",
@@ -737,6 +751,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         let pubkey = buffer_keypair.pubkey();
                         tracing::info!("created market config buffer `{pubkey}` at tx {signature}");
@@ -753,6 +768,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("market config buffer `{buffer}` closed at tx {signature}");
                         Ok(())
@@ -792,6 +808,7 @@ impl Args {
                         ctx,
                         serialize_only,
                         *skip_preflight,
+                        priority_lamports,
                         *max_transaction_size,
                         *batch,
                     )
@@ -808,6 +825,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("set the authority of buffer `{buffer}` to `{new_authority}` at tx {signature}");
                         Ok(())
@@ -836,6 +854,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("funded at tx {signature}");
                         Ok(())
@@ -853,6 +872,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!(
                             %market_token,
@@ -893,6 +913,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("initialized GT at tx {signature}");
                         Ok(())
@@ -910,6 +931,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("set order fee discount factors at tx {signature}");
                         Ok(())
@@ -927,6 +949,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("set referral reward factors at tx {signature}");
                         Ok(())
@@ -945,6 +968,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     false,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("set referred discount factor at tx {signature}");
                         Ok(())
@@ -1047,6 +1071,7 @@ async fn insert_token_configs(
     ctx: Option<InstructionBufferCtx<'_>>,
     serialize_only: Option<InstructionSerialization>,
     skip_preflight: bool,
+    priority_lamports: u64,
     set_token_map: bool,
     max_transaction_size: Option<usize>,
     configs: &IndexMap<String, TokenConfig>,
@@ -1095,6 +1120,7 @@ async fn insert_token_configs(
         ctx,
         serialize_only,
         skip_preflight,
+        Some(priority_lamports),
         |signatures, error| {
             tracing::info!("{signatures:#?}");
             match error {
@@ -1127,6 +1153,7 @@ async fn create_markets(
     ctx: Option<InstructionBufferCtx<'_>>,
     serialize_only: Option<InstructionSerialization>,
     skip_preflight: bool,
+    priority_lamports: u64,
     enable: bool,
     max_transaction_size: Option<usize>,
     markets: &IndexMap<String, Market>,
@@ -1164,6 +1191,7 @@ async fn create_markets(
         ctx,
         serialize_only,
         skip_preflight,
+        Some(priority_lamports),
         |signatures, error| {
             println!("{signatures:#?}");
             match error {
@@ -1196,6 +1224,7 @@ impl MarketConfigMap {
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
         batch: NonZeroUsize,
     ) -> gmsol::Result<()> {
@@ -1236,6 +1265,7 @@ impl MarketConfigMap {
             ctx,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
             |signatures, error| {
                 tracing::info!("{signatures:#?}");
                 match error {
@@ -1271,6 +1301,7 @@ impl MarketConfigs {
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
         receiver: Option<&Pubkey>,
         close_buffers: bool,
@@ -1339,6 +1370,7 @@ impl MarketConfigs {
             ctx,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
             |signatures, error| {
                 println!("{signatures:#?}");
                 match error {

--- a/crates/gmsol/src/cli/migration.rs
+++ b/crates/gmsol/src/cli/migration.rs
@@ -35,6 +35,7 @@ impl Args {
         instruction_buffer: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         let bundle = match &self.command {
@@ -99,6 +100,7 @@ impl Args {
             instruction_buffer,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
         )
         .await?;
         Ok(())

--- a/crates/gmsol/src/cli/order_keeper.rs
+++ b/crates/gmsol/src/cli/order_keeper.rs
@@ -138,6 +138,7 @@ impl KeeperArgs {
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         if serialize_only.is_some() {
@@ -148,7 +149,7 @@ impl KeeperArgs {
         match &self.command {
             Command::Watch { wait } => {
                 crate::utils::instruction_buffer_not_supported(ctx)?;
-                let task = Box::pin(self.start_watching(client, store, *wait));
+                let task = Box::pin(self.start_watching(client, store, *wait, priority_lamports));
                 task.await?;
             }
             Command::Pending {
@@ -190,6 +191,7 @@ impl KeeperArgs {
                                         None,
                                         serialize_only,
                                         skip_preflight,
+                                        priority_lamports,
                                         max_transaction_size,
                                     ),
                                 )
@@ -227,6 +229,7 @@ impl KeeperArgs {
                                         None,
                                         serialize_only,
                                         skip_preflight,
+                                        priority_lamports,
                                         max_transaction_size,
                                     ),
                                 )
@@ -264,6 +267,7 @@ impl KeeperArgs {
                                         None,
                                         serialize_only,
                                         skip_preflight,
+                                        priority_lamports,
                                         max_transaction_size,
                                     ),
                                 )
@@ -291,6 +295,7 @@ impl KeeperArgs {
                         ctx,
                         serialize_only,
                         skip_preflight,
+                        priority_lamports,
                         max_transaction_size,
                         Some(self.compute_unit_price),
                     )
@@ -321,6 +326,7 @@ impl KeeperArgs {
                         ctx,
                         serialize_only,
                         skip_preflight,
+                        priority_lamports,
                         max_transaction_size,
                         Some(self.compute_unit_price),
                     )
@@ -342,6 +348,7 @@ impl KeeperArgs {
                         ctx,
                         serialize_only,
                         skip_preflight,
+                        priority_lamports,
                         max_transaction_size,
                         Some(self.compute_unit_price),
                     )
@@ -383,6 +390,7 @@ impl KeeperArgs {
                                 ctx,
                                 serialize_only,
                                 skip_preflight,
+                                priority_lamports,
                                 max_transaction_size,
                                 Some(self.compute_unit_price),
                             )
@@ -397,6 +405,7 @@ impl KeeperArgs {
                                 ctx,
                                 serialize_only,
                                 skip_preflight,
+                                priority_lamports,
                                 max_transaction_size,
                                 Some(self.compute_unit_price),
                             )
@@ -410,6 +419,7 @@ impl KeeperArgs {
                                 ctx,
                                 serialize_only,
                                 skip_preflight,
+                                priority_lamports,
                                 max_transaction_size,
                                 Some(self.compute_unit_price),
                             )
@@ -428,6 +438,7 @@ impl KeeperArgs {
                                 ctx,
                                 serialize_only,
                                 skip_preflight,
+                                priority_lamports,
                                 max_transaction_size,
                                 Some(self.compute_unit_price),
                             )
@@ -445,6 +456,7 @@ impl KeeperArgs {
                                 ctx,
                                 serialize_only,
                                 skip_preflight,
+                                priority_lamports,
                                 max_transaction_size,
                                 Some(self.compute_unit_price),
                             )
@@ -463,6 +475,7 @@ impl KeeperArgs {
                                 ctx,
                                 serialize_only,
                                 skip_preflight,
+                                priority_lamports,
                                 max_transaction_size,
                                 Some(self.compute_unit_price),
                             )
@@ -480,6 +493,7 @@ impl KeeperArgs {
                                 ctx,
                                 serialize_only,
                                 skip_preflight,
+                                priority_lamports,
                                 max_transaction_size,
                                 Some(self.compute_unit_price),
                             )
@@ -502,6 +516,7 @@ impl KeeperArgs {
         client: &GMSOLClient,
         store: &Pubkey,
         wait: u64,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         use tokio::sync::mpsc;
 
@@ -579,7 +594,7 @@ impl KeeperArgs {
                 tracing::info!(?command, "received new command");
                 match self
                     .with_command(command)
-                    .run(client, &store, None, None, true, None)
+                    .run(client, &store, None, None, true, priority_lamports, None)
                     .await
                 {
                     Ok(()) => {

--- a/crates/gmsol/src/cli/other.rs
+++ b/crates/gmsol/src/cli/other.rs
@@ -97,6 +97,7 @@ impl Args {
         instruction_buffer: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         match &self.command {
@@ -128,6 +129,7 @@ impl Args {
                     instruction_buffer,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -189,6 +191,7 @@ impl Args {
                     instruction_buffer,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -216,6 +219,7 @@ impl Args {
                     instruction_buffer,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         println!("{signature}");
                         Ok(())
@@ -240,6 +244,7 @@ impl Args {
                     instruction_buffer,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("{signature}");
                         Ok(())
@@ -260,6 +265,7 @@ impl Args {
                     instruction_buffer,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("{signature}");
                         Ok(())
@@ -279,6 +285,7 @@ impl Args {
                     instruction_buffer,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signature| {
                         tracing::info!("{signature}");
                         Ok(())
@@ -356,6 +363,7 @@ impl Args {
                     instruction_buffer,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                 )
                 .await
             }

--- a/crates/gmsol/src/cli/timelock.rs
+++ b/crates/gmsol/src/cli/timelock.rs
@@ -72,6 +72,7 @@ impl Args {
         store: &Pubkey,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
     ) -> gmsol::Result<()> {
         let req = match &self.command {
             Command::Config => {
@@ -154,6 +155,7 @@ impl Args {
                     None,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                     |signatures, error| {
                         match error {
                             Some(err) => {
@@ -194,6 +196,7 @@ impl Args {
             None,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
             |signature| {
                 tracing::info!("{signature}");
                 Ok(())

--- a/crates/gmsol/src/cli/treasury.rs
+++ b/crates/gmsol/src/cli/treasury.rs
@@ -160,6 +160,7 @@ impl Args {
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         let req = match &self.command {
@@ -337,6 +338,7 @@ impl Args {
                             ctx,
                             serialize_only,
                             skip_preflight,
+                            Some(priority_lamports),
                             |signatures, error| {
                                 match error {
                                     Some(err) => {
@@ -367,6 +369,7 @@ impl Args {
                             ctx,
                             serialize_only,
                             skip_preflight,
+                            Some(priority_lamports),
                             |signatures, error| {
                                 match error {
                                     Some(err) => {
@@ -553,6 +556,7 @@ impl Args {
                     ctx,
                     serialize_only,
                     skip_preflight,
+                    Some(priority_lamports),
                 )
                 .await;
             }
@@ -563,6 +567,7 @@ impl Args {
             ctx,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
             |signature| {
                 tracing::info!("{signature}");
                 Ok(())

--- a/crates/gmsol/src/cli/user.rs
+++ b/crates/gmsol/src/cli/user.rs
@@ -36,6 +36,7 @@ impl Args {
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
     ) -> gmsol::Result<()> {
         let options = BundleOptions {
@@ -74,6 +75,7 @@ impl Args {
             ctx,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
         )
         .await
     }

--- a/crates/gmsol/src/cli/utils/executor.rs
+++ b/crates/gmsol/src/cli/utils/executor.rs
@@ -81,6 +81,7 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> Executor<'a, C> {
         ctx: Option<InstructionBufferCtx<'_>>,
         serialize_only: Option<InstructionSerialization>,
         skip_preflight: bool,
+        priority_lamports: u64,
         max_transaction_size: Option<usize>,
         compute_unit_price: Option<u64>,
     ) -> gmsol::Result<()> {
@@ -153,6 +154,7 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> Executor<'a, C> {
             ctx,
             serialize_only,
             skip_preflight,
+            Some(priority_lamports),
         )
         .await?;
 

--- a/crates/gmsol/src/error.rs
+++ b/crates/gmsol/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     Anchor(AnchorError),
     /// Client Error.
     #[error("{0:#?}")]
-    Client(anchor_client::ClientError),
+    Client(Box<anchor_client::ClientError>),
     /// Model error.
     #[error("model: {0}")]
     Model(#[from] gmsol_model::Error),
@@ -127,10 +127,10 @@ impl From<anchor_client::ClientError> for Error {
             ClientError::AccountNotFound => Self::NotFound,
             ClientError::SolanaClientError(error) => match handle_solana_client_error(&error) {
                 Some(err) => err,
-                None => Self::Client(ClientError::SolanaClientError(error)),
+                None => Self::Client(Box::new(ClientError::SolanaClientError(error))),
             },
             ClientError::SolanaClientPubsubError(err) => Self::from(err),
-            err => Self::Client(err),
+            err => Self::Client(Box::new(err)),
         }
     }
 }
@@ -149,7 +149,7 @@ impl From<gmsol_solana_utils::Error> for Error {
 
 impl From<anchor_client::anchor_lang::error::Error> for Error {
     fn from(value: anchor_client::anchor_lang::error::Error) -> Self {
-        Self::Client(value.into())
+        Self::Client(Box::new(value.into()))
     }
 }
 


### PR DESCRIPTION
- **sdk: add min priority fee option to `SendBundleOptions`**
- **cli: ensure all commands respect the `--priority-lamports` option**
- **sdk: box `ClientError` in the `Error` definition**
