### PR TITLE
fix(cli): Add an option to enable idempotent price updates for cli

### DIFF
--- a/crates/cli/src/commands/exchange/executor.rs
+++ b/crates/cli/src/commands/exchange/executor.rs
@@ -29,7 +29,7 @@ pub struct ExecutorArgs {
     #[arg(long, default_value_t = 0)]
     feed_index: u16,
     /// Whether to enable idempotent price updates for Chainlink.
-    #[arg(long, default_value_t = true)]
+    #[arg(long, default_value_t = false)]
     chainlink_idempotent: bool,
 }
 


### PR DESCRIPTION
Add an option to enable idempotent price updates for the CLI's exchange execute command.