### PR TITLE
feat: persist market status and defer openness

### DIFF
--- a/crates/chainlink-datastreams/src/error.rs
+++ b/crates/chainlink-datastreams/src/error.rs
@@ -10,7 +10,4 @@ pub enum Error {
     /// Overflow.
     #[error("overflow: {0}")]
     Overflow(&'static str),
-    /// Unknown market status.
-    #[error("unknown market status")]
-    UnknownMarketStatus,
 }

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -35,10 +35,12 @@ impl super::FromChainlinkReport for PriceFeedPrice {
 
         debug_assert!(!divisor.is_zero());
 
-        // Base openness: closed only when the coarse status is Closed and there is
-        // no granular extended status to defer to.
-        let mut is_open = report.extended_market_status().is_some()
-            || report.market_status() != Some(MarketStatus::Closed);
+        // Defer openness to the consumer (per-token flags); only freshness (below)
+        // can still force closed. Some v11 feeds are 24/7 and keep publishing
+        // valid prices even while their (extended) status is Unknown or Closed, so
+        // whether to trade then is a per-token policy. On v8 this is unobserved and
+        // AllowClosed is generally not advised, but staleness backstops it either way.
+        let mut is_open = true;
 
         let observations_timestamp = report.observations_timestamp;
 
@@ -97,6 +99,13 @@ impl super::FromChainlinkReport for PriceFeedPrice {
             price.set_flag(PriceFlag::LastUpdateDiffSecs, true);
         }
 
+        // Persisting the status here is what makes the `is_open` change
+        // migration-free. Base openness only flips closed -> open for prices this
+        // code writes, and any report that was previously coarse-closed gets a
+        // non-Disabled status here. So an old account (Open=false, status
+        // Disabled) resolves closed via the base flag, and a new one (Open=true,
+        // status Closed) resolves closed via the status — either version of a
+        // stored price yields the same verdict at read time.
         price.set_market_status(canonical_market_status(report));
 
         Ok(price)
@@ -258,19 +267,20 @@ mod tests {
     }
 
     #[test]
-    fn v8_closed_is_hard_closed_even_with_allow_closed() {
-        // v8 explicitly Closed: base is closed at write; no flag can reopen it.
+    fn allow_closed_opens_a_reported_closed_market() {
         let closed = v8_report(1); // 1 -> Closed
         let price = PriceFeedPrice::from_chainlink_report(&closed).unwrap();
         assert!(price.market_status() == FeedMarketStatus::Closed);
+
+        // Default flags: a reported Closed stays closed.
+        assert!(!price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+
+        // AllowClosed opens it while the price is fresh...
         let mut allow_closed = MarketStatusFlagContainer::default();
         allow_closed.set_flag(MarketStatusFlag::AllowClosed, true);
-        assert!(!price.is_market_open(1000, u32::MAX, allow_closed));
+        assert!(price.is_market_open(1000, u32::MAX, allow_closed));
 
-        // v8 Open: base open; default flags keep it open.
-        let open = v8_report(2); // 2 -> Open
-        let price = PriceFeedPrice::from_chainlink_report(&open).unwrap();
-        assert!(price.market_status() == FeedMarketStatus::RegularHours);
-        assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+        // ...but staleness closes it regardless of the flag.
+        assert!(!price.is_market_open(i64::MAX, 0, allow_closed));
     }
 }

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -38,18 +38,14 @@ impl super::FromChainlinkReport for PriceFeedPrice {
 
         debug_assert!(!divisor.is_zero());
 
-        let mut is_open = if enable_market_status {
-            // Defer openness to the consumer; freshness still applies below.
-            true
-        } else {
-            match report.market_status() {
-                MarketStatus::Unknown => {
-                    return Err(crate::Error::UnknownMarketStatus);
-                }
-                MarketStatus::Closed => false,
-                MarketStatus::Open => true,
-            }
-        };
+        // A coarse Unknown is only accepted when persisting the status (legacy path).
+        if !enable_market_status && report.market_status() == Some(MarketStatus::Unknown) {
+            return Err(crate::Error::UnknownMarketStatus);
+        }
+        // Base openness: closed only when the coarse status is Closed and there is
+        // no granular extended status to defer to (persist path only).
+        let mut is_open = (enable_market_status && report.extended_market_status().is_some())
+            || report.market_status() != Some(MarketStatus::Closed);
 
         let observations_timestamp = report.observations_timestamp;
 
@@ -130,31 +126,26 @@ impl From<ExtendedMarketStatus> for FeedMarketStatus {
 }
 
 fn canonical_market_status(report: &Report) -> FeedMarketStatus {
-    canonical(
-        report.version(),
-        report.market_status(),
-        report.extended_market_status(),
-    )
+    canonical(report.market_status(), report.extended_market_status())
 }
 
+/// Maps a decoded report to the canonical [`FeedMarketStatus`].
+///
+/// A granular extended status is authoritative. Otherwise the decoder tells us
+/// whether the report has a coarse market status at all: `Some` is mapped, and
+/// `None` (no market-status concept) persists nothing.
 fn canonical(
-    version: u16,
-    coarse: MarketStatus,
+    coarse: Option<MarketStatus>,
     extended: Option<ExtendedMarketStatus>,
 ) -> FeedMarketStatus {
-    // Only v11 carries an extended status; when present it is authoritative.
     if let Some(extended) = extended {
         return extended.into();
     }
-    match version {
-        // v4 / v8 carry a coarse RWA market status.
-        4 | 8 => match coarse {
-            MarketStatus::Open => FeedMarketStatus::RegularHours,
-            MarketStatus::Closed => FeedMarketStatus::Closed,
-            MarketStatus::Unknown => FeedMarketStatus::Unknown,
-        },
-        // Other versions (crypto: v2/v3/v7) carry no market-status field.
-        _ => FeedMarketStatus::Disabled,
+    match coarse {
+        Some(MarketStatus::Open) => FeedMarketStatus::RegularHours,
+        Some(MarketStatus::Closed) => FeedMarketStatus::Closed,
+        Some(MarketStatus::Unknown) => FeedMarketStatus::Unknown,
+        None => FeedMarketStatus::Disabled,
     }
 }
 
@@ -246,20 +237,58 @@ mod tests {
     }
 
     #[test]
-    fn canonical_resolves_by_version_and_extended() {
-        // v11: granular extended status wins (extended is `Some`).
+    fn canonical_resolves_coarse_and_extended() {
+        // Granular extended status wins.
         assert!(
             canonical(
-                11,
-                MarketStatus::Open,
+                Some(MarketStatus::Open),
                 Some(ExtendedMarketStatus::PreMarket)
             ) == FeedMarketStatus::PreMarket
         );
-        // v4 / v8: coarse status maps.
-        assert!(canonical(8, MarketStatus::Open, None) == FeedMarketStatus::RegularHours);
-        assert!(canonical(8, MarketStatus::Closed, None) == FeedMarketStatus::Closed);
-        assert!(canonical(4, MarketStatus::Unknown, None) == FeedMarketStatus::Unknown);
-        // crypto (no market-status field): disabled.
-        assert!(canonical(3, MarketStatus::Open, None) == FeedMarketStatus::Disabled);
+        // Coarse status maps.
+        assert!(canonical(Some(MarketStatus::Open), None) == FeedMarketStatus::RegularHours);
+        assert!(canonical(Some(MarketStatus::Closed), None) == FeedMarketStatus::Closed);
+        assert!(canonical(Some(MarketStatus::Unknown), None) == FeedMarketStatus::Unknown);
+        // No market-status concept.
+        assert!(canonical(None, None) == FeedMarketStatus::Disabled);
+    }
+
+    fn v8_report(market_status: u32) -> Report {
+        use chainlink_data_streams_report::report::v8::ReportDataV8;
+        use num_bigint::BigInt;
+
+        let mut feed_id_bytes = [0u8; 32];
+        feed_id_bytes[1] = 0x08; // version 8
+        let feed_id = chainlink_data_streams_report::feed_id::ID(feed_id_bytes);
+        let m: BigInt = "1000000000000000000".parse().unwrap();
+        let data = ReportDataV8 {
+            feed_id,
+            valid_from_timestamp: 1000,
+            observations_timestamp: 1000,
+            native_fee: BigInt::from(100),
+            link_fee: BigInt::from(200),
+            expires_at: 1100,
+            last_update_timestamp: 1_000_000_000_000,
+            mid_price: BigInt::from(50000) * &m,
+            market_status,
+        };
+        crate::report::decode(&data.abi_encode().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn v8_closed_is_hard_closed_even_with_allow_closed() {
+        // v8 explicitly Closed: base is closed at write; no flag can reopen it.
+        let closed = v8_report(1); // 1 -> Closed
+        let price = PriceFeedPrice::from_chainlink_report(&closed, true).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::Closed);
+        let mut allow_closed = MarketStatusFlagContainer::default();
+        allow_closed.set_flag(MarketStatusFlag::AllowClosed, true);
+        assert!(!price.is_market_open(1000, u32::MAX, allow_closed));
+
+        // v8 Open: base open; default flags keep it open.
+        let open = v8_report(2); // 2 -> Open
+        let price = PriceFeedPrice::from_chainlink_report(&open, true).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::RegularHours);
+        assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
     }
 }

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -7,7 +7,10 @@ use crate::{report::MarketStatus, Report};
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 
 impl super::FromChainlinkReport for PriceFeedPrice {
-    fn from_chainlink_report(report: &Report) -> Result<Self, crate::Error> {
+    fn from_chainlink_report(
+        report: &Report,
+        enable_market_status: bool,
+    ) -> Result<Self, crate::Error> {
         let price = report
             .non_negative_price()
             .ok_or(crate::Error::NegativePrice("price"))?;
@@ -35,12 +38,17 @@ impl super::FromChainlinkReport for PriceFeedPrice {
 
         debug_assert!(!divisor.is_zero());
 
-        let mut is_open = match report.market_status() {
-            MarketStatus::Unknown => {
-                return Err(crate::Error::UnknownMarketStatus);
+        let mut is_open = if enable_market_status {
+            // Defer openness to the consumer; freshness still applies below.
+            true
+        } else {
+            match report.market_status() {
+                MarketStatus::Unknown => {
+                    return Err(crate::Error::UnknownMarketStatus);
+                }
+                MarketStatus::Closed => false,
+                MarketStatus::Open => true,
             }
-            MarketStatus::Closed => false,
-            MarketStatus::Open => true,
         };
 
         let observations_timestamp = report.observations_timestamp;
@@ -100,6 +108,10 @@ impl super::FromChainlinkReport for PriceFeedPrice {
             price.set_flag(PriceFlag::LastUpdateDiffSecs, true);
         }
 
+        if enable_market_status {
+            price.set_market_status(canonical_market_status(report));
+        }
+
         Ok(price)
     }
 }
@@ -117,7 +129,6 @@ impl From<ExtendedMarketStatus> for FeedMarketStatus {
     }
 }
 
-#[allow(dead_code)]
 fn canonical_market_status(report: &Report) -> FeedMarketStatus {
     canonical(
         report.version(),
@@ -126,7 +137,6 @@ fn canonical_market_status(report: &Report) -> FeedMarketStatus {
     )
 }
 
-#[allow(dead_code)]
 fn canonical(
     version: u16,
     coarse: MarketStatus,
@@ -153,6 +163,67 @@ mod tests {
     use super::*;
     use crate::report::{ExtendedMarketStatus, MarketStatus};
     use gmsol_utils::price::market_status::MarketStatus as FeedMarketStatus;
+
+    use crate::FromChainlinkReport;
+    use gmsol_utils::price::feed_price::PriceFeedPrice;
+    use gmsol_utils::price::market_status::{MarketStatusFlag, MarketStatusFlagContainer};
+
+    fn v11_report(market_status: u32) -> Report {
+        use chainlink_data_streams_report::report::v11::ReportDataV11;
+        use num_bigint::BigInt;
+
+        let mut feed_id_bytes = [0u8; 32];
+        feed_id_bytes[1] = 0x0b; // version 11
+        let feed_id = chainlink_data_streams_report::feed_id::ID(feed_id_bytes);
+        let m: BigInt = "1000000000000000000".parse().unwrap();
+        let data = ReportDataV11 {
+            feed_id,
+            valid_from_timestamp: 1000,
+            observations_timestamp: 1000,
+            native_fee: BigInt::from(100),
+            link_fee: BigInt::from(200),
+            expires_at: 1100,
+            mid: BigInt::from(50000) * &m,
+            last_seen_timestamp_ns: 1_000_000_000_000,
+            bid: BigInt::from(49900) * &m,
+            bid_volume: BigInt::from(1000) * &m,
+            ask: BigInt::from(50100) * &m,
+            ask_volume: BigInt::from(2000) * &m,
+            last_traded_price: BigInt::from(50050) * &m,
+            market_status,
+        };
+        crate::report::decode(&data.abi_encode().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn disabled_keeps_legacy_behavior() {
+        // RegularHours (=2) with feature off: coarse-open, status not stored.
+        let report = v11_report(2);
+        let price = PriceFeedPrice::from_chainlink_report(&report, false).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::Disabled);
+        assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+    }
+
+    #[test]
+    fn enabled_stores_status_and_defers() {
+        // RegularHours with feature on: stored, open via default flags.
+        let open = v11_report(2);
+        let price = PriceFeedPrice::from_chainlink_report(&open, true).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::RegularHours);
+        assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+
+        // Closed (=5) with feature on: stored, closed via default flags.
+        let closed = v11_report(5);
+        let price = PriceFeedPrice::from_chainlink_report(&closed, true).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::Closed);
+        assert!(!price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+
+        // RegularHours but the token halts it.
+        let mut halt = MarketStatusFlagContainer::default();
+        halt.set_flag(MarketStatusFlag::HaltRegularHours, true);
+        let price = PriceFeedPrice::from_chainlink_report(&open, true).unwrap();
+        assert!(!price.is_market_open(1000, u32::MAX, halt));
+    }
 
     #[test]
     fn from_extended_maps_each_variant() {

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -2,7 +2,7 @@ use gmsol_utils::price::market_status::MarketStatus as FeedMarketStatus;
 use gmsol_utils::price::{feed_price::PriceFeedPrice, find_divisor_decimals, PriceFlag, TEN, U192};
 
 use crate::report::ExtendedMarketStatus;
-use crate::{report::MarketStatus, Report};
+use crate::Report;
 
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 
@@ -125,34 +125,18 @@ impl From<ExtendedMarketStatus> for FeedMarketStatus {
     }
 }
 
+/// Maps a decoded report to the canonical [`FeedMarketStatus`]: the granular
+/// status if the report defines one, else `Disabled`.
 fn canonical_market_status(report: &Report) -> FeedMarketStatus {
-    canonical(report.market_status(), report.extended_market_status())
-}
-
-/// Maps a decoded report to the canonical [`FeedMarketStatus`].
-///
-/// A granular extended status is authoritative. Otherwise the decoder tells us
-/// whether the report has a coarse market status at all: `Some` is mapped, and
-/// `None` (no market-status concept) persists nothing.
-fn canonical(
-    coarse: Option<MarketStatus>,
-    extended: Option<ExtendedMarketStatus>,
-) -> FeedMarketStatus {
-    if let Some(extended) = extended {
-        return extended.into();
-    }
-    match coarse {
-        Some(MarketStatus::Open) => FeedMarketStatus::RegularHours,
-        Some(MarketStatus::Closed) => FeedMarketStatus::Closed,
-        Some(MarketStatus::Unknown) => FeedMarketStatus::Unknown,
-        None => FeedMarketStatus::Disabled,
-    }
+    report
+        .extended_market_status()
+        .map_or(FeedMarketStatus::Disabled, FeedMarketStatus::from)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::report::{ExtendedMarketStatus, MarketStatus};
+    use crate::report::ExtendedMarketStatus;
     use gmsol_utils::price::market_status::MarketStatus as FeedMarketStatus;
 
     use crate::FromChainlinkReport;
@@ -225,23 +209,6 @@ mod tests {
             FeedMarketStatus::from(ExtendedMarketStatus::Overnight) == FeedMarketStatus::Overnight
         );
         assert!(FeedMarketStatus::from(ExtendedMarketStatus::Closed) == FeedMarketStatus::Closed);
-    }
-
-    #[test]
-    fn canonical_resolves_coarse_and_extended() {
-        // Granular extended status wins.
-        assert!(
-            canonical(
-                Some(MarketStatus::Open),
-                Some(ExtendedMarketStatus::PreMarket)
-            ) == FeedMarketStatus::PreMarket
-        );
-        // Coarse status maps.
-        assert!(canonical(Some(MarketStatus::Open), None) == FeedMarketStatus::RegularHours);
-        assert!(canonical(Some(MarketStatus::Closed), None) == FeedMarketStatus::Closed);
-        assert!(canonical(Some(MarketStatus::Unknown), None) == FeedMarketStatus::Unknown);
-        // No market-status concept.
-        assert!(canonical(None, None) == FeedMarketStatus::Disabled);
     }
 
     fn v8_report(market_status: u32) -> Report {

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -1,5 +1,7 @@
+use gmsol_utils::price::market_status::MarketStatus as FeedMarketStatus;
 use gmsol_utils::price::{feed_price::PriceFeedPrice, find_divisor_decimals, PriceFlag, TEN, U192};
 
+use crate::report::ExtendedMarketStatus;
 use crate::{report::MarketStatus, Report};
 
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
@@ -99,5 +101,94 @@ impl super::FromChainlinkReport for PriceFeedPrice {
         }
 
         Ok(price)
+    }
+}
+
+impl From<ExtendedMarketStatus> for FeedMarketStatus {
+    fn from(value: ExtendedMarketStatus) -> Self {
+        match value {
+            ExtendedMarketStatus::Unknown => Self::Unknown,
+            ExtendedMarketStatus::PreMarket => Self::PreMarket,
+            ExtendedMarketStatus::RegularHours => Self::RegularHours,
+            ExtendedMarketStatus::PostMarket => Self::PostMarket,
+            ExtendedMarketStatus::Overnight => Self::Overnight,
+            ExtendedMarketStatus::Closed => Self::Closed,
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn canonical_market_status(report: &Report) -> FeedMarketStatus {
+    canonical(
+        report.version(),
+        report.market_status(),
+        report.extended_market_status(),
+    )
+}
+
+#[allow(dead_code)]
+fn canonical(
+    version: u16,
+    coarse: MarketStatus,
+    extended: Option<ExtendedMarketStatus>,
+) -> FeedMarketStatus {
+    // Only v11 carries an extended status; when present it is authoritative.
+    if let Some(extended) = extended {
+        return extended.into();
+    }
+    match version {
+        // v4 / v8 carry a coarse RWA market status.
+        4 | 8 => match coarse {
+            MarketStatus::Open => FeedMarketStatus::RegularHours,
+            MarketStatus::Closed => FeedMarketStatus::Closed,
+            MarketStatus::Unknown => FeedMarketStatus::Unknown,
+        },
+        // Other versions (crypto: v2/v3/v7) carry no market-status field.
+        _ => FeedMarketStatus::Disabled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::{ExtendedMarketStatus, MarketStatus};
+    use gmsol_utils::price::market_status::MarketStatus as FeedMarketStatus;
+
+    #[test]
+    fn from_extended_maps_each_variant() {
+        assert!(FeedMarketStatus::from(ExtendedMarketStatus::Unknown) == FeedMarketStatus::Unknown);
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::PreMarket) == FeedMarketStatus::PreMarket
+        );
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::RegularHours)
+                == FeedMarketStatus::RegularHours
+        );
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::PostMarket)
+                == FeedMarketStatus::PostMarket
+        );
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::Overnight) == FeedMarketStatus::Overnight
+        );
+        assert!(FeedMarketStatus::from(ExtendedMarketStatus::Closed) == FeedMarketStatus::Closed);
+    }
+
+    #[test]
+    fn canonical_resolves_by_version_and_extended() {
+        // v11: granular extended status wins (extended is `Some`).
+        assert!(
+            canonical(
+                11,
+                MarketStatus::Open,
+                Some(ExtendedMarketStatus::PreMarket)
+            ) == FeedMarketStatus::PreMarket
+        );
+        // v4 / v8: coarse status maps.
+        assert!(canonical(8, MarketStatus::Open, None) == FeedMarketStatus::RegularHours);
+        assert!(canonical(8, MarketStatus::Closed, None) == FeedMarketStatus::Closed);
+        assert!(canonical(4, MarketStatus::Unknown, None) == FeedMarketStatus::Unknown);
+        // crypto (no market-status field): disabled.
+        assert!(canonical(3, MarketStatus::Open, None) == FeedMarketStatus::Disabled);
     }
 }

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -7,10 +7,7 @@ use crate::{report::MarketStatus, Report};
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 
 impl super::FromChainlinkReport for PriceFeedPrice {
-    fn from_chainlink_report(
-        report: &Report,
-        enable_market_status: bool,
-    ) -> Result<Self, crate::Error> {
+    fn from_chainlink_report(report: &Report) -> Result<Self, crate::Error> {
         let price = report
             .non_negative_price()
             .ok_or(crate::Error::NegativePrice("price"))?;
@@ -38,13 +35,9 @@ impl super::FromChainlinkReport for PriceFeedPrice {
 
         debug_assert!(!divisor.is_zero());
 
-        // A coarse Unknown is only accepted when persisting the status (legacy path).
-        if !enable_market_status && report.market_status() == Some(MarketStatus::Unknown) {
-            return Err(crate::Error::UnknownMarketStatus);
-        }
         // Base openness: closed only when the coarse status is Closed and there is
-        // no granular extended status to defer to (persist path only).
-        let mut is_open = (enable_market_status && report.extended_market_status().is_some())
+        // no granular extended status to defer to.
+        let mut is_open = report.extended_market_status().is_some()
             || report.market_status() != Some(MarketStatus::Closed);
 
         let observations_timestamp = report.observations_timestamp;
@@ -104,9 +97,7 @@ impl super::FromChainlinkReport for PriceFeedPrice {
             price.set_flag(PriceFlag::LastUpdateDiffSecs, true);
         }
 
-        if enable_market_status {
-            price.set_market_status(canonical_market_status(report));
-        }
+        price.set_market_status(canonical_market_status(report));
 
         Ok(price)
     }
@@ -187,32 +178,23 @@ mod tests {
     }
 
     #[test]
-    fn disabled_keeps_legacy_behavior() {
-        // RegularHours (=2) with feature off: coarse-open, status not stored.
-        let report = v11_report(2);
-        let price = PriceFeedPrice::from_chainlink_report(&report, false).unwrap();
-        assert!(price.market_status() == FeedMarketStatus::Disabled);
-        assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
-    }
-
-    #[test]
-    fn enabled_stores_status_and_defers() {
-        // RegularHours with feature on: stored, open via default flags.
+    fn stores_status_and_defers() {
+        // RegularHours: stored, open via default flags.
         let open = v11_report(2);
-        let price = PriceFeedPrice::from_chainlink_report(&open, true).unwrap();
+        let price = PriceFeedPrice::from_chainlink_report(&open).unwrap();
         assert!(price.market_status() == FeedMarketStatus::RegularHours);
         assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
 
-        // Closed (=5) with feature on: stored, closed via default flags.
+        // Closed (=5): stored, closed via default flags.
         let closed = v11_report(5);
-        let price = PriceFeedPrice::from_chainlink_report(&closed, true).unwrap();
+        let price = PriceFeedPrice::from_chainlink_report(&closed).unwrap();
         assert!(price.market_status() == FeedMarketStatus::Closed);
         assert!(!price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
 
         // RegularHours but the token halts it.
         let mut halt = MarketStatusFlagContainer::default();
         halt.set_flag(MarketStatusFlag::HaltRegularHours, true);
-        let price = PriceFeedPrice::from_chainlink_report(&open, true).unwrap();
+        let price = PriceFeedPrice::from_chainlink_report(&open).unwrap();
         assert!(!price.is_market_open(1000, u32::MAX, halt));
     }
 
@@ -279,7 +261,7 @@ mod tests {
     fn v8_closed_is_hard_closed_even_with_allow_closed() {
         // v8 explicitly Closed: base is closed at write; no flag can reopen it.
         let closed = v8_report(1); // 1 -> Closed
-        let price = PriceFeedPrice::from_chainlink_report(&closed, true).unwrap();
+        let price = PriceFeedPrice::from_chainlink_report(&closed).unwrap();
         assert!(price.market_status() == FeedMarketStatus::Closed);
         let mut allow_closed = MarketStatusFlagContainer::default();
         allow_closed.set_flag(MarketStatusFlag::AllowClosed, true);
@@ -287,7 +269,7 @@ mod tests {
 
         // v8 Open: base open; default flags keep it open.
         let open = v8_report(2); // 2 -> Open
-        let price = PriceFeedPrice::from_chainlink_report(&open, true).unwrap();
+        let price = PriceFeedPrice::from_chainlink_report(&open).unwrap();
         assert!(price.market_status() == FeedMarketStatus::RegularHours);
         assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
     }

--- a/crates/chainlink-datastreams/src/lib.rs
+++ b/crates/chainlink-datastreams/src/lib.rs
@@ -28,5 +28,5 @@ pub use report::Report;
 /// Type that can be created from [`Report`].
 pub trait FromChainlinkReport: Sized {
     /// Create from [`Report`].
-    fn from_chainlink_report(report: &Report) -> Result<Self, Error>;
+    fn from_chainlink_report(report: &Report, enable_market_status: bool) -> Result<Self, Error>;
 }

--- a/crates/chainlink-datastreams/src/lib.rs
+++ b/crates/chainlink-datastreams/src/lib.rs
@@ -28,5 +28,5 @@ pub use report::Report;
 /// Type that can be created from [`Report`].
 pub trait FromChainlinkReport: Sized {
     /// Create from [`Report`].
-    fn from_chainlink_report(report: &Report, enable_market_status: bool) -> Result<Self, Error>;
+    fn from_chainlink_report(report: &Report) -> Result<Self, Error>;
 }

--- a/crates/chainlink-datastreams/src/report.rs
+++ b/crates/chainlink-datastreams/src/report.rs
@@ -33,7 +33,7 @@ pub struct Report {
     bid: Signed,
     /// Simulated price impact of a sell order up to the X% depth of liquidity utilisation (8 or 18 decimals).
     ask: Signed,
-    market_status: Option<MarketStatus>,
+    market_status: MarketStatus,
     extended_market_status: Option<ExtendedMarketStatus>,
 }
 
@@ -48,11 +48,10 @@ pub enum MarketStatus {
     Open,
 }
 
-/// Extended market status (v11 only).
+/// The market status.
 ///
-/// Downstream consumers can use this for finer-grained trading decisions
-/// instead of relying on [`MarketStatus`], which is a compatibility trade-off
-/// that collapses all non-regular-hours states to [`MarketStatus::Closed`].
+/// This is the granular status carried by every report that defines a market
+/// status; prefer it over the deprecated coarse [`MarketStatus`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExtendedMarketStatus {
     /// Unknown.
@@ -69,12 +68,12 @@ pub enum ExtendedMarketStatus {
     Closed,
 }
 
-impl From<ExtendedMarketStatus> for MarketStatus {
-    fn from(ext: ExtendedMarketStatus) -> Self {
-        match ext {
-            ExtendedMarketStatus::Unknown => MarketStatus::Unknown,
-            ExtendedMarketStatus::RegularHours => MarketStatus::Open,
-            _ => MarketStatus::Closed,
+impl From<MarketStatus> for ExtendedMarketStatus {
+    fn from(status: MarketStatus) -> Self {
+        match status {
+            MarketStatus::Unknown => ExtendedMarketStatus::Unknown,
+            MarketStatus::Closed => ExtendedMarketStatus::Closed,
+            MarketStatus::Open => ExtendedMarketStatus::RegularHours,
         }
     }
 }
@@ -100,14 +99,9 @@ impl Report {
         non_negative(self.ask)
     }
 
-    /// Returns the coarse market status, or `None` for reports that carry no
-    /// market-status concept (e.g. crypto feeds).
-    ///
-    /// Reports that expose a granular extended status derive this coarse value
-    /// from it via [`From`] (a compatibility trade-off); consumers that need
-    /// finer-grained control should use [`Self::extended_market_status()`]
-    /// instead.
-    pub fn market_status(&self) -> Option<MarketStatus> {
+    /// Returns the coarse market status.
+    #[deprecated(since = "0.10.0", note = "use `extended_market_status` instead")]
+    pub fn market_status(&self) -> MarketStatus {
         self.market_status
     }
 
@@ -206,7 +200,7 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 // Bid and ask values are not available for the report schema v2.
                 bid: price,
                 ask: price,
-                market_status: None,
+                market_status: MarketStatus::Open,
                 extended_market_status: None,
             })
         }
@@ -223,13 +217,14 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 price: bigint_to_signed(report.benchmark_price)?,
                 bid: bigint_to_signed(report.bid)?,
                 ask: bigint_to_signed(report.ask)?,
-                market_status: None,
+                market_status: MarketStatus::Open,
                 extended_market_status: None,
             })
         }
         4 => {
             let report = ReportDataV4::decode(data)?;
             let price = bigint_to_signed(report.price)?;
+            let market_status = decode_market_status(report.market_status)?;
             Ok(Report {
                 feed_id: report.feed_id,
                 valid_from_timestamp: report.valid_from_timestamp,
@@ -243,8 +238,8 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 // of the RWA report schema (v4).
                 bid: price,
                 ask: price,
-                market_status: Some(decode_market_status(report.market_status)?),
-                extended_market_status: None,
+                market_status,
+                extended_market_status: Some(market_status.into()),
             })
         }
         7 => {
@@ -262,13 +257,14 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 // Bid and ask values are not available for the report schema v7.
                 bid: price,
                 ask: price,
-                market_status: None,
+                market_status: MarketStatus::Open,
                 extended_market_status: None,
             })
         }
         8 => {
             let report = ReportDataV8::decode(data)?;
             let price = bigint_to_signed(report.mid_price)?;
+            let market_status = decode_market_status(report.market_status)?;
             Ok(Report {
                 feed_id: report.feed_id,
                 valid_from_timestamp: report.valid_from_timestamp,
@@ -280,14 +276,13 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 price,
                 bid: price,
                 ask: price,
-                market_status: Some(decode_market_status(report.market_status)?),
-                extended_market_status: None,
+                market_status,
+                extended_market_status: Some(market_status.into()),
             })
         }
         11 => {
             let report = ReportDataV11::decode(data)?;
             let extended = decode_extended_market_status(report.market_status)?;
-            let market_status = Some(MarketStatus::from(extended));
             let price = bigint_to_signed(report.mid)?;
             let bid = bigint_to_signed(report.bid)?;
             let ask = bigint_to_signed(report.ask)?;
@@ -303,7 +298,9 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 price,
                 bid,
                 ask,
-                market_status,
+                // v11 has no coarse status of its own; force the deprecated
+                // field to Unknown so consumers use `extended_market_status`.
+                market_status: MarketStatus::Unknown,
                 extended_market_status: Some(extended),
             })
         }
@@ -443,30 +440,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extended_market_status_to_market_status() {
+    fn test_market_status_to_extended() {
         assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::Unknown),
-            MarketStatus::Unknown
+            ExtendedMarketStatus::from(MarketStatus::Unknown),
+            ExtendedMarketStatus::Unknown
         );
         assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::RegularHours),
-            MarketStatus::Open
+            ExtendedMarketStatus::from(MarketStatus::Closed),
+            ExtendedMarketStatus::Closed
         );
         assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::Closed),
-            MarketStatus::Closed
-        );
-        assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::PreMarket),
-            MarketStatus::Closed
-        );
-        assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::PostMarket),
-            MarketStatus::Closed
-        );
-        assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::Overnight),
-            MarketStatus::Closed
+            ExtendedMarketStatus::from(MarketStatus::Open),
+            ExtendedMarketStatus::RegularHours
         );
     }
 
@@ -500,6 +485,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_decode_v11() {
         use chainlink_data_streams_report::report::v11::ReportDataV11;
         use num_bigint::BigInt;
@@ -536,7 +522,7 @@ mod tests {
         assert_eq!(report.observations_timestamp, 1000);
         assert_eq!(report.expires_at, 1100);
         assert_eq!(report.last_update_timestamp(), Some(1_000_000_000_000));
-        assert_eq!(report.market_status(), Some(MarketStatus::Open));
+        assert_eq!(report.market_status(), MarketStatus::Unknown);
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::RegularHours)
@@ -547,6 +533,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_decode_v11_pre_market() {
         use chainlink_data_streams_report::report::v11::ReportDataV11;
         use num_bigint::BigInt;
@@ -579,7 +566,7 @@ mod tests {
         let report = decode(&encoded).unwrap();
 
         // PreMarket should map to Closed
-        assert_eq!(report.market_status(), Some(MarketStatus::Closed));
+        assert_eq!(report.market_status(), MarketStatus::Unknown);
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::PreMarket)
@@ -587,6 +574,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_decode_v11_xau_full_report() {
         let data = hex::decode(
             "00094baebfda9b87680d8e59aa20a3e565126640ee7caeab3cd965e5568b17ee\
@@ -646,7 +634,7 @@ mod tests {
         assert!(report.non_negative_ask() == Some(ask));
 
         // market_status=5 -> Closed
-        assert_eq!(report.market_status(), Some(MarketStatus::Closed));
+        assert_eq!(report.market_status(), MarketStatus::Unknown);
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::Closed)

--- a/crates/chainlink-datastreams/src/report.rs
+++ b/crates/chainlink-datastreams/src/report.rs
@@ -131,6 +131,11 @@ impl Report {
     pub fn expires_at(&self) -> u32 {
         self.expires_at
     }
+
+    /// Returns the report schema version.
+    pub fn version(&self) -> u16 {
+        decode_version(&self.feed_id)
+    }
 }
 
 impl fmt::Debug for Report {

--- a/crates/chainlink-datastreams/src/report.rs
+++ b/crates/chainlink-datastreams/src/report.rs
@@ -33,7 +33,7 @@ pub struct Report {
     bid: Signed,
     /// Simulated price impact of a sell order up to the X% depth of liquidity utilisation (8 or 18 decimals).
     ask: Signed,
-    market_status: MarketStatus,
+    market_status: Option<MarketStatus>,
     extended_market_status: Option<ExtendedMarketStatus>,
 }
 
@@ -100,14 +100,14 @@ impl Report {
         non_negative(self.ask)
     }
 
-    /// Returns the market status.
+    /// Returns the coarse market status, or `None` for reports that carry no
+    /// market-status concept (e.g. crypto feeds).
     ///
-    /// For v11 reports, this is derived from [`ExtendedMarketStatus`]:
-    /// only [`ExtendedMarketStatus::RegularHours`] maps to [`MarketStatus::Open`];
-    /// all other states map to [`MarketStatus::Closed`].
-    /// This is a compatibility trade-off — downstream consumers that need
-    /// finer-grained control should use [`Self::extended_market_status()`] instead.
-    pub fn market_status(&self) -> MarketStatus {
+    /// Reports that expose a granular extended status derive this coarse value
+    /// from it via [`From`] (a compatibility trade-off); consumers that need
+    /// finer-grained control should use [`Self::extended_market_status()`]
+    /// instead.
+    pub fn market_status(&self) -> Option<MarketStatus> {
         self.market_status
     }
 
@@ -130,11 +130,6 @@ impl Report {
     /// Returns the expiry timestamp for the report.
     pub fn expires_at(&self) -> u32 {
         self.expires_at
-    }
-
-    /// Returns the report schema version.
-    pub fn version(&self) -> u16 {
-        decode_version(&self.feed_id)
     }
 }
 
@@ -211,7 +206,7 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 // Bid and ask values are not available for the report schema v2.
                 bid: price,
                 ask: price,
-                market_status: MarketStatus::Open,
+                market_status: None,
                 extended_market_status: None,
             })
         }
@@ -228,7 +223,7 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 price: bigint_to_signed(report.benchmark_price)?,
                 bid: bigint_to_signed(report.bid)?,
                 ask: bigint_to_signed(report.ask)?,
-                market_status: MarketStatus::Open,
+                market_status: None,
                 extended_market_status: None,
             })
         }
@@ -248,7 +243,7 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 // of the RWA report schema (v4).
                 bid: price,
                 ask: price,
-                market_status: decode_market_status(report.market_status)?,
+                market_status: Some(decode_market_status(report.market_status)?),
                 extended_market_status: None,
             })
         }
@@ -267,7 +262,7 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 // Bid and ask values are not available for the report schema v7.
                 bid: price,
                 ask: price,
-                market_status: MarketStatus::Open,
+                market_status: None,
                 extended_market_status: None,
             })
         }
@@ -285,14 +280,14 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 price,
                 bid: price,
                 ask: price,
-                market_status: decode_market_status(report.market_status)?,
+                market_status: Some(decode_market_status(report.market_status)?),
                 extended_market_status: None,
             })
         }
         11 => {
             let report = ReportDataV11::decode(data)?;
             let extended = decode_extended_market_status(report.market_status)?;
-            let market_status = MarketStatus::from(extended);
+            let market_status = Some(MarketStatus::from(extended));
             let price = bigint_to_signed(report.mid)?;
             let bid = bigint_to_signed(report.bid)?;
             let ask = bigint_to_signed(report.ask)?;
@@ -541,7 +536,7 @@ mod tests {
         assert_eq!(report.observations_timestamp, 1000);
         assert_eq!(report.expires_at, 1100);
         assert_eq!(report.last_update_timestamp(), Some(1_000_000_000_000));
-        assert_eq!(report.market_status(), MarketStatus::Open);
+        assert_eq!(report.market_status(), Some(MarketStatus::Open));
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::RegularHours)
@@ -584,7 +579,7 @@ mod tests {
         let report = decode(&encoded).unwrap();
 
         // PreMarket should map to Closed
-        assert_eq!(report.market_status(), MarketStatus::Closed);
+        assert_eq!(report.market_status(), Some(MarketStatus::Closed));
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::PreMarket)
@@ -651,7 +646,7 @@ mod tests {
         assert!(report.non_negative_ask() == Some(ask));
 
         // market_status=5 -> Closed
-        assert_eq!(report.market_status(), MarketStatus::Closed);
+        assert_eq!(report.market_status(), Some(MarketStatus::Closed));
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::Closed)

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -36,10 +36,11 @@ pub enum MarketStatus {
 /// Each flag names the deviation from the default, so all-zero (unconfigured)
 /// resolves to: RegularHours open, every other status closed.
 ///
-/// These flags only modify openness on top of the feed's base openness (its
-/// `Open` flag plus freshness): a resolved status can close a market whose base
-/// is open, but no flag can reopen a base that is already closed (stale, or a
-/// report that reported closed).
+/// These flags resolve openness from the stored status per token: any status,
+/// including a reported `Closed`, can be configured open or closed. Freshness is
+/// the only hard floor — a stale price is always closed regardless of any flag.
+/// (`AllowClosed` on a v8 feed is generally not advised, but staleness still
+/// backstops it.)
 #[derive(IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 #[non_exhaustive]

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -35,6 +35,11 @@ pub enum MarketStatus {
 ///
 /// Each flag names the deviation from the default, so all-zero (unconfigured)
 /// resolves to: RegularHours open, every other status closed.
+///
+/// These flags only modify openness on top of the feed's base openness (its
+/// `Open` flag plus freshness): a resolved status can close a market whose base
+/// is open, but no flag can reopen a base that is already closed (stale, or a
+/// report that reported closed).
 #[derive(IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 #[non_exhaustive]

--- a/programs/store/src/instructions/oracle/custom.rs
+++ b/programs/store/src/instructions/oracle/custom.rs
@@ -8,10 +8,6 @@ use crate::{
     CoreError,
 };
 
-/// Compile-time global switch for persisting/deferring market status.
-/// ON at launch; flip to `false` to fall back to legacy write-side openness.
-const ENABLE_MARKET_STATUS: bool = true;
-
 /// The accounts definition for [`initialize_price_feed`](crate::initialize_price_feed) instruction.
 #[derive(Accounts)]
 #[instruction(index: u16, provider: u8, token: Pubkey)]
@@ -113,7 +109,7 @@ pub(crate) fn unchecked_update_price_feed_with_chainlink(
         CoreError::InvalidArgument
     );
 
-    let price = accounts.decode_and_validate_report(&compressed_report, ENABLE_MARKET_STATUS)?;
+    let price = accounts.decode_and_validate_report(&compressed_report)?;
     accounts.verify_report(compressed_report)?;
 
     let updated = accounts.price_feed.load_mut()?.update(
@@ -140,11 +136,7 @@ impl<'info> internal::Authentication<'info> for UpdatePriceFeedWithChainlink<'in
 }
 
 impl UpdatePriceFeedWithChainlink<'_> {
-    fn decode_and_validate_report(
-        &self,
-        compressed_full_report: &[u8],
-        enable_market_status: bool,
-    ) -> Result<PriceFeedPrice> {
+    fn decode_and_validate_report(&self, compressed_full_report: &[u8]) -> Result<PriceFeedPrice> {
         use gmsol_chainlink_datastreams::{
             report::decode_compressed_full_report, Error as ChainlinkError, FromChainlinkReport,
         };
@@ -167,13 +159,11 @@ impl UpdatePriceFeedWithChainlink<'_> {
             CoreError::InvalidPriceReport
         );
 
-        PriceFeedPrice::from_chainlink_report(&report, enable_market_status).map_err(|err| {
+        PriceFeedPrice::from_chainlink_report(&report).map_err(|err| {
             msg!("Invalid report: {}", err);
             let err = match err {
                 ChainlinkError::NegativePrice(_) => CoreError::NegativePriceIsNotSupported,
-                ChainlinkError::InvalidRange(_) | ChainlinkError::UnknownMarketStatus => {
-                    CoreError::InvalidPriceReport
-                }
+                ChainlinkError::InvalidRange(_) => CoreError::InvalidPriceReport,
                 ChainlinkError::Overflow(_) => CoreError::PriceOverflow,
             };
             error!(err)

--- a/programs/store/src/instructions/oracle/custom.rs
+++ b/programs/store/src/instructions/oracle/custom.rs
@@ -8,6 +8,10 @@ use crate::{
     CoreError,
 };
 
+/// Compile-time global switch for persisting/deferring market status.
+/// ON at launch; flip to `false` to fall back to legacy write-side openness.
+const ENABLE_MARKET_STATUS: bool = true;
+
 /// The accounts definition for [`initialize_price_feed`](crate::initialize_price_feed) instruction.
 #[derive(Accounts)]
 #[instruction(index: u16, provider: u8, token: Pubkey)]
@@ -109,7 +113,7 @@ pub(crate) fn unchecked_update_price_feed_with_chainlink(
         CoreError::InvalidArgument
     );
 
-    let price = accounts.decode_and_validate_report(&compressed_report)?;
+    let price = accounts.decode_and_validate_report(&compressed_report, ENABLE_MARKET_STATUS)?;
     accounts.verify_report(compressed_report)?;
 
     let updated = accounts.price_feed.load_mut()?.update(
@@ -136,7 +140,11 @@ impl<'info> internal::Authentication<'info> for UpdatePriceFeedWithChainlink<'in
 }
 
 impl UpdatePriceFeedWithChainlink<'_> {
-    fn decode_and_validate_report(&self, compressed_full_report: &[u8]) -> Result<PriceFeedPrice> {
+    fn decode_and_validate_report(
+        &self,
+        compressed_full_report: &[u8],
+        enable_market_status: bool,
+    ) -> Result<PriceFeedPrice> {
         use gmsol_chainlink_datastreams::{
             report::decode_compressed_full_report, Error as ChainlinkError, FromChainlinkReport,
         };
@@ -159,7 +167,7 @@ impl UpdatePriceFeedWithChainlink<'_> {
             CoreError::InvalidPriceReport
         );
 
-        PriceFeedPrice::from_chainlink_report(&report).map_err(|err| {
+        PriceFeedPrice::from_chainlink_report(&report, enable_market_status).map_err(|err| {
             msg!("Invalid report: {}", err);
             let err = match err {
                 ChainlinkError::NegativePrice(_) => CoreError::NegativePriceIsNotSupported,


### PR DESCRIPTION
Persist a granular market status per price update and defer open/closed to per-token config at consumption. This turns the feature on in the store program.

- datastreams: map a decoded report to the canonical `MarketStatus` by version (v11 -> extended; v4/v8 -> coarse; crypto -> Disabled). `report.rs` stays a pure decoder (adds `version()`).
- `from_chainlink_report(report, enable_market_status)`: enabled -> set the `Open` flag from freshness only and persist the canonical status; disabled -> unchanged legacy behavior.
- store `custom.rs`: `const ENABLE_MARKET_STATUS = true` (a flippable global switch), threaded into decode.

Backward compatible: default (all-zero) per-token flags reproduce today's behavior (RegularHours open; other sessions closed). One change: an `Unknown` status no longer rejects the price update - the price is recorded and the market resolves closed (via the default `AllowUnknown = false`).

Tested: `cargo test -p gmsol-chainlink-datastreams --features gmsol`; `cargo build -p gmsol-store`.
