### PR TITLE
fix: move market status flags to feed level

### DIFF
--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -35,10 +35,10 @@ impl super::FromChainlinkReport for PriceFeedPrice {
 
         debug_assert!(!divisor.is_zero());
 
-        // Defer openness to the consumer (per-token flags); only freshness (below)
+        // Defer openness to the consumer (per-feed flags); only freshness (below)
         // can still force closed. Some v11 feeds are 24/7 and keep publishing
         // valid prices even while their (extended) status is Unknown or Closed, so
-        // whether to trade then is a per-token policy. On v8 this is unobserved and
+        // whether to trade then is a per-feed policy. On v8 this is unobserved and
         // AllowClosed is generally not advised, but staleness backstops it either way.
         let mut is_open = true;
 

--- a/crates/utils/src/price/feed_price.rs
+++ b/crates/utils/src/price/feed_price.rs
@@ -113,7 +113,7 @@ impl PriceFeedPrice {
         &self.price
     }
 
-    /// Returns whether the market is open for the given per-token flags.
+    /// Returns whether the market is open for the given per-feed flags.
     pub fn is_market_open(
         &self,
         current_timestamp: i64,

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -31,12 +31,12 @@ pub enum MarketStatus {
     Closed = 6,
 }
 
-/// Per-token market-status policy flags.
+/// Per-feed market-status policy flags.
 ///
 /// Each flag names the deviation from the default, so all-zero (unconfigured)
 /// resolves to: RegularHours open, every other status closed.
 ///
-/// These flags resolve openness from the stored status per token: any status,
+/// These flags resolve openness from the stored status per feed: any status,
 /// including a reported `Closed`, can be configured open or closed. Freshness is
 /// the only hard floor — a stale price is always closed regardless of any flag.
 /// (`AllowClosed` on a v8 feed is generally not advised, but staleness still
@@ -62,12 +62,12 @@ pub enum MarketStatusFlag {
     // CHECK: should have no more than `MAX_MARKET_STATUS_FLAGS` of flags.
     // CHECK: append-only. Each variant's position is a persisted bitmap bit
     // (see `MarketStatusFlagContainer`); only add new flags at the end, never
-    // reorder or remove, or stored `TokenConfig` flags will be misread.
+    // reorder or remove, or stored `FeedConfig` flags will be misread.
 }
 
 crate::flags!(MarketStatusFlag, MAX_MARKET_STATUS_FLAGS, u8);
 
-/// Resolved openness of a market status under a per-token policy.
+/// Resolved openness of a market status under a per-feed policy.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum MarketOpenness {
@@ -80,7 +80,7 @@ pub enum MarketOpenness {
 }
 
 impl MarketStatus {
-    /// Resolve openness under the given per-token flags.
+    /// Resolve openness under the given per-feed flags.
     pub fn openness(self, flags: MarketStatusFlagContainer) -> MarketOpenness {
         let open_if = |open: bool| {
             if open {

--- a/crates/utils/src/token_config.rs
+++ b/crates/utils/src/token_config.rs
@@ -288,9 +288,10 @@ pub struct FeedConfig {
     /// The maximum allowed deviation ratio from the mid-price.
     /// A value of `0` means no restriction is applied.
     max_deviation_ratio: u32,
+    market_status_flags: MarketStatusFlagContainer,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 24],
+    reserved: [u8; 23],
 }
 
 #[cfg(feature = "display")]
@@ -315,6 +316,7 @@ impl FeedConfig {
             feed,
             timestamp_adjustment: DEFAULT_TIMESTAMP_ADJUSTMENT,
             max_deviation_ratio: DEFAULT_MAX_DEVIATION_RATIO,
+            market_status_flags: Default::default(),
             reserved: Default::default(),
         }
     }
@@ -370,6 +372,16 @@ impl FeedConfig {
         } else {
             Some(u128::from(ratio) * Self::RATIO_MULTIPLIER)
         }
+    }
+
+    /// Returns the per-feed market-status flags.
+    pub fn market_status_flags(&self) -> MarketStatusFlagContainer {
+        self.market_status_flags
+    }
+
+    /// Sets a per-feed market-status flag, returning the previous value.
+    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) -> bool {
+        self.market_status_flags.set_flag(flag, enable)
     }
 }
 
@@ -706,5 +718,29 @@ mod market_status_tests {
             MarketStatus::PreMarket.openness(config.market_status_flags()),
             MarketOpenness::Open
         ));
+    }
+
+    #[test]
+    fn feed_default_flags_open_regular_hours() {
+        let config = FeedConfig::zeroed();
+        assert!(matches!(
+            MarketStatus::RegularHours.openness(config.market_status_flags()),
+            MarketOpenness::Open
+        ));
+        assert!(matches!(
+            MarketStatus::PreMarket.openness(config.market_status_flags()),
+            MarketOpenness::Closed
+        ));
+    }
+
+    #[test]
+    fn feed_set_flag_round_trip() {
+        let mut config = FeedConfig::zeroed();
+        assert!(!config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, true));
+        assert!(matches!(
+            MarketStatus::PreMarket.openness(config.market_status_flags()),
+            MarketOpenness::Open
+        ));
+        assert!(config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, false));
     }
 }

--- a/crates/utils/src/token_config.rs
+++ b/crates/utils/src/token_config.rs
@@ -91,9 +91,8 @@ pub struct TokenConfig {
     pub feeds: [FeedConfig; MAX_FEEDS],
     /// Heartbeat duration.
     pub heartbeat_duration: u32,
-    market_status_flags: MarketStatusFlagContainer,
     #[cfg_attr(feature = "debug", debug(skip))]
-    reserved: [u8; 31],
+    reserved: [u8; 32],
 }
 
 #[cfg(feature = "display")]
@@ -146,6 +145,9 @@ impl TokenConfig {
     }
 
     /// Set feed config.
+    ///
+    /// Note: this replaces the whole [`FeedConfig`], including its
+    /// market-status flags.
     pub fn set_feed_config(
         &mut self,
         kind: &PriceProviderKind,
@@ -256,16 +258,6 @@ impl TokenConfig {
     /// Get token name.
     pub fn name(&self) -> TokenConfigResult<&str> {
         Ok(bytes_to_fixed_str(&self.name)?)
-    }
-
-    /// Returns the per-token market-status flags.
-    pub fn market_status_flags(&self) -> MarketStatusFlagContainer {
-        self.market_status_flags
-    }
-
-    /// Sets a per-token market-status flag, returning the previous value.
-    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) -> bool {
-        self.market_status_flags.set_flag(flag, enable)
     }
 }
 
@@ -696,29 +688,6 @@ mod market_status_tests {
     use super::*;
     use crate::price::market_status::{MarketOpenness, MarketStatus, MarketStatusFlag};
     use bytemuck::Zeroable;
-
-    #[test]
-    fn default_flags_open_regular_hours() {
-        let config = TokenConfig::zeroed();
-        assert!(matches!(
-            MarketStatus::RegularHours.openness(config.market_status_flags()),
-            MarketOpenness::Open
-        ));
-        assert!(matches!(
-            MarketStatus::PreMarket.openness(config.market_status_flags()),
-            MarketOpenness::Closed
-        ));
-    }
-
-    #[test]
-    fn set_flag_round_trip() {
-        let mut config = TokenConfig::zeroed();
-        config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, true);
-        assert!(matches!(
-            MarketStatus::PreMarket.openness(config.market_status_flags()),
-            MarketOpenness::Open
-        ));
-    }
 
     #[test]
     fn feed_default_flags_open_regular_hours() {

--- a/programs/store/src/instructions/token_config.rs
+++ b/programs/store/src/instructions/token_config.rs
@@ -207,9 +207,9 @@ impl<'info> internal::Authentication<'info> for ToggleTokenConfig<'info> {
     }
 }
 
-/// The accounts definition for [`set_token_config_market_status_flag`](crate::gmsol_store::set_token_config_market_status_flag).
+/// The accounts definition for [`set_feed_config_market_status_flag`](crate::gmsol_store::set_feed_config_market_status_flag).
 #[derive(Accounts)]
-pub struct SetTokenConfigMarketStatusFlag<'info> {
+pub struct SetFeedConfigMarketStatusFlag<'info> {
     /// The authority of the instruction.
     pub authority: Signer<'info>,
     /// The store that owns the token map.
@@ -217,18 +217,20 @@ pub struct SetTokenConfigMarketStatusFlag<'info> {
     /// The token map to update.
     #[account(mut, has_one = store)]
     pub token_map: AccountLoader<'info, TokenMapHeader>,
-    /// The token whose config will be updated.
+    /// The token whose feed config will be updated.
     /// CHECK: used only as the key into the token map; not deserialized.
     pub token: UncheckedAccount<'info>,
 }
 
-impl SetTokenConfigMarketStatusFlag<'_> {
-    /// Set a per-token market-status flag, returning the previous value.
+impl SetFeedConfigMarketStatusFlag<'_> {
+    /// Set a market-status flag on the feed config of the given provider,
+    /// returning the previous value.
     ///
     /// ## CHECK
     /// - Only [`MARKET_KEEPER`](crate::states::RoleKey::MARKET_KEEPER) can perform this action.
     pub(crate) fn invoke_unchecked(
         ctx: Context<Self>,
+        provider: &PriceProviderKind,
         flag: MarketStatusFlag,
         enable: bool,
     ) -> Result<bool> {
@@ -239,12 +241,15 @@ impl SetTokenConfigMarketStatusFlag<'_> {
             .load_token_map_mut()?
             .get_mut(&token)
             .ok_or_else(|| error!(CoreError::NotFound))?
+            .get_feed_config_mut(provider)
+            .map_err(CoreError::from)
+            .map_err(|err| error!(err))?
             .set_market_status_flag(flag, enable);
         Ok(previous)
     }
 }
 
-impl<'info> internal::Authentication<'info> for SetTokenConfigMarketStatusFlag<'info> {
+impl<'info> internal::Authentication<'info> for SetFeedConfigMarketStatusFlag<'info> {
     fn authority(&self) -> &Signer<'info> {
         &self.authority
     }
@@ -347,6 +352,7 @@ impl SetFeedConfig<'_> {
             .map_err(CoreError::from)
             .map_err(|err| error!(err))?;
 
+        let previous_feed = *feed_config.feed();
         let mut new_config = *feed_config;
 
         if let Some(feed) = feed {
@@ -369,6 +375,13 @@ impl SetFeedConfig<'_> {
         }
 
         *feed_config = new_config;
+
+        if *new_config.feed() != previous_feed {
+            msg!(
+                "[Set Feed Config] feed changed: market status flags are NOT reset (current: {})",
+                new_config.market_status_flags().into_value(),
+            );
+        }
 
         Ok(())
     }

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -84,6 +84,7 @@
 //! - [`toggle_token_config`]: Enable or disable a token config of the given token map.
 //! - [`set_expected_provider`]: Set the expected provider for the given token.
 //! - [`set_feed_config_v2`]: Set the feed config of the given provider for the given token.
+//! - [`set_feed_config_market_status_flag`]: Set a market-status flag on the feed config of the given provider for the given token.
 //! - [`is_token_config_enabled`](gmsol_store::is_token_config_enabled): Check if the config for the given token is enabled.
 //! - [`token_expected_provider`](gmsol_store::token_expected_provider): Get the expected provider set for the given token.
 //! - [`token_feed`](gmsol_store::token_feed): Get the feed address of the given provider set for the given token.
@@ -880,36 +881,52 @@ pub mod gmsol_store {
         )
     }
 
-    /// Set a per-token market-status flag.
+    /// Set a market-status flag on the feed config of the given provider for
+    /// the given token.
     ///
     /// # Accounts
-    /// [*See the documentation for the accounts*](SetTokenConfigMarketStatusFlag).
+    /// [*See the documentation for the accounts*](SetFeedConfigMarketStatusFlag).
     ///
     /// # Arguments
+    /// - `provider`: The index of the provider whose feed config will be updated.
+    ///   Must be a valid [`PriceProviderKind`] value.
     /// - `flag`: The [`MarketStatusFlag`] index to set.
     /// - `enable`: Enable or disable the flag.
     ///
     /// # Errors
-    /// - The [`authority`](SetTokenConfigMarketStatusFlag::authority) must be a
+    /// - The [`authority`](SetFeedConfigMarketStatusFlag::authority) must be a
     ///   signer and a MARKET_KEEPER in the given store.
-    /// - The [`token`](SetTokenConfigMarketStatusFlag::token) must exist in the token map.
+    /// - The [`token`](SetFeedConfigMarketStatusFlag::token) must exist in the token map.
+    /// - The `provider` index must correspond to a valid [`PriceProviderKind`].
+    /// - The feed config of the `provider` for the `token` must be initialized.
     /// - `flag` must be a valid [`MarketStatusFlag`] value.
     #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
-    pub fn set_token_config_market_status_flag(
-        ctx: Context<SetTokenConfigMarketStatusFlag>,
+    pub fn set_feed_config_market_status_flag(
+        ctx: Context<SetFeedConfigMarketStatusFlag>,
+        provider: u8,
         flag: u8,
         enable: bool,
     ) -> Result<()> {
         let token = ctx.accounts.token.key();
         let authorized =
             ctx.accounts.store.load()?.token_map() == Some(&ctx.accounts.token_map.key());
+        let kind = PriceProviderKind::try_from(provider)
+            .map_err(|_| CoreError::InvalidProviderKindIndex)?;
         let market_status_flag =
             MarketStatusFlag::try_from(flag).map_err(|_| error!(CoreError::InvalidArgument))?;
-        let previous =
-            SetTokenConfigMarketStatusFlag::invoke_unchecked(ctx, market_status_flag, enable)?;
+        if !matches!(kind, PriceProviderKind::ChainlinkDataStreams) {
+            msg!("set market status flag: note: this provider does not report market status; the flag has no effect for now");
+        }
+        let previous = SetFeedConfigMarketStatusFlag::invoke_unchecked(
+            ctx,
+            &kind,
+            market_status_flag,
+            enable,
+        )?;
         msg!(
-            "set market status flag: token={}, flag={}, {} -> {}, authorized_token_map={}",
+            "set market status flag: token={}, provider={}, flag={}, {} -> {}, authorized_token_map={}",
             token,
+            kind,
             flag,
             previous,
             enable,

--- a/programs/store/src/states/oracle/feed.rs
+++ b/programs/store/src/states/oracle/feed.rs
@@ -157,15 +157,21 @@ impl PriceFeed {
             provider
         );
 
-        let feed_id = token_config.get_feed(&provider).map_err(CoreError::from)?;
-        require_keys_eq!(self.feed_id, feed_id, CoreError::InvalidPriceFeedAccount);
+        let feed_config = token_config
+            .get_feed_config(&provider)
+            .map_err(CoreError::from)?;
+        require_keys_eq!(
+            self.feed_id,
+            *feed_config.feed(),
+            CoreError::InvalidPriceFeedAccount
+        );
 
         let current = clock.unix_timestamp;
         let heartbeat_duration = token_config.heartbeat_duration();
         let is_open = self.price.is_market_open(
             current,
             heartbeat_duration,
-            token_config.market_status_flags(),
+            feed_config.market_status_flags(),
         );
 
         if !allow_closed {

--- a/programs/store/src/states/oracle/mod.rs
+++ b/programs/store/src/states/oracle/mod.rs
@@ -407,7 +407,9 @@ impl OraclePrice {
                 parsed.ok_or_else(|| error!(CoreError::Internal))?
             }
             PriceProviderKind::Pyth => {
-                // `allow_closed` is not used for Pyth, since all Pyth feeds are considered open.
+                // Market status is not supported by this provider: prices are always
+                // treated as open (as if the status were `MarketStatus::Disabled`), so
+                // `allow_closed` and per-feed market-status flags have no effect here.
                 Pyth::check_and_get_price(clock, token_config, account, feed_id)?
             }
             PriceProviderKind::Chainlink => {
@@ -415,7 +417,9 @@ impl OraclePrice {
                 return err!(CoreError::Deprecated);
             }
             PriceProviderKind::Switchboard => {
-                // `allow_closed` is not used for Switchboard, since all Switchboard feeds are considered open.
+                // Market status is not supported by this provider: prices are always
+                // treated as open (as if the status were `MarketStatus::Disabled`), so
+                // `allow_closed` and per-feed market-status flags have no effect here.
                 require_keys_eq!(*feed_id, account.key(), CoreError::InvalidPriceFeedAccount);
                 Switchboard::check_and_get_price(clock, token_config, account)?
             }

--- a/programs/store/src/states/token_config.rs
+++ b/programs/store/src/states/token_config.rs
@@ -108,6 +108,9 @@ impl TokenConfigExt for TokenConfig {
             .collect::<Vec<_>>()
             .try_into()
             .map_err(|_| error!(CoreError::InvalidArgument))?;
+        if !init {
+            msg!("[Token Config] feeds are rebuilt: market status flags and max deviation ratios are reset");
+        }
         self.expected_provider = expected_provider.unwrap_or(PriceProviderKind::default() as u8);
         self.heartbeat_duration = heartbeat_duration;
         Ok(())


### PR DESCRIPTION
- market status is persisted per feed (`PriceFeedPrice`); the policy flags interpreting it now live on `FeedConfig` (per token + provider) instead of `TokenConfig`
- rename: `set_token_config_market_status_flag` -> `set_feed_config_market_status_flag` (new `provider` arg; requires the provider's feed config to be initialized)
- full token-config rebuild resets the flags (logged); `set_feed_config_v2` preserves them (logged when the feed changes)
- any token-level flags set since #368 are dropped by this migration; re-apply per feed via the new instruction
- IDLs deliberately untouched; needs a regen after merge (same flow as #372)