### PR TITLE
feat(utils): market status + per-token flags

### DIFF
--- a/crates/utils/src/price/feed_price.rs
+++ b/crates/utils/src/price/feed_price.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::zero_copy;
 use crate::{
     price::{
         decimal::{Decimal, DecimalError},
+        market_status::MarketStatus,
         Price, PriceFlag, MAX_PRICE_FLAG,
     },
     token_config::TokenConfig,
@@ -18,7 +19,8 @@ const NANOS_PER_SECOND_U32: u32 = 1_000_000_000;
 pub struct PriceFeedPrice {
     decimals: u8,
     flags: PriceFlagContainer,
-    padding: [u8; 2],
+    market_status_value: u8,
+    padding: [u8; 1],
     last_update_diff: u32,
     ts: i64,
     price: u128,
@@ -39,7 +41,8 @@ impl PriceFeedPrice {
         Self {
             decimals,
             flags: Default::default(),
-            padding: [0; 2],
+            market_status_value: u8::from(MarketStatus::Disabled),
+            padding: [0; 1],
             last_update_diff,
             ts,
             price,
@@ -149,6 +152,16 @@ impl PriceFeedPrice {
                 .saturating_sub(current_diff)
     }
 
+    /// Returns the market status. An invalid stored value maps to [`MarketStatus::Disabled`].
+    pub fn market_status(&self) -> MarketStatus {
+        MarketStatus::try_from(self.market_status_value).unwrap_or(MarketStatus::Disabled)
+    }
+
+    /// Sets the market status.
+    pub fn set_market_status(&mut self, market_status: MarketStatus) {
+        self.market_status_value = u8::from(market_status);
+    }
+
     /// Try converting to [`Price`].
     pub fn try_to_price(&self, token_config: &TokenConfig) -> Result<Price, DecimalError> {
         let token_decimals = token_config.token_decimals();
@@ -174,6 +187,37 @@ impl PriceFeedPrice {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn market_status_round_trip() {
+        let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
+        for status in [
+            MarketStatus::Disabled,
+            MarketStatus::Unknown,
+            MarketStatus::PreMarket,
+            MarketStatus::RegularHours,
+            MarketStatus::PostMarket,
+            MarketStatus::Overnight,
+            MarketStatus::Closed,
+        ] {
+            price.set_market_status(status);
+            assert!(price.market_status() == status);
+        }
+    }
+
+    #[test]
+    fn market_status_invalid_maps_to_disabled() {
+        let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
+        price.market_status_value = 99;
+        assert!(price.market_status() == MarketStatus::Disabled);
+    }
+
+    #[test]
+    fn zeroed_price_market_status_is_disabled() {
+        use bytemuck::Zeroable;
+        let price = PriceFeedPrice::zeroed();
+        assert!(price.market_status() == MarketStatus::Disabled);
+    }
 
     #[test]
     fn test_is_market_open_in_nanoseconds() {

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -39,19 +39,24 @@ pub enum MarketStatus {
 #[repr(u8)]
 #[non_exhaustive]
 pub enum MarketStatusFlag {
-    /// Force RegularHours closed.
-    HaltRegularHours,
+    /// Allow trading while the status is Unknown.
+    AllowUnknown,
     /// Allow trading during pre-market.
     AllowPreMarket,
+    /// Force RegularHours closed. RegularHours is the one status open by
+    /// default (all-zero policy), so this is the inverted flag ("Halt", not
+    /// "Allow").
+    HaltRegularHours,
     /// Allow trading during post-market.
     AllowPostMarket,
     /// Allow trading overnight.
     AllowOvernight,
     /// Allow trading while the status is Closed.
     AllowClosed,
-    /// Allow trading while the status is Unknown.
-    AllowUnknown,
     // CHECK: should have no more than `MAX_MARKET_STATUS_FLAGS` of flags.
+    // CHECK: append-only. Each variant's position is a persisted bitmap bit
+    // (see `MarketStatusFlagContainer`); only add new flags at the end, never
+    // reorder or remove, or stored `TokenConfig` flags will be misread.
 }
 
 crate::flags!(MarketStatusFlag, MAX_MARKET_STATUS_FLAGS, u8);
@@ -80,12 +85,12 @@ impl MarketStatus {
         };
         match self {
             Self::Disabled => MarketOpenness::Skip,
-            Self::RegularHours => open_if(!flags.get_flag(MarketStatusFlag::HaltRegularHours)),
+            Self::Unknown => open_if(flags.get_flag(MarketStatusFlag::AllowUnknown)),
             Self::PreMarket => open_if(flags.get_flag(MarketStatusFlag::AllowPreMarket)),
+            Self::RegularHours => open_if(!flags.get_flag(MarketStatusFlag::HaltRegularHours)),
             Self::PostMarket => open_if(flags.get_flag(MarketStatusFlag::AllowPostMarket)),
             Self::Overnight => open_if(flags.get_flag(MarketStatusFlag::AllowOvernight)),
             Self::Closed => open_if(flags.get_flag(MarketStatusFlag::AllowClosed)),
-            Self::Unknown => open_if(flags.get_flag(MarketStatusFlag::AllowUnknown)),
         }
     }
 }
@@ -129,11 +134,11 @@ mod tests {
         ));
 
         for (flag, status) in [
+            (MarketStatusFlag::AllowUnknown, MarketStatus::Unknown),
             (MarketStatusFlag::AllowPreMarket, MarketStatus::PreMarket),
             (MarketStatusFlag::AllowPostMarket, MarketStatus::PostMarket),
             (MarketStatusFlag::AllowOvernight, MarketStatus::Overnight),
             (MarketStatusFlag::AllowClosed, MarketStatus::Closed),
-            (MarketStatusFlag::AllowUnknown, MarketStatus::Unknown),
         ] {
             let mut f = flags();
             f.set_flag(flag, true);

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -1,0 +1,143 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+/// Max number of market-status flags.
+pub const MAX_MARKET_STATUS_FLAGS: usize = 8;
+
+/// Market status of a price feed.
+///
+/// `Disabled` (the zero value) means "no market-status information" — a skip
+/// sentinel, neither open nor closed. Persisted on-chain so a future Risk
+/// Oracle-driven contract can switch `MarketConfig` sets from a token's status.
+#[non_exhaustive]
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum MarketStatus {
+    /// No market-status information (skip).
+    Disabled = 0,
+    /// Unknown.
+    Unknown = 1,
+    /// Pre-market.
+    PreMarket = 2,
+    /// Regular trading hours.
+    RegularHours = 3,
+    /// Post-market.
+    PostMarket = 4,
+    /// Overnight.
+    Overnight = 5,
+    /// Closed.
+    Closed = 6,
+}
+
+/// Per-token market-status policy flags.
+///
+/// Each flag names the deviation from the default, so all-zero (unconfigured)
+/// resolves to: RegularHours open, every other status closed.
+#[derive(IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum MarketStatusFlag {
+    /// Force RegularHours closed.
+    HaltRegularHours,
+    /// Allow trading during pre-market.
+    AllowPreMarket,
+    /// Allow trading during post-market.
+    AllowPostMarket,
+    /// Allow trading overnight.
+    AllowOvernight,
+    /// Allow trading while the status is Closed.
+    AllowClosed,
+    /// Allow trading while the status is Unknown.
+    AllowUnknown,
+    // CHECK: should have no more than `MAX_MARKET_STATUS_FLAGS` of flags.
+}
+
+crate::flags!(MarketStatusFlag, MAX_MARKET_STATUS_FLAGS, u8);
+
+/// Resolved openness of a market status under a per-token policy.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub enum MarketOpenness {
+    /// Open.
+    Open,
+    /// Closed.
+    Closed,
+    /// No status — defer to the base openness.
+    Skip,
+}
+
+impl MarketStatus {
+    /// Resolve openness under the given per-token flags.
+    pub fn openness(self, flags: MarketStatusFlagContainer) -> MarketOpenness {
+        let open_if = |open: bool| {
+            if open {
+                MarketOpenness::Open
+            } else {
+                MarketOpenness::Closed
+            }
+        };
+        match self {
+            Self::Disabled => MarketOpenness::Skip,
+            Self::RegularHours => open_if(!flags.get_flag(MarketStatusFlag::HaltRegularHours)),
+            Self::PreMarket => open_if(flags.get_flag(MarketStatusFlag::AllowPreMarket)),
+            Self::PostMarket => open_if(flags.get_flag(MarketStatusFlag::AllowPostMarket)),
+            Self::Overnight => open_if(flags.get_flag(MarketStatusFlag::AllowOvernight)),
+            Self::Closed => open_if(flags.get_flag(MarketStatusFlag::AllowClosed)),
+            Self::Unknown => open_if(flags.get_flag(MarketStatusFlag::AllowUnknown)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flags() -> MarketStatusFlagContainer {
+        MarketStatusFlagContainer::default()
+    }
+
+    #[test]
+    fn default_flags_openness() {
+        assert!(matches!(
+            MarketStatus::Disabled.openness(flags()),
+            MarketOpenness::Skip
+        ));
+        assert!(matches!(
+            MarketStatus::RegularHours.openness(flags()),
+            MarketOpenness::Open
+        ));
+        for status in [
+            MarketStatus::Unknown,
+            MarketStatus::PreMarket,
+            MarketStatus::PostMarket,
+            MarketStatus::Overnight,
+            MarketStatus::Closed,
+        ] {
+            assert!(matches!(status.openness(flags()), MarketOpenness::Closed));
+        }
+    }
+
+    #[test]
+    fn flags_flip_each_status() {
+        let mut halt = flags();
+        halt.set_flag(MarketStatusFlag::HaltRegularHours, true);
+        assert!(matches!(
+            MarketStatus::RegularHours.openness(halt),
+            MarketOpenness::Closed
+        ));
+
+        for (flag, status) in [
+            (MarketStatusFlag::AllowPreMarket, MarketStatus::PreMarket),
+            (MarketStatusFlag::AllowPostMarket, MarketStatus::PostMarket),
+            (MarketStatusFlag::AllowOvernight, MarketStatus::Overnight),
+            (MarketStatusFlag::AllowClosed, MarketStatus::Closed),
+            (MarketStatusFlag::AllowUnknown, MarketStatus::Unknown),
+        ] {
+            let mut f = flags();
+            f.set_flag(flag, true);
+            assert!(matches!(status.openness(f), MarketOpenness::Open));
+        }
+    }
+}

--- a/crates/utils/src/price/mod.rs
+++ b/crates/utils/src/price/mod.rs
@@ -4,9 +4,13 @@ pub mod decimal;
 /// Price Feed Price.
 pub mod feed_price;
 
+/// Market status.
+pub mod market_status;
+
 pub use self::{
     decimal::{Decimal, DecimalError},
     feed_price::PriceFeedPrice,
+    market_status::{MarketOpenness, MarketStatus, MarketStatusFlag, MarketStatusFlagContainer},
 };
 use anchor_lang::prelude::*;
 

--- a/crates/utils/src/token_config.rs
+++ b/crates/utils/src/token_config.rs
@@ -7,6 +7,7 @@ use crate::{
     fixed_str::{bytes_to_fixed_str, FixedStrError},
     market::HasMarketMeta,
     oracle::PriceProviderKind,
+    price::market_status::{MarketStatusFlag, MarketStatusFlagContainer},
     pubkey::DEFAULT_PUBKEY,
     swap::HasSwapParams,
 };
@@ -90,8 +91,9 @@ pub struct TokenConfig {
     pub feeds: [FeedConfig; MAX_FEEDS],
     /// Heartbeat duration.
     pub heartbeat_duration: u32,
+    market_status_flags: MarketStatusFlagContainer,
     #[cfg_attr(feature = "debug", debug(skip))]
-    reserved: [u8; 32],
+    reserved: [u8; 31],
 }
 
 #[cfg(feature = "display")]
@@ -254,6 +256,16 @@ impl TokenConfig {
     /// Get token name.
     pub fn name(&self) -> TokenConfigResult<&str> {
         Ok(bytes_to_fixed_str(&self.name)?)
+    }
+
+    /// Returns the per-token market-status flags.
+    pub fn market_status_flags(&self) -> MarketStatusFlagContainer {
+        self.market_status_flags
+    }
+
+    /// Sets a per-token market-status flag.
+    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) {
+        self.market_status_flags.set_flag(flag, enable);
     }
 }
 
@@ -665,4 +677,34 @@ pub enum TokenFlag {
     /// Allow withdrawal.
     AllowWithdrawal,
     // CHECK: cannot have more than `MAX_TREASURY_TOKEN_FLAGS` flags.
+}
+
+#[cfg(test)]
+mod market_status_tests {
+    use super::*;
+    use crate::price::market_status::{MarketOpenness, MarketStatus, MarketStatusFlag};
+    use bytemuck::Zeroable;
+
+    #[test]
+    fn default_flags_open_regular_hours() {
+        let config = TokenConfig::zeroed();
+        assert!(matches!(
+            MarketStatus::RegularHours.openness(config.market_status_flags()),
+            MarketOpenness::Open
+        ));
+        assert!(matches!(
+            MarketStatus::PreMarket.openness(config.market_status_flags()),
+            MarketOpenness::Closed
+        ));
+    }
+
+    #[test]
+    fn set_flag_round_trip() {
+        let mut config = TokenConfig::zeroed();
+        config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, true);
+        assert!(matches!(
+            MarketStatus::PreMarket.openness(config.market_status_flags()),
+            MarketOpenness::Open
+        ));
+    }
 }


### PR DESCRIPTION
Introduce a canonical market-status model in `gmsol-utils`, to be resolved per token at price consumption.

- `MarketStatus` enum + `openness()` policy mapping (`MarketOpenness`) with a `MarketStatusFlag` bitmap.
- Store the status on `PriceFeedPrice` (carved from existing padding; zero-copy layout unchanged).
- Per-token flags on `TokenConfig` (carved from `reserved`; size unchanged, no migration).
- Additive only: no call-site or behavior changes.

Tested: `cargo test -p gmsol-utils`.
