### PR TITLE
feat: SDK and CLI for market status flags

### DIFF
--- a/crates/cli/src/commands/market.rs
+++ b/crates/cli/src/commands/market.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, num::NonZeroUsize, path::PathBuf};
 
 use anchor_spl::associated_token::get_associated_token_address;
+use clap::ValueEnum;
 use either::Either;
 use eyre::OptionExt;
 use gmsol_sdk::{
@@ -9,6 +10,7 @@ use gmsol_sdk::{
         config::FactorKey,
         market::{MarketConfigFlag, VirtualInventoryFlag},
         oracle::PriceProviderKind,
+        price::market_status::MarketStatusFlag,
         token_config::{
             TokenMapAccess, UpdateTokenConfigParams, DEFAULT_HEARTBEAT_DURATION, DEFAULT_PRECISION,
             DEFAULT_TIMESTAMP_ADJUSTMENT,
@@ -122,6 +124,23 @@ enum Command {
         token: Pubkey,
         #[command(flatten)]
         toggle: ToggleValue,
+    },
+    /// Set market-status flags on the feed configs of the given tokens.
+    SetMarketStatusFlag {
+        #[arg(long)]
+        token_map: Option<Pubkey>,
+        /// The provider whose feed configs will be updated.
+        #[arg(long)]
+        provider: PriceProviderKind,
+        /// Market-status flags to enable (repeat or comma-separate).
+        #[arg(long, value_delimiter = ',')]
+        enable: Vec<MarketStatusFlag>,
+        /// Market-status flags to disable (repeat or comma-separate).
+        #[arg(long, value_delimiter = ',')]
+        disable: Vec<MarketStatusFlag>,
+        /// The tokens to update.
+        #[arg(required = true)]
+        tokens: Vec<Pubkey>,
     },
     /// Toggle the token price adjustment for the given token.
     ToggleTokenPriceAdjustment {
@@ -571,6 +590,45 @@ impl super::Command for Market {
                 client
                     .toggle_token_config(store, &token_map_address, token, toggle.is_enable())
                     .into_bundle_with_options(options)?
+            }
+            Command::SetMarketStatusFlag {
+                token_map,
+                provider,
+                enable,
+                disable,
+                tokens,
+            } => {
+                if enable.is_empty() && disable.is_empty() {
+                    eyre::bail!("at least one `--enable` or `--disable` flag must be provided");
+                }
+                if let Some(flag) = enable.iter().find(|flag| disable.contains(flag)) {
+                    eyre::bail!(
+                        "`{}` appears in both `--enable` and `--disable`",
+                        flag.to_possible_value()
+                            .expect("no skipped variants")
+                            .get_name()
+                    );
+                }
+                let token_map_address = token_map_address(client, token_map.as_ref()).await?;
+                let mut bundle = client.bundle_with_options(options);
+                for token in tokens {
+                    for (flag, value) in enable
+                        .iter()
+                        .map(|flag| (flag, true))
+                        .chain(disable.iter().map(|flag| (flag, false)))
+                    {
+                        let rpc = client.set_feed_config_market_status_flag(
+                            store,
+                            &token_map_address,
+                            token,
+                            *provider,
+                            *flag,
+                            value,
+                        );
+                        bundle.push(rpc)?;
+                    }
+                }
+                bundle
             }
             Command::ToggleTokenPriceAdjustment {
                 token,

--- a/crates/sdk/src/client/ops/token_config.rs
+++ b/crates/sdk/src/client/ops/token_config.rs
@@ -2,7 +2,10 @@ use std::ops::Deref;
 
 use gmsol_programs::gmsol_store::client::{accounts, args};
 use gmsol_solana_utils::transaction_builder::TransactionBuilder;
-use gmsol_utils::{oracle::PriceProviderKind, token_config::UpdateTokenConfigParams};
+use gmsol_utils::{
+    oracle::PriceProviderKind, price::market_status::MarketStatusFlag,
+    token_config::UpdateTokenConfigParams,
+};
 use solana_sdk::{pubkey::Pubkey, signer::Signer, system_program};
 
 use crate::{serde::StringPubkey, utils::Value};
@@ -49,6 +52,18 @@ pub trait TokenConfigOps<C> {
         store: &Pubkey,
         token_map: &Pubkey,
         token: &Pubkey,
+        enable: bool,
+    ) -> TransactionBuilder<C>;
+
+    /// Set a market-status flag on the feed config of the given provider for
+    /// the given token.
+    fn set_feed_config_market_status_flag(
+        &self,
+        store: &Pubkey,
+        token_map: &Pubkey,
+        token: &Pubkey,
+        provider: PriceProviderKind,
+        flag: MarketStatusFlag,
         enable: bool,
     ) -> TransactionBuilder<C>;
 
@@ -172,6 +187,30 @@ impl<C: Deref<Target = impl Signer> + Clone> TokenConfigOps<C> for crate::Client
             })
             .anchor_args(args::ToggleTokenConfig {
                 token: *token,
+                enable,
+            })
+    }
+
+    fn set_feed_config_market_status_flag(
+        &self,
+        store: &Pubkey,
+        token_map: &Pubkey,
+        token: &Pubkey,
+        provider: PriceProviderKind,
+        flag: MarketStatusFlag,
+        enable: bool,
+    ) -> TransactionBuilder<C> {
+        let authority = self.payer();
+        self.store_transaction()
+            .anchor_accounts(accounts::SetFeedConfigMarketStatusFlag {
+                authority,
+                store: *store,
+                token_map: *token_map,
+                token: *token,
+            })
+            .anchor_args(args::SetFeedConfigMarketStatusFlag {
+                provider: provider.into(),
+                flag: flag.into(),
                 enable,
             })
     }

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -41,9 +41,12 @@ pub enum MarketStatus {
 /// the only hard floor — a stale price is always closed regardless of any flag.
 /// (`AllowClosed` on a v8 feed is generally not advised, but staleness still
 /// backstops it.)
-#[derive(IntoPrimitive, TryFromPrimitive)]
+#[derive(Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 #[non_exhaustive]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", clap(rename_all = "snake_case"))]
 pub enum MarketStatusFlag {
     /// Allow trading while the status is Unknown.
     AllowUnknown,

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -13,7 +13,7 @@ pub const MAX_MARKET_STATUS_FLAGS: usize = 8;
 #[derive(Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum MarketStatus {
     /// No market-status information (skip).
     Disabled = 0,


### PR DESCRIPTION
- SDK: `set_feed_config_market_status_flag` op on `TokenConfigOps`
- CLI: `market set-market-status-flag` — one shared `--provider`, per-flag `--enable`/`--disable` lists (repeat or comma-separate), variadic tokens; one ix per (token, flag) pair in a single bundle
- `MarketStatusFlag` now derives `clap::ValueEnum` (snake_case, aligned with the other config enums)
- `MarketStatus` serde casing aligned to snake_case for the same reason (unreleased, no consumers yet)