### PR TITLE
feat(store): add set market status flag ix

### DIFF
--- a/crates/utils/src/token_config.rs
+++ b/crates/utils/src/token_config.rs
@@ -263,9 +263,9 @@ impl TokenConfig {
         self.market_status_flags
     }
 
-    /// Sets a per-token market-status flag.
-    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) {
-        self.market_status_flags.set_flag(flag, enable);
+    /// Sets a per-token market-status flag, returning the previous value.
+    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) -> bool {
+        self.market_status_flags.set_flag(flag, enable)
     }
 }
 

--- a/programs/store/src/instructions/token_config.rs
+++ b/programs/store/src/instructions/token_config.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::Mint;
+use gmsol_utils::price::market_status::MarketStatusFlag;
 use gmsol_utils::token_config::TokenConfigFlag;
 
 use crate::{
@@ -197,6 +198,53 @@ impl ToggleTokenConfig<'_> {
 }
 
 impl<'info> internal::Authentication<'info> for ToggleTokenConfig<'info> {
+    fn authority(&self) -> &Signer<'info> {
+        &self.authority
+    }
+
+    fn store(&self) -> &AccountLoader<'info, Store> {
+        &self.store
+    }
+}
+
+/// The accounts definition for [`set_token_config_market_status_flag`](crate::gmsol_store::set_token_config_market_status_flag).
+#[derive(Accounts)]
+pub struct SetTokenConfigMarketStatusFlag<'info> {
+    /// The authority of the instruction.
+    pub authority: Signer<'info>,
+    /// The store that owns the token map.
+    pub store: AccountLoader<'info, Store>,
+    /// The token map to update.
+    #[account(mut, has_one = store)]
+    pub token_map: AccountLoader<'info, TokenMapHeader>,
+    /// The token whose config will be updated.
+    /// CHECK: used only as the key into the token map; not deserialized.
+    pub token: UncheckedAccount<'info>,
+}
+
+impl SetTokenConfigMarketStatusFlag<'_> {
+    /// Set a per-token market-status flag, returning the previous value.
+    ///
+    /// ## CHECK
+    /// - Only [`MARKET_KEEPER`](crate::states::RoleKey::MARKET_KEEPER) can perform this action.
+    pub(crate) fn invoke_unchecked(
+        ctx: Context<Self>,
+        flag: MarketStatusFlag,
+        enable: bool,
+    ) -> Result<bool> {
+        let token = ctx.accounts.token.key();
+        let previous = ctx
+            .accounts
+            .token_map
+            .load_token_map_mut()?
+            .get_mut(&token)
+            .ok_or_else(|| error!(CoreError::NotFound))?
+            .set_market_status_flag(flag, enable);
+        Ok(previous)
+    }
+}
+
+impl<'info> internal::Authentication<'info> for SetTokenConfigMarketStatusFlag<'info> {
     fn authority(&self) -> &Signer<'info> {
         &self.authority
     }

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -257,6 +257,7 @@ declare_id!("Gmso1uvJnLbawvw7yezdfCDcPydwW2s2iqG3w6MDucLo");
 #[program]
 /// Instructions definitions of the GMSOL Store Program.
 pub mod gmsol_store {
+    use gmsol_utils::price::market_status::MarketStatusFlag;
     use gmsol_utils::token_config::TokenConfigFlag;
 
     use super::*;
@@ -877,6 +878,44 @@ pub mod gmsol_store {
             TokenConfigFlag::AllowPriceAdjustment,
             enable,
         )
+    }
+
+    /// Set a per-token market-status flag.
+    ///
+    /// # Accounts
+    /// [*See the documentation for the accounts*](SetTokenConfigMarketStatusFlag).
+    ///
+    /// # Arguments
+    /// - `flag`: The [`MarketStatusFlag`] index to set.
+    /// - `enable`: Enable or disable the flag.
+    ///
+    /// # Errors
+    /// - The [`authority`](SetTokenConfigMarketStatusFlag::authority) must be a
+    ///   signer and a MARKET_KEEPER in the given store.
+    /// - The [`token`](SetTokenConfigMarketStatusFlag::token) must exist in the token map.
+    /// - `flag` must be a valid [`MarketStatusFlag`] value.
+    #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
+    pub fn set_token_config_market_status_flag(
+        ctx: Context<SetTokenConfigMarketStatusFlag>,
+        flag: u8,
+        enable: bool,
+    ) -> Result<()> {
+        let token = ctx.accounts.token.key();
+        let authorized =
+            ctx.accounts.store.load()?.token_map() == Some(&ctx.accounts.token_map.key());
+        let market_status_flag =
+            MarketStatusFlag::try_from(flag).map_err(|_| error!(CoreError::InvalidArgument))?;
+        let previous =
+            SetTokenConfigMarketStatusFlag::invoke_unchecked(ctx, market_status_flag, enable)?;
+        msg!(
+            "set market status flag: token={}, flag={}, {} -> {}, authorized_token_map={}",
+            token,
+            flag,
+            previous,
+            enable,
+            authorized,
+        );
+        Ok(())
     }
 
     /// Set the expected provider for the given token.


### PR DESCRIPTION
Add `set_token_config_market_status_flag`: a MARKET_KEEPER instruction to set a per-token `MarketStatusFlag`.

- `token` is passed as an account (ALT-compressible), used only as the map key.
- `flag` is a `u8` (converted to `MarketStatusFlag`); `enable` toggles it.
- Mirrors `toggle_token_config` (accounts, auth, MARKET_KEEPER guard).
