### PR TITLE
feat(sdk): add standardized simulation error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- sdk(js): The `simulate_*` methods of `Simulator` now throw structured `SimulationError` values (`{ code, message, details }`) instead of plain strings.
+
+### Added
+
+- sdk(sdk): Added `SimulationError` and `SimulationErrorCode` with stable codes and messages for simulation failures.
+
 ## [0.9.0] - 2026-02-04
 
 ### Added

--- a/crates/programs/src/constants/mod.rs
+++ b/crates/programs/src/constants/mod.rs
@@ -25,3 +25,19 @@ pub const NUM_MARKET_FLAGS: usize = 8;
 
 /// Max length of the role anme.
 pub const MAX_ROLE_NAME_LEN: usize = 32;
+
+/// Error message indicating the virtual inventory for swaps is required but missing.
+pub const VI_FOR_SWAPS_MISSING_ERROR: &str =
+    "virtual inventory for swaps should be present but is missing";
+
+/// Error message indicating the virtual inventory for swaps is provided but not expected.
+pub const VI_FOR_SWAPS_UNEXPECTED_ERROR: &str =
+    "virtual inventory for swaps should not be present but is provided";
+
+/// Error message indicating the virtual inventory for positions is required but missing.
+pub const VI_FOR_POSITIONS_MISSING_ERROR: &str =
+    "virtual inventory for positions should be present but is missing";
+
+/// Error message indicating the virtual inventory for positions is provided but not expected.
+pub const VI_FOR_POSITIONS_UNEXPECTED_ERROR: &str =
+    "virtual inventory for positions should not be present but is provided";

--- a/crates/programs/src/model/market.rs
+++ b/crates/programs/src/model/market.rs
@@ -544,10 +544,10 @@ impl MarketModel {
 
         match (market_has_vi, model_has_vi) {
             (true, false) => Err(gmsol_model::Error::InvalidArgument(
-                "virtual inventory for swaps should be present but is missing",
+                crate::constants::VI_FOR_SWAPS_MISSING_ERROR,
             )),
             (false, true) => Err(gmsol_model::Error::InvalidArgument(
-                "virtual inventory for swaps should not be present but is provided",
+                crate::constants::VI_FOR_SWAPS_UNEXPECTED_ERROR,
             )),
             _ => Ok(()),
         }
@@ -569,10 +569,10 @@ impl MarketModel {
 
         match (market_has_vi, model_has_vi) {
             (true, false) => Err(gmsol_model::Error::InvalidArgument(
-                "virtual inventory for positions should be present but is missing",
+                crate::constants::VI_FOR_POSITIONS_MISSING_ERROR,
             )),
             (false, true) => Err(gmsol_model::Error::InvalidArgument(
-                "virtual inventory for positions should not be present but is provided",
+                crate::constants::VI_FOR_POSITIONS_UNEXPECTED_ERROR,
             )),
             _ => Ok(()),
         }

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -60,6 +60,10 @@ pub enum Error {
     /// Market closed error.
     #[error("market closed: {0}")]
     MarketClosed(String),
+    /// Simulation error.
+    #[cfg(simulation)]
+    #[error("simulation: {0}")]
+    Simulation(crate::simulation::SimulationError),
     /// Convert integer error.
     #[error(transparent)]
     ConvertInterger(#[from] std::num::TryFromIntError),
@@ -87,6 +91,13 @@ impl Error {
     /// Create a [`MarketClosed`](Error::MarketClosed) error.
     pub fn market_closed(msg: impl ToString) -> Self {
         Self::MarketClosed(msg.to_string())
+    }
+}
+
+#[cfg(simulation)]
+impl From<crate::simulation::SimulationError> for Error {
+    fn from(value: crate::simulation::SimulationError) -> Self {
+        Self::Simulation(value)
     }
 }
 

--- a/crates/sdk/src/js/simulation/simulator.rs
+++ b/crates/sdk/src/js/simulation/simulator.rs
@@ -16,7 +16,7 @@ use crate::{
     js::glv::JsGlvModel,
     market::Value,
     serde::StringPubkey,
-    simulation::{order::UpdatePriceOptions, SimulationOptions, Simulator},
+    simulation::{order::UpdatePriceOptions, SimulationError, SimulationOptions, Simulator},
 };
 
 use crate::js::{
@@ -145,9 +145,11 @@ impl JsSimulator {
     pub fn disable_vis(&self) -> bool {
         self.disable_vis
     }
+}
 
+impl JsSimulator {
     /// Simulate an order execution.
-    pub fn simulate_order(
+    fn simulate_order_impl(
         &mut self,
         args: SimulateOrderArgs,
         position: Option<JsPosition>,
@@ -189,7 +191,7 @@ impl JsSimulator {
     }
 
     /// Simulate a deposit execution.
-    pub fn simulate_deposit(
+    fn simulate_deposit_impl(
         &mut self,
         args: SimulateDepositArgs,
     ) -> crate::Result<JsDepositSimulationOutput> {
@@ -227,7 +229,7 @@ impl JsSimulator {
     }
 
     /// Simulate a withdrawal execution.
-    pub fn simulate_withdrawal(
+    fn simulate_withdrawal_impl(
         &mut self,
         args: SimulateWithdrawalArgs,
     ) -> crate::Result<JsWithdrawalSimulationOutput> {
@@ -271,7 +273,7 @@ impl JsSimulator {
     }
 
     /// Simulate a shift execution.
-    pub fn simulate_shift(
+    fn simulate_shift_impl(
         &mut self,
         args: SimulateShiftArgs,
     ) -> crate::Result<JsShiftSimulationOutput> {
@@ -304,7 +306,7 @@ impl JsSimulator {
     }
 
     /// Simulate a GLV deposit execution.
-    pub fn simulate_glv_deposit(
+    fn simulate_glv_deposit_impl(
         &mut self,
         args: SimulateGlvDepositArgs,
     ) -> crate::Result<JsGlvDepositSimulationOutput> {
@@ -348,7 +350,7 @@ impl JsSimulator {
     }
 
     /// Simulate a GLV withdrawal execution.
-    pub fn simulate_glv_withdrawal(
+    fn simulate_glv_withdrawal_impl(
         &mut self,
         args: SimulateGlvWithdrawalArgs,
     ) -> crate::Result<JsGlvWithdrawalSimulationOutput> {
@@ -391,7 +393,10 @@ impl JsSimulator {
 
         Ok(JsGlvWithdrawalSimulationOutput { output })
     }
+}
 
+#[wasm_bindgen(js_class = Simulator)]
+impl JsSimulator {
     /// Create a clone of this simulator.
     #[wasm_bindgen(js_name = clone)]
     pub fn js_clone(&self) -> Self {
@@ -407,6 +412,79 @@ impl JsSimulator {
     pub fn get_glv_token_value(&self, args: GetGlvTokenValueArgs) -> crate::Result<u128> {
         self.simulator
             .get_glv_token_value(&args.glv_token, args.amount.try_into()?, args.maximize)
+    }
+
+    /// Simulate an order execution.
+    ///
+    /// # Errors
+    /// Throws a [`SimulationError`] with a stable code and message on failure.
+    pub fn simulate_order(
+        &mut self,
+        args: SimulateOrderArgs,
+        position: Option<JsPosition>,
+    ) -> Result<JsOrderSimulationOutput, SimulationError> {
+        self.simulate_order_impl(args, position)
+            .map_err(SimulationError::from)
+    }
+
+    /// Simulate a deposit execution.
+    ///
+    /// # Errors
+    /// Throws a [`SimulationError`] with a stable code and message on failure.
+    pub fn simulate_deposit(
+        &mut self,
+        args: SimulateDepositArgs,
+    ) -> Result<JsDepositSimulationOutput, SimulationError> {
+        self.simulate_deposit_impl(args)
+            .map_err(SimulationError::from)
+    }
+
+    /// Simulate a withdrawal execution.
+    ///
+    /// # Errors
+    /// Throws a [`SimulationError`] with a stable code and message on failure.
+    pub fn simulate_withdrawal(
+        &mut self,
+        args: SimulateWithdrawalArgs,
+    ) -> Result<JsWithdrawalSimulationOutput, SimulationError> {
+        self.simulate_withdrawal_impl(args)
+            .map_err(SimulationError::from)
+    }
+
+    /// Simulate a shift execution.
+    ///
+    /// # Errors
+    /// Throws a [`SimulationError`] with a stable code and message on failure.
+    pub fn simulate_shift(
+        &mut self,
+        args: SimulateShiftArgs,
+    ) -> Result<JsShiftSimulationOutput, SimulationError> {
+        self.simulate_shift_impl(args)
+            .map_err(SimulationError::from)
+    }
+
+    /// Simulate a GLV deposit execution.
+    ///
+    /// # Errors
+    /// Throws a [`SimulationError`] with a stable code and message on failure.
+    pub fn simulate_glv_deposit(
+        &mut self,
+        args: SimulateGlvDepositArgs,
+    ) -> Result<JsGlvDepositSimulationOutput, SimulationError> {
+        self.simulate_glv_deposit_impl(args)
+            .map_err(SimulationError::from)
+    }
+
+    /// Simulate a GLV withdrawal execution.
+    ///
+    /// # Errors
+    /// Throws a [`SimulationError`] with a stable code and message on failure.
+    pub fn simulate_glv_withdrawal(
+        &mut self,
+        args: SimulateGlvWithdrawalArgs,
+    ) -> Result<JsGlvWithdrawalSimulationOutput, SimulationError> {
+        self.simulate_glv_withdrawal_impl(args)
+            .map_err(SimulationError::from)
     }
 }
 

--- a/crates/sdk/src/simulation/deposit.rs
+++ b/crates/sdk/src/simulation/deposit.rs
@@ -6,7 +6,7 @@ use gmsol_programs::gmsol_store::types::CreateDepositParams;
 use solana_sdk::pubkey::Pubkey;
 use typed_builder::TypedBuilder;
 
-use super::{SimulationOptions, Simulator};
+use super::{SimulationError, SimulationErrorCode, SimulationOptions, Simulator};
 
 /// Deposit simulation output.
 #[derive(Debug)]
@@ -66,7 +66,11 @@ impl DepositSimulation<'_> {
         } = self;
 
         if params.initial_long_token_amount == 0 && params.initial_short_token_amount == 0 {
-            return Err(crate::Error::custom("[sim] empty deposit"));
+            return Err(SimulationError::new(
+                SimulationErrorCode::EmptyDeposit,
+                "[sim] empty deposit",
+            )
+            .into());
         }
 
         let (prices, meta) = simulator.get_prices_and_meta_for_market(market_token)?;
@@ -84,7 +88,7 @@ impl DepositSimulation<'_> {
             options.clone(),
         )?;
         if long_swap_output.output_token != long_token {
-            return Err(crate::Error::custom("[sim] invalid long swap path"));
+            return Err(SimulationError::invalid_swap_path("[sim] invalid long swap path").into());
         }
 
         let short_swap_output = simulator.swap_along_path_with_options(
@@ -94,7 +98,7 @@ impl DepositSimulation<'_> {
             options.clone(),
         )?;
         if short_swap_output.output_token != short_token {
-            return Err(crate::Error::custom("[sim] invalid short swap path"));
+            return Err(SimulationError::invalid_swap_path("[sim] invalid short swap path").into());
         }
 
         // Execute deposit.

--- a/crates/sdk/src/simulation/error.rs
+++ b/crates/sdk/src/simulation/error.rs
@@ -1,0 +1,322 @@
+//! Standardized simulation errors.
+
+use gmsol_programs::constants;
+use solana_sdk::pubkey::Pubkey;
+
+/// A stable code identifying the kind of a simulation failure.
+///
+/// The codes and their serialized names are stable: existing variants will
+/// not be renamed or removed, but new variants may be added over time, so
+/// downstream matching should always keep a fallback branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(serde, derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(serde, serde(rename_all = "snake_case"))]
+#[cfg_attr(js, derive(tsify_next::Tsify))]
+#[cfg_attr(js, tsify(into_wasm_abi, from_wasm_abi))]
+#[non_exhaustive]
+pub enum SimulationErrorCode {
+    /// A required market is missing from the simulator.
+    MarketNotFound,
+    /// A required token is missing from the simulator.
+    TokenNotFound,
+    /// Prices for a required token or market are missing or not ready.
+    PricesNotReady,
+    /// The provided swap path is invalid.
+    InvalidSwapPath,
+    /// A required virtual inventory is missing.
+    MissingVirtualInventory,
+    /// A virtual inventory is provided but not expected.
+    UnexpectedVirtualInventory,
+    /// The provided arguments are invalid.
+    InvalidArgument,
+    /// The provided prices are invalid.
+    InvalidPrices,
+    /// The deposit is empty.
+    EmptyDeposit,
+    /// The withdrawal is empty.
+    EmptyWithdrawal,
+    /// The swap is empty.
+    EmptySwap,
+    /// The shift is empty.
+    EmptyShift,
+    /// The GLV deposit is empty.
+    EmptyGlvDeposit,
+    /// The GLV withdrawal is empty.
+    EmptyGlvWithdrawal,
+    /// The reserve is insufficient.
+    InsufficientReserve,
+    /// A PnL factor is exceeded.
+    PnlFactorExceeded,
+    /// The max pool amount is exceeded.
+    MaxPoolAmountExceeded,
+    /// The max pool value is exceeded.
+    MaxPoolValueExceeded,
+    /// The max open interest is exceeded.
+    MaxOpenInterestExceeded,
+    /// The funds are insufficient to pay for the costs.
+    InsufficientFundsToPayForCosts,
+    /// The position state is invalid.
+    InvalidPosition,
+    /// The position is liquidatable.
+    Liquidatable,
+    /// A numeric computation failed.
+    Computation,
+    /// The simulation input or state is invalid.
+    InvalidSimulationInput,
+    /// An unclassified error.
+    Unknown,
+}
+
+impl SimulationErrorCode {
+    /// Returns the stable serialized name of this code.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::MarketNotFound => "market_not_found",
+            Self::TokenNotFound => "token_not_found",
+            Self::PricesNotReady => "prices_not_ready",
+            Self::InvalidSwapPath => "invalid_swap_path",
+            Self::MissingVirtualInventory => "missing_virtual_inventory",
+            Self::UnexpectedVirtualInventory => "unexpected_virtual_inventory",
+            Self::InvalidArgument => "invalid_argument",
+            Self::InvalidPrices => "invalid_prices",
+            Self::EmptyDeposit => "empty_deposit",
+            Self::EmptyWithdrawal => "empty_withdrawal",
+            Self::EmptySwap => "empty_swap",
+            Self::EmptyShift => "empty_shift",
+            Self::EmptyGlvDeposit => "empty_glv_deposit",
+            Self::EmptyGlvWithdrawal => "empty_glv_withdrawal",
+            Self::InsufficientReserve => "insufficient_reserve",
+            Self::PnlFactorExceeded => "pnl_factor_exceeded",
+            Self::MaxPoolAmountExceeded => "max_pool_amount_exceeded",
+            Self::MaxPoolValueExceeded => "max_pool_value_exceeded",
+            Self::MaxOpenInterestExceeded => "max_open_interest_exceeded",
+            Self::InsufficientFundsToPayForCosts => "insufficient_funds_to_pay_for_costs",
+            Self::InvalidPosition => "invalid_position",
+            Self::Liquidatable => "liquidatable",
+            Self::Computation => "computation",
+            Self::InvalidSimulationInput => "invalid_simulation_input",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Returns the stable human readable message for this code.
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::MarketNotFound => "market not found in the simulator",
+            Self::TokenNotFound => "token not found in the simulator",
+            Self::PricesNotReady => "prices are not ready in the simulator",
+            Self::InvalidSwapPath => "invalid swap path",
+            Self::MissingVirtualInventory => "a required virtual inventory is missing",
+            Self::UnexpectedVirtualInventory => "an unexpected virtual inventory is provided",
+            Self::InvalidArgument => "invalid argument",
+            Self::InvalidPrices => "invalid prices",
+            Self::EmptyDeposit => "empty deposit",
+            Self::EmptyWithdrawal => "empty withdrawal",
+            Self::EmptySwap => "empty swap",
+            Self::EmptyShift => "empty shift",
+            Self::EmptyGlvDeposit => "empty GLV deposit",
+            Self::EmptyGlvWithdrawal => "empty GLV withdrawal",
+            Self::InsufficientReserve => "insufficient reserve",
+            Self::PnlFactorExceeded => "pnl factor exceeded",
+            Self::MaxPoolAmountExceeded => "max pool amount exceeded",
+            Self::MaxPoolValueExceeded => "max pool value exceeded",
+            Self::MaxOpenInterestExceeded => "max open interest exceeded",
+            Self::InsufficientFundsToPayForCosts => "insufficient funds to pay for costs",
+            Self::InvalidPosition => "invalid position state",
+            Self::Liquidatable => "the position is liquidatable",
+            Self::Computation => "computation error",
+            Self::InvalidSimulationInput => "invalid simulation input or state",
+            Self::Unknown => "simulation failed",
+        }
+    }
+}
+
+impl std::fmt::Display for SimulationErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A standardized simulation error.
+///
+/// Contains a stable [`code`](Self::code) for programmatic handling, a stable
+/// [`message`](Self::message) suitable for display, and free-form
+/// [`details`](Self::details) describing the exact failure.
+#[derive(Debug, Clone, thiserror::Error)]
+#[cfg_attr(serde, derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(js, derive(tsify_next::Tsify))]
+#[cfg_attr(js, tsify(into_wasm_abi, from_wasm_abi))]
+#[error("{details}")]
+pub struct SimulationError {
+    /// The stable error code.
+    pub code: SimulationErrorCode,
+    /// The stable message corresponding to the code.
+    pub message: String,
+    /// Details describing the exact failure.
+    pub details: String,
+}
+
+impl SimulationError {
+    /// Creates a new [`SimulationError`] with the given code and details.
+    pub fn new(code: SimulationErrorCode, details: impl ToString) -> Self {
+        Self {
+            code,
+            message: code.message().to_string(),
+            details: details.to_string(),
+        }
+    }
+
+    pub(crate) fn market_not_found(market_token: &Pubkey) -> Self {
+        Self::new(
+            SimulationErrorCode::MarketNotFound,
+            format!("[sim] market `{market_token}` not found in the simulator"),
+        )
+    }
+
+    pub(crate) fn token_not_found(token: &Pubkey) -> Self {
+        Self::new(
+            SimulationErrorCode::TokenNotFound,
+            format!("[sim] token `{token}` is not found in the simulator"),
+        )
+    }
+
+    pub(crate) fn prices_not_ready_for_market(market_token: &Pubkey) -> Self {
+        Self::new(
+            SimulationErrorCode::PricesNotReady,
+            format!("[sim] prices for market `{market_token}` are not ready in the simulator"),
+        )
+    }
+
+    pub(crate) fn price_not_ready(token: &Pubkey) -> Self {
+        Self::new(
+            SimulationErrorCode::PricesNotReady,
+            format!("[sim] price for {token} is not ready"),
+        )
+    }
+
+    pub(crate) fn invalid_swap_path(details: impl ToString) -> Self {
+        Self::new(SimulationErrorCode::InvalidSwapPath, details)
+    }
+}
+
+impl From<crate::Error> for SimulationError {
+    fn from(error: crate::Error) -> Self {
+        match error {
+            crate::Error::Simulation(error) => error,
+            crate::Error::Model(ref err) => Self::new(classify_model_error(err), &error),
+            crate::Error::Custom(ref msg)
+                if msg.starts_with("[sim]") || msg.starts_with("[swap]") =>
+            {
+                Self::new(SimulationErrorCode::InvalidSimulationInput, &error)
+            }
+            error => Self::new(SimulationErrorCode::Unknown, &error),
+        }
+    }
+}
+
+fn classify_model_error(error: &gmsol_model::Error) -> SimulationErrorCode {
+    use gmsol_model::Error as ModelError;
+    use SimulationErrorCode as Code;
+
+    match error {
+        ModelError::InvalidArgument(msg) => match *msg {
+            constants::VI_FOR_SWAPS_MISSING_ERROR | constants::VI_FOR_POSITIONS_MISSING_ERROR => {
+                Code::MissingVirtualInventory
+            }
+            constants::VI_FOR_SWAPS_UNEXPECTED_ERROR
+            | constants::VI_FOR_POSITIONS_UNEXPECTED_ERROR => Code::UnexpectedVirtualInventory,
+            _ => Code::InvalidArgument,
+        },
+        ModelError::EmptyDeposit => Code::EmptyDeposit,
+        ModelError::EmptyWithdrawal => Code::EmptyWithdrawal,
+        ModelError::EmptySwap => Code::EmptySwap,
+        ModelError::InvalidPrices => Code::InvalidPrices,
+        ModelError::InsufficientReserve(..)
+        | ModelError::InsufficientReserveForOpenInterest(..) => Code::InsufficientReserve,
+        ModelError::PnlFactorExceeded(..) => Code::PnlFactorExceeded,
+        ModelError::MaxPoolAmountExceeded(_) => Code::MaxPoolAmountExceeded,
+        ModelError::MaxPoolValueExceeded(_) => Code::MaxPoolValueExceeded,
+        ModelError::MaxOpenInterestExceeded => Code::MaxOpenInterestExceeded,
+        ModelError::InsufficientFundsToPayForCosts(_) => Code::InsufficientFundsToPayForCosts,
+        ModelError::InvalidPosition(_) => Code::InvalidPosition,
+        ModelError::Liquidatable(_) => Code::Liquidatable,
+        ModelError::MintReceiverNotSet
+        | ModelError::WithdrawalVaultNotSet
+        | ModelError::InvalidTokenBalance(..)
+        | ModelError::NotLiquidatable => Code::InvalidArgument,
+        ModelError::Computation(_)
+        | ModelError::PoolComputation(..)
+        | ModelError::PowComputation
+        | ModelError::Overflow
+        | ModelError::DividedByZero
+        | ModelError::Convert
+        | ModelError::InvalidPoolValue(_)
+        | ModelError::BuildParams(_)
+        | ModelError::MissingPoolKind(_)
+        | ModelError::MissingClockKind(_)
+        | ModelError::UnableToGetBorrowingFactorEmptyPoolValue
+        | ModelError::UnableToGetFundingFactorEmptyOpenInterest => Code::Computation,
+        _ => Code::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_model_errors() {
+        let error = SimulationError::from(crate::Error::from(gmsol_model::Error::InvalidArgument(
+            constants::VI_FOR_POSITIONS_MISSING_ERROR,
+        )));
+        assert_eq!(error.code, SimulationErrorCode::MissingVirtualInventory);
+        assert_eq!(
+            error.message,
+            SimulationErrorCode::MissingVirtualInventory.message()
+        );
+        assert!(error.details.contains("virtual inventory for positions"));
+
+        let error = SimulationError::from(crate::Error::from(gmsol_model::Error::InvalidPrices));
+        assert_eq!(error.code, SimulationErrorCode::InvalidPrices);
+
+        let error = SimulationError::from(crate::Error::from(
+            gmsol_model::Error::MaxOpenInterestExceeded,
+        ));
+        assert_eq!(error.code, SimulationErrorCode::MaxOpenInterestExceeded);
+    }
+
+    #[test]
+    fn classify_custom_errors() {
+        let error = SimulationError::from(crate::Error::custom("[sim] trigger price is required"));
+        assert_eq!(error.code, SimulationErrorCode::InvalidSimulationInput);
+
+        let error = SimulationError::from(crate::Error::custom("some other error"));
+        assert_eq!(error.code, SimulationErrorCode::Unknown);
+    }
+
+    #[test]
+    fn typed_errors_pass_through() {
+        let market_token = Pubkey::new_unique();
+        let error = SimulationError::from(crate::Error::from(SimulationError::market_not_found(
+            &market_token,
+        )));
+        assert_eq!(error.code, SimulationErrorCode::MarketNotFound);
+        assert!(error.details.contains(&market_token.to_string()));
+    }
+
+    #[cfg(serde)]
+    #[test]
+    fn code_serialization_matches_as_str() {
+        for code in [
+            SimulationErrorCode::MarketNotFound,
+            SimulationErrorCode::EmptyGlvWithdrawal,
+            SimulationErrorCode::Unknown,
+        ] {
+            let serialized = serde_json::to_value(code).unwrap();
+            assert_eq!(
+                serialized,
+                serde_json::Value::String(code.as_str().to_string())
+            );
+        }
+    }
+}

--- a/crates/sdk/src/simulation/glv_deposit.rs
+++ b/crates/sdk/src/simulation/glv_deposit.rs
@@ -8,7 +8,10 @@ use typed_builder::TypedBuilder;
 
 use crate::{glv::calculator::GlvCalculator, simulation::deposit::DepositSimulation};
 
-use super::{deposit::DepositSimulationOutput, SimulationOptions, Simulator};
+use super::{
+    deposit::DepositSimulationOutput, SimulationError, SimulationErrorCode, SimulationOptions,
+    Simulator,
+};
 
 /// GLV deposit simulation output.
 #[derive(Debug)]
@@ -132,7 +135,11 @@ impl GlvDepositSimulation<'_> {
                     "[sim] insufficient deposit output amount",
                 ));
             } else {
-                return Err(crate::Error::custom("[sim] empty GLV deposit"));
+                return Err(SimulationError::new(
+                    SimulationErrorCode::EmptyGlvDeposit,
+                    "[sim] empty GLV deposit",
+                )
+                .into());
             }
         }
 

--- a/crates/sdk/src/simulation/glv_withdrawal.rs
+++ b/crates/sdk/src/simulation/glv_withdrawal.rs
@@ -8,7 +8,7 @@ use typed_builder::TypedBuilder;
 
 use crate::{constants, glv::calculator::GlvCalculator};
 
-use super::{SimulationOptions, Simulator};
+use super::{SimulationError, SimulationErrorCode, SimulationOptions, Simulator};
 
 /// GLV withdrawal simulation output.
 #[derive(Debug)]
@@ -82,7 +82,11 @@ impl GlvWithdrawalSimulation<'_> {
         } = self;
 
         if params.glv_token_amount == 0 {
-            return Err(crate::Error::custom("[sim] empty GLV withdrawal"));
+            return Err(SimulationError::new(
+                SimulationErrorCode::EmptyGlvWithdrawal,
+                "[sim] empty GLV withdrawal",
+            )
+            .into());
         }
 
         let (market, prices) = simulator.get_market_with_prices(market_token)?;
@@ -151,7 +155,9 @@ impl GlvWithdrawalSimulation<'_> {
             )?;
 
             if swap_output.output_token != long_receive_token {
-                return Err(crate::Error::custom("[sim] invalid long swap path"));
+                return Err(
+                    SimulationError::invalid_swap_path("[sim] invalid long swap path").into(),
+                );
             }
 
             (swap_output.reports, swap_output.amount)
@@ -176,7 +182,9 @@ impl GlvWithdrawalSimulation<'_> {
             )?;
 
             if swap_output.output_token != short_receive_token {
-                return Err(crate::Error::custom("[sim] invalid short swap path"));
+                return Err(
+                    SimulationError::invalid_swap_path("[sim] invalid short swap path").into(),
+                );
             }
 
             (swap_output.reports, swap_output.amount)

--- a/crates/sdk/src/simulation/mod.rs
+++ b/crates/sdk/src/simulation/mod.rs
@@ -1,3 +1,6 @@
+/// Standardized simulation errors.
+pub mod error;
+
 /// Simulator.
 pub mod simulator;
 
@@ -19,4 +22,5 @@ pub mod glv_deposit;
 /// GLV withdrawal simulation.
 pub mod glv_withdrawal;
 
+pub use error::{SimulationError, SimulationErrorCode};
 pub use simulator::{SimulationOptions, Simulator, SwapOutput, TokenState};

--- a/crates/sdk/src/simulation/order.rs
+++ b/crates/sdk/src/simulation/order.rs
@@ -22,7 +22,10 @@ use typed_builder::TypedBuilder;
 
 use crate::builders::order::{CreateOrderKind, CreateOrderParams};
 
-use super::simulator::{SimulationOptions, Simulator, SwapOutput};
+use super::{
+    error::SimulationError,
+    simulator::{SimulationOptions, Simulator, SwapOutput},
+};
 
 /// Order simulation output.
 #[derive(Debug)]
@@ -119,12 +122,14 @@ impl OrderSimulation<'_> {
                 let swap_out = *self.collateral_or_swap_out_token;
                 let swap_in_amount = self.params.amount;
                 let swap_out_amount = self.params.min_output;
-                let swap_in_price = self.simulator.get_price(&swap_in).ok_or_else(|| {
-                    crate::Error::custom(format!("[sim] price for {swap_in} is not ready"))
-                })?;
-                let swap_out_price = self.simulator.get_price(&swap_out).ok_or_else(|| {
-                    crate::Error::custom(format!("[sim] price for {swap_out} is not ready"))
-                })?;
+                let swap_in_price = self
+                    .simulator
+                    .get_price(&swap_in)
+                    .ok_or_else(|| SimulationError::price_not_ready(&swap_in))?;
+                let swap_out_price = self
+                    .simulator
+                    .get_price(&swap_out)
+                    .ok_or_else(|| SimulationError::price_not_ready(&swap_out))?;
                 let slippage = options
                     .limit_swap_slippage
                     .unwrap_or(DEFAULT_LIMIT_SWAP_SLIPPAGE);
@@ -232,7 +237,7 @@ impl OrderSimulation<'_> {
             options.clone(),
         )?;
         if swap_output.output_token() != collateral_or_swap_out_token {
-            return Err(crate::Error::custom("[sim] invalid swap path"));
+            return Err(SimulationError::invalid_swap_path("[sim] invalid swap path").into());
         }
 
         // Execute the increase against a cloned market model, while VI state
@@ -464,7 +469,7 @@ impl OrderSimulation<'_> {
             options.clone(),
         )?;
         if swap_output.output_token() != collateral_or_swap_out_token {
-            return Err(crate::Error::custom("[sim] invalid swap path"));
+            return Err(SimulationError::invalid_swap_path("[sim] invalid swap path").into());
         }
 
         if matches!(kind, CreateOrderKind::LimitSwap) && !options.skip_limit_price_validation {

--- a/crates/sdk/src/simulation/shift.rs
+++ b/crates/sdk/src/simulation/shift.rs
@@ -6,7 +6,7 @@ use gmsol_programs::{gmsol_store::types::CreateShiftParams, model::SwapPricingKi
 use solana_sdk::pubkey::Pubkey;
 use typed_builder::TypedBuilder;
 
-use super::{SimulationOptions, Simulator};
+use super::{SimulationError, SimulationErrorCode, SimulationOptions, Simulator};
 
 /// Shift simulation output.
 #[derive(Debug)]
@@ -50,7 +50,9 @@ impl ShiftSimulation<'_> {
         } = self;
 
         if params.from_market_token_amount == 0 {
-            return Err(crate::Error::custom("[sim] empty shift"));
+            return Err(
+                SimulationError::new(SimulationErrorCode::EmptyShift, "[sim] empty shift").into(),
+            );
         }
 
         let (from_market, prices_for_from_market) =

--- a/crates/sdk/src/simulation/simulator.rs
+++ b/crates/sdk/src/simulation/simulator.rs
@@ -26,6 +26,7 @@ use crate::{
 
 use super::{
     deposit::{DepositSimulation, DepositSimulationBuilder},
+    error::SimulationError,
     glv_deposit::{GlvDepositSimulation, GlvDepositSimulationBuilder},
     glv_withdrawal::{GlvWithdrawalSimulation, GlvWithdrawalSimulationBuilder},
     order::OrderSimulationBuilder,
@@ -169,11 +170,10 @@ impl Simulator {
         token: &Pubkey,
         price: Arc<Price<u128>>,
     ) -> crate::Result<&mut Self> {
-        let state = self.tokens.get_mut(token).ok_or_else(|| {
-            crate::Error::custom(format!(
-                "[sim] token `{token}` is not found in the simulator"
-            ))
-        })?;
+        let state = self
+            .tokens
+            .get_mut(token)
+            .ok_or_else(|| SimulationError::token_not_found(token))?;
         state.price = Some(price);
         Ok(self)
     }
@@ -194,17 +194,14 @@ impl Simulator {
         &self,
         market_token: &Pubkey,
     ) -> crate::Result<(Prices<u128>, &MarketMeta)> {
-        let market = self.markets.get(market_token).ok_or_else(|| {
-            crate::Error::custom(format!(
-                "[sim] market `{market_token}` not found in the simulator"
-            ))
-        })?;
+        let market = self
+            .markets
+            .get(market_token)
+            .ok_or_else(|| SimulationError::market_not_found(market_token))?;
         let meta = &market.meta;
-        let prices = self.get_prices(meta).ok_or_else(|| {
-            crate::Error::custom(format!(
-                "[sim] prices for market `{market_token}` are not ready in the simulator"
-            ))
-        })?;
+        let prices = self
+            .get_prices(meta)
+            .ok_or_else(|| SimulationError::prices_not_ready_for_market(market_token))?;
         Ok((prices, meta))
     }
 
@@ -220,11 +217,9 @@ impl Simulator {
         market_token: &Pubkey,
     ) -> crate::Result<(&MarketModel, Prices<u128>)> {
         let prices = self.get_prices_for_market(market_token)?;
-        let market = self.get_market(market_token).ok_or_else(|| {
-            crate::Error::custom(format!(
-                "[sim] market `{market_token}` not found in the simulator"
-            ))
-        })?;
+        let market = self
+            .get_market(market_token)
+            .ok_or_else(|| SimulationError::market_not_found(market_token))?;
         Ok((market, prices))
     }
 
@@ -246,11 +241,9 @@ impl Simulator {
             vis,
         } = self;
 
-        let market = markets.get_mut(market_token).ok_or_else(|| {
-            crate::Error::custom(format!(
-                "[sim] market `{market_token}` not found in the simulator"
-            ))
-        })?;
+        let market = markets
+            .get_mut(market_token)
+            .ok_or_else(|| SimulationError::market_not_found(market_token))?;
 
         Ok((market, vis))
     }
@@ -314,11 +307,8 @@ impl Simulator {
             // Then borrow market (and VI map if needed) mutably.
             let (market, maybe_vi_map) = if options.disable_vis {
                 (
-                    self.get_market_mut(market_token).ok_or_else(|| {
-                        crate::Error::custom(format!(
-                            "[sim] market `{market_token}` not found in the simulator"
-                        ))
-                    })?,
+                    self.get_market_mut(market_token)
+                        .ok_or_else(|| SimulationError::market_not_found(market_token))?,
                     None,
                 )
             } else {
@@ -328,9 +318,10 @@ impl Simulator {
 
             let meta = &market.meta;
             if meta.long_token_mint == meta.short_token_mint {
-                return Err(crate::Error::custom(format!(
+                return Err(SimulationError::invalid_swap_path(format!(
                     "[swap] `{market_token}` is not a swappable market"
-                )));
+                ))
+                .into());
             }
             let is_token_in_long = if meta.long_token_mint == current_token {
                 current_token = meta.short_token_mint;
@@ -339,9 +330,10 @@ impl Simulator {
                 current_token = meta.long_token_mint;
                 false
             } else {
-                return Err(crate::Error::custom(format!(
+                return Err(SimulationError::invalid_swap_path(format!(
                     "[swap] invalid swap step. Current step: {market_token}"
-                )));
+                ))
+                .into());
             };
             let report = match maybe_vi_map {
                 None => market.with_vis_disabled(|market| {

--- a/crates/sdk/src/simulation/withdrawal.rs
+++ b/crates/sdk/src/simulation/withdrawal.rs
@@ -6,7 +6,7 @@ use gmsol_programs::gmsol_store::types::CreateWithdrawalParams;
 use solana_sdk::pubkey::Pubkey;
 use typed_builder::TypedBuilder;
 
-use super::{SimulationOptions, Simulator};
+use super::{SimulationError, SimulationErrorCode, SimulationOptions, Simulator};
 
 /// Withdrawal simulation output.
 #[derive(Debug)]
@@ -78,7 +78,11 @@ impl WithdrawalSimulation<'_> {
         } = self;
 
         if params.market_token_amount == 0 {
-            return Err(crate::Error::custom("[sim] empty withdrawal"));
+            return Err(SimulationError::new(
+                SimulationErrorCode::EmptyWithdrawal,
+                "[sim] empty withdrawal",
+            )
+            .into());
         }
 
         let prices = simulator.get_prices_for_market(market_token)?;
@@ -126,7 +130,9 @@ impl WithdrawalSimulation<'_> {
             )?;
 
             if swap_output.output_token != long_receive_token {
-                return Err(crate::Error::custom("[sim] invalid long swap path"));
+                return Err(
+                    SimulationError::invalid_swap_path("[sim] invalid long swap path").into(),
+                );
             }
 
             (swap_output.reports, swap_output.amount)
@@ -151,7 +157,9 @@ impl WithdrawalSimulation<'_> {
             )?;
 
             if swap_output.output_token != short_receive_token {
-                return Err(crate::Error::custom("[sim] invalid short swap path"));
+                return Err(
+                    SimulationError::invalid_swap_path("[sim] invalid short swap path").into(),
+                );
             }
 
             (swap_output.reports, swap_output.amount)


### PR DESCRIPTION
Closes #329

## Context

Simulation failures currently surface as free-form `Error::Custom(String)` values, so a caller (especially on the JS side) can only string-match on messages to tell one failure apart from another.

## What this does

Adds `SimulationError { code, message, details }` and `SimulationErrorCode` in `crates/sdk/src/simulation/error.rs`:

- `code` is a stable, `non_exhaustive` enum for programmatic handling; `message` is a stable human-readable string; `details` carries the exact context (the original `[sim] ...` text).
- The internal simulator now builds typed errors at its lookup and swap-path failure points (market/token not found, prices not ready, invalid swap path).
- A `From<crate::Error>` conversion maps everything else to a stable code: `gmsol_model` errors are classified by variant, and the `[sim]`/`[swap]` custom strings fall back to `InvalidSimulationInput` (anything unrecognized becomes `Unknown`).
- On the JS boundary, `Simulator.simulate_*` now returns `SimulationError`, which serializes to `{ code, message, details }` so JS callers can branch on `code`.

To classify the virtual inventory consistency errors without duplicating string literals, the four VI messages in `gmsol-programs` were pulled into named constants (first commit).

## Notes / questions for reviewers

- **Breaking change for JS**: `simulate_*` now throws a structured object instead of a string. Flagged in the CHANGELOG under Breaking Changes. Happy to gate this behind something if you'd rather not break the JS surface in a minor.
- I mapped model variants to codes conservatively; if you'd prefer a different granularity (e.g. splitting `Computation` vs `Overflow`, or a distinct code for `InsufficientFundsToPayForCosts`) I can adjust.
- The `Definition of Done` in the issue mentions a "unified mapping ... at the simulation's external entry point". I put that mapping in `From<crate::Error>` and applied it at the JS entry points; if you also want the native `Simulator` methods to return `SimulationError` directly rather than `crate::Error`, say the word and I'll thread it through.

## Testing

- `cargo test --features u128` (all crates green; 3 new unit tests in `simulation::error` covering model/custom/typed classification and code serialization).
- `cargo clippy -p gmsol-sdk --all-features` and `cargo clippy -p gmsol-programs --all-features`.
- `cargo check -p gmsol-sdk --target wasm32-unknown-unknown --features js`.
- `cargo fmt --check` (1.88).