### PR TITLE
add reqwest timeouts for rpc and oracle http calls

### DIFF
--- a/crates/sdk/src/client/chainlink/pull_oracle/client.rs
+++ b/crates/sdk/src/client/chainlink/pull_oracle/client.rs
@@ -149,7 +149,7 @@ impl Client {
         Ok(Self {
             base: base.into_url()?,
             ws_base: ws_base.into_url()?,
-            client: reqwest::Client::new(),
+            client: crate::client::http_timeout::streaming_http_client(),
             credential: Arc::new(credential),
         })
     }
@@ -202,7 +202,10 @@ impl Client {
     where
         T: Serialize,
     {
-        self.get_inner(path, query, sign, false)
+        Ok(
+            self.get_inner(path, query, sign, false)?
+                .timeout(crate::client::http_timeout::REST_REQUEST_TIMEOUT),
+        )
     }
 
     /// Get available feeds.

--- a/crates/sdk/src/client/http_timeout.rs
+++ b/crates/sdk/src/client/http_timeout.rs
@@ -1,0 +1,43 @@
+//! Default timeouts for outbound HTTP clients.
+//!
+//! [`reqwest::Client::new`] applies no connect or request timeout, so a stuck peer can block
+//! async workers indefinitely. These helpers set conservative bounds for RPC-style calls while
+//! leaving long-lived streams (Hermes SSE, Chainlink WS) without a full-response timeout.
+
+use std::time::Duration;
+
+use reqwest::Client;
+
+/// Connect handshake bound for all outbound HTTP integrations in this crate.
+pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Idle connection eviction for the reqwest connection pool.
+pub(crate) const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Typical REST / JSON response (Hermes latest price, Chaos recommendations, etc.).
+pub(crate) const REST_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+const TCP_KEEPALIVE: Duration = Duration::from_secs(60);
+
+/// HTTP client for request/response calls where the full body should finish within
+/// [`REST_REQUEST_TIMEOUT`].
+pub(crate) fn bounded_rest_client() -> Client {
+    Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REST_REQUEST_TIMEOUT)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .tcp_keepalive(TCP_KEEPALIVE)
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}
+
+/// HTTP client for long-lived streams (SSE, WebSocket upgrade). Only the connect phase is
+/// strictly bounded; reading the body can take as long as the stream stays open.
+pub(crate) fn streaming_http_client() -> Client {
+    Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .tcp_keepalive(TCP_KEEPALIVE)
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}

--- a/crates/sdk/src/client/mod.rs
+++ b/crates/sdk/src/client/mod.rs
@@ -31,6 +31,14 @@ pub mod instruction_buffer;
 /// Program IDs.
 pub mod program_ids;
 
+/// Default HTTP timeouts for oracle and similar outbound clients.
+#[cfg(any(
+    feature = "pyth",
+    feature = "chainlink",
+    feature = "chaoslabs-risk-oracle"
+))]
+pub(crate) mod http_timeout;
+
 /// Chainlink support.
 #[cfg(feature = "chainlink")]
 pub mod chainlink;

--- a/crates/sdk/src/client/pyth/pull_oracle/hermes.rs
+++ b/crates/sdk/src/client/pyth/pull_oracle/hermes.rs
@@ -14,7 +14,7 @@ use reqwest::{Client, IntoUrl, Url};
 
 pub use pyth_sdk::Identifier;
 
-use crate::client::pyth::pubkey_to_identifier;
+use crate::client::{http_timeout, pyth::pubkey_to_identifier};
 
 /// Default base URL for Hermes.
 pub const DEFAULT_HERMES_BASE: &str = "https://hermes.pyth.network";
@@ -41,7 +41,7 @@ impl Hermes {
     pub fn try_new(base: impl IntoUrl) -> crate::Result<Self> {
         Ok(Self {
             base: base.into_url()?,
-            client: Client::new(),
+            client: http_timeout::streaming_http_client(),
         })
     }
 
@@ -83,6 +83,7 @@ impl Hermes {
             .client
             .get(self.base.join(PRICE_LATEST).map_err(crate::Error::custom)?)
             .query(&params)
+            .timeout(http_timeout::REST_REQUEST_TIMEOUT)
             .send()
             .await?
             .json()
@@ -106,6 +107,7 @@ impl Hermes {
             .client
             .get(self.base.join(&path).map_err(crate::Error::custom)?)
             .query(&params)
+            .timeout(http_timeout::REST_REQUEST_TIMEOUT)
             .send()
             .await?
             .json()
@@ -182,7 +184,7 @@ impl Default for Hermes {
     fn default() -> Self {
         Self {
             base: DEFAULT_HERMES_BASE.parse().unwrap(),
-            client: Default::default(),
+            client: http_timeout::streaming_http_client(),
         }
     }
 }

--- a/crates/sdk/src/client/risk_oracle/client.rs
+++ b/crates/sdk/src/client/risk_oracle/client.rs
@@ -23,7 +23,7 @@ impl ChaosClient {
         Ok(Self {
             base_url,
             api_key,
-            http: reqwest::Client::new(),
+            http: crate::client::http_timeout::bounded_rest_client(),
         })
     }
 

--- a/crates/solana-utils/src/client_traits/rpc_sender/http_rpc_sender.rs
+++ b/crates/solana-utils/src/client_traits/rpc_sender/http_rpc_sender.rs
@@ -32,7 +32,7 @@ pub struct HttpRpcSender {
 impl HttpRpcSender {
     /// Create an HTTP RPC sender with default reqwest client.
     pub fn new(url: impl ToString) -> Self {
-        Self::new_with_client(url, Default::default())
+        Self::new_with_client(url, default_rpc_client())
     }
 
     /// Create an HTTP RPC sender.
@@ -50,6 +50,16 @@ impl HttpRpcSender {
     pub fn default_headers() -> header::HeaderMap {
         header::HeaderMap::new()
     }
+}
+
+fn default_rpc_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(180))
+        .pool_idle_timeout(Duration::from_secs(90))
+        .tcp_keepalive(Duration::from_secs(60))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
 }
 
 struct StatsUpdater<'a> {


### PR DESCRIPTION
## what this does

reqwest default client does not set connect or overall request timeouts, so a misbehaving rpc or oracle endpoint can leave tasks waiting without a clean failure. this change adds bounded timeouts for:

- `HttpRpcSender` (json-rpc over http): 15s connect, 180s total (room for heavy simulate), pool idle and tcp keepalive
- pyth hermes: streaming client without a full-response timeout (sse), plus per-request timeout on rest calls (`/latest`, historical)
- chainlink data streams: same split — websocket upgrade stays long-lived; signed rest `get` calls get the shared rest timeout
- chaos labs risk oracle: bounded rest client

## testing

local `cargo check` on this machine hit a windows gnu toolchain issue building `ring` (missing gcc); the edits are straightforward api usage only.

made by mooncitydev