### PR TITLE
chore: backport changes for 0.10.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-callback"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "num_enum",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-chainlink-datastreams"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "chainlink-data-streams-report",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-cli"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-spl",
  "anyhow",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-competition"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "gmsol-callback",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-decode"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "base64 0.22.1",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-examples"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-spl",
  "futures-util",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-liquidity-provider"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-mock-chainlink-verifier"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "cfg-if",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-model"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-programs"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "bitmaps",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-sdk"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-solana-utils"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-store"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-tests"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-spl",
  "event-listener 5.4.0",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-timelock"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "bytemuck",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-treasury"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "gmsol-utils"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "anchor-lang",
  "bitmaps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "programs/*", "examples", "tests"]
 
 [workspace.package]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 edition = "2021"
 license-file = "LICENSE"
 description = "GMX-Solana is an extension of GMX on the Solana blockchain."
@@ -121,59 +121,59 @@ gql_client = "1.1.0"
 version = "1.2.1"
 
 [workspace.dependencies.gmsol-model]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "crates/model"
 
 [workspace.dependencies.gmsol-utils]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "crates/utils"
 
 [workspace.dependencies.gmsol-store]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "programs/store"
 
 [workspace.dependencies.gmsol-treasury]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "programs/treasury"
 
 [workspace.dependencies.gmsol-timelock]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "programs/timelock"
 
 [workspace.dependencies.gmsol-mock-chainlink-verifier]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "programs/mock-chainlink-verifier"
 
 [workspace.dependencies.gmsol-callback]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "programs/callback"
 
 [workspace.dependencies.gmsol-competition]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "programs/competition"
 
 [workspace.dependencies.gmsol-liquidity-provider]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "programs/liquidity-provider"
 
 [workspace.dependencies.gmsol-decode]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "crates/decode"
 
 [workspace.dependencies.gmsol-chainlink-datastreams]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "crates/chainlink-datastreams"
 
 [workspace.dependencies.gmsol-solana-utils]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "crates/solana-utils"
 
 [workspace.dependencies.gmsol-programs]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "crates/programs"
 
 [workspace.dependencies.gmsol-sdk]
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 path = "crates/sdk"
 
 [profile.release]

--- a/crates/chainlink-datastreams/src/error.rs
+++ b/crates/chainlink-datastreams/src/error.rs
@@ -10,7 +10,4 @@ pub enum Error {
     /// Overflow.
     #[error("overflow: {0}")]
     Overflow(&'static str),
-    /// Unknown market status.
-    #[error("unknown market status")]
-    UnknownMarketStatus,
 }

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -35,10 +35,10 @@ impl super::FromChainlinkReport for PriceFeedPrice {
 
         debug_assert!(!divisor.is_zero());
 
-        // Defer openness to the consumer (per-token flags); only freshness (below)
+        // Defer openness to the consumer (per-feed flags); only freshness (below)
         // can still force closed. Some v11 feeds are 24/7 and keep publishing
         // valid prices even while their (extended) status is Unknown or Closed, so
-        // whether to trade then is a per-token policy. On v8 this is unobserved and
+        // whether to trade then is a per-feed policy. On v8 this is unobserved and
         // AllowClosed is generally not advised, but staleness backstops it either way.
         let mut is_open = true;
 

--- a/crates/chainlink-datastreams/src/gmsol.rs
+++ b/crates/chainlink-datastreams/src/gmsol.rs
@@ -1,6 +1,8 @@
+use gmsol_utils::price::market_status::MarketStatus as FeedMarketStatus;
 use gmsol_utils::price::{feed_price::PriceFeedPrice, find_divisor_decimals, PriceFlag, TEN, U192};
 
-use crate::{report::MarketStatus, Report};
+use crate::report::ExtendedMarketStatus;
+use crate::Report;
 
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 
@@ -33,13 +35,12 @@ impl super::FromChainlinkReport for PriceFeedPrice {
 
         debug_assert!(!divisor.is_zero());
 
-        let mut is_open = match report.market_status() {
-            MarketStatus::Unknown => {
-                return Err(crate::Error::UnknownMarketStatus);
-            }
-            MarketStatus::Closed => false,
-            MarketStatus::Open => true,
-        };
+        // Defer openness to the consumer (per-token flags); only freshness (below)
+        // can still force closed. Some v11 feeds are 24/7 and keep publishing
+        // valid prices even while their (extended) status is Unknown or Closed, so
+        // whether to trade then is a per-token policy. On v8 this is unobserved and
+        // AllowClosed is generally not advised, but staleness backstops it either way.
+        let mut is_open = true;
 
         let observations_timestamp = report.observations_timestamp;
 
@@ -98,6 +99,155 @@ impl super::FromChainlinkReport for PriceFeedPrice {
             price.set_flag(PriceFlag::LastUpdateDiffSecs, true);
         }
 
+        // Persisting the status here is what makes the `is_open` change
+        // migration-free. Base openness only flips closed -> open for prices this
+        // code writes, and any report that was previously coarse-closed gets a
+        // non-Disabled status here. So an old account (Open=false, status
+        // Disabled) resolves closed via the base flag, and a new one (Open=true,
+        // status Closed) resolves closed via the status — either version of a
+        // stored price yields the same verdict at read time.
+        price.set_market_status(canonical_market_status(report));
+
         Ok(price)
+    }
+}
+
+impl From<ExtendedMarketStatus> for FeedMarketStatus {
+    fn from(value: ExtendedMarketStatus) -> Self {
+        match value {
+            ExtendedMarketStatus::Unknown => Self::Unknown,
+            ExtendedMarketStatus::PreMarket => Self::PreMarket,
+            ExtendedMarketStatus::RegularHours => Self::RegularHours,
+            ExtendedMarketStatus::PostMarket => Self::PostMarket,
+            ExtendedMarketStatus::Overnight => Self::Overnight,
+            ExtendedMarketStatus::Closed => Self::Closed,
+        }
+    }
+}
+
+/// Maps a decoded report to the canonical [`FeedMarketStatus`]: the granular
+/// status if the report defines one, else `Disabled`.
+fn canonical_market_status(report: &Report) -> FeedMarketStatus {
+    report
+        .extended_market_status()
+        .map_or(FeedMarketStatus::Disabled, FeedMarketStatus::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::ExtendedMarketStatus;
+    use gmsol_utils::price::market_status::MarketStatus as FeedMarketStatus;
+
+    use crate::FromChainlinkReport;
+    use gmsol_utils::price::feed_price::PriceFeedPrice;
+    use gmsol_utils::price::market_status::{MarketStatusFlag, MarketStatusFlagContainer};
+
+    fn v11_report(market_status: u32) -> Report {
+        use chainlink_data_streams_report::report::v11::ReportDataV11;
+        use num_bigint::BigInt;
+
+        let mut feed_id_bytes = [0u8; 32];
+        feed_id_bytes[1] = 0x0b; // version 11
+        let feed_id = chainlink_data_streams_report::feed_id::ID(feed_id_bytes);
+        let m: BigInt = "1000000000000000000".parse().unwrap();
+        let data = ReportDataV11 {
+            feed_id,
+            valid_from_timestamp: 1000,
+            observations_timestamp: 1000,
+            native_fee: BigInt::from(100),
+            link_fee: BigInt::from(200),
+            expires_at: 1100,
+            mid: BigInt::from(50000) * &m,
+            last_seen_timestamp_ns: 1_000_000_000_000,
+            bid: BigInt::from(49900) * &m,
+            bid_volume: BigInt::from(1000) * &m,
+            ask: BigInt::from(50100) * &m,
+            ask_volume: BigInt::from(2000) * &m,
+            last_traded_price: BigInt::from(50050) * &m,
+            market_status,
+        };
+        crate::report::decode(&data.abi_encode().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn stores_status_and_defers() {
+        // RegularHours: stored, open via default flags.
+        let open = v11_report(2);
+        let price = PriceFeedPrice::from_chainlink_report(&open).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::RegularHours);
+        assert!(price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+
+        // Closed (=5): stored, closed via default flags.
+        let closed = v11_report(5);
+        let price = PriceFeedPrice::from_chainlink_report(&closed).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::Closed);
+        assert!(!price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+
+        // RegularHours but the token halts it.
+        let mut halt = MarketStatusFlagContainer::default();
+        halt.set_flag(MarketStatusFlag::HaltRegularHours, true);
+        let price = PriceFeedPrice::from_chainlink_report(&open).unwrap();
+        assert!(!price.is_market_open(1000, u32::MAX, halt));
+    }
+
+    #[test]
+    fn from_extended_maps_each_variant() {
+        assert!(FeedMarketStatus::from(ExtendedMarketStatus::Unknown) == FeedMarketStatus::Unknown);
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::PreMarket) == FeedMarketStatus::PreMarket
+        );
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::RegularHours)
+                == FeedMarketStatus::RegularHours
+        );
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::PostMarket)
+                == FeedMarketStatus::PostMarket
+        );
+        assert!(
+            FeedMarketStatus::from(ExtendedMarketStatus::Overnight) == FeedMarketStatus::Overnight
+        );
+        assert!(FeedMarketStatus::from(ExtendedMarketStatus::Closed) == FeedMarketStatus::Closed);
+    }
+
+    fn v8_report(market_status: u32) -> Report {
+        use chainlink_data_streams_report::report::v8::ReportDataV8;
+        use num_bigint::BigInt;
+
+        let mut feed_id_bytes = [0u8; 32];
+        feed_id_bytes[1] = 0x08; // version 8
+        let feed_id = chainlink_data_streams_report::feed_id::ID(feed_id_bytes);
+        let m: BigInt = "1000000000000000000".parse().unwrap();
+        let data = ReportDataV8 {
+            feed_id,
+            valid_from_timestamp: 1000,
+            observations_timestamp: 1000,
+            native_fee: BigInt::from(100),
+            link_fee: BigInt::from(200),
+            expires_at: 1100,
+            last_update_timestamp: 1_000_000_000_000,
+            mid_price: BigInt::from(50000) * &m,
+            market_status,
+        };
+        crate::report::decode(&data.abi_encode().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn allow_closed_opens_a_reported_closed_market() {
+        let closed = v8_report(1); // 1 -> Closed
+        let price = PriceFeedPrice::from_chainlink_report(&closed).unwrap();
+        assert!(price.market_status() == FeedMarketStatus::Closed);
+
+        // Default flags: a reported Closed stays closed.
+        assert!(!price.is_market_open(1000, u32::MAX, MarketStatusFlagContainer::default()));
+
+        // AllowClosed opens it while the price is fresh...
+        let mut allow_closed = MarketStatusFlagContainer::default();
+        allow_closed.set_flag(MarketStatusFlag::AllowClosed, true);
+        assert!(price.is_market_open(1000, u32::MAX, allow_closed));
+
+        // ...but staleness closes it regardless of the flag.
+        assert!(!price.is_market_open(i64::MAX, 0, allow_closed));
     }
 }

--- a/crates/chainlink-datastreams/src/report.rs
+++ b/crates/chainlink-datastreams/src/report.rs
@@ -48,11 +48,10 @@ pub enum MarketStatus {
     Open,
 }
 
-/// Extended market status (v11 only).
+/// The market status.
 ///
-/// Downstream consumers can use this for finer-grained trading decisions
-/// instead of relying on [`MarketStatus`], which is a compatibility trade-off
-/// that collapses all non-regular-hours states to [`MarketStatus::Closed`].
+/// This is the granular status carried by every report that defines a market
+/// status; prefer it over the deprecated coarse [`MarketStatus`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExtendedMarketStatus {
     /// Unknown.
@@ -69,12 +68,12 @@ pub enum ExtendedMarketStatus {
     Closed,
 }
 
-impl From<ExtendedMarketStatus> for MarketStatus {
-    fn from(ext: ExtendedMarketStatus) -> Self {
-        match ext {
-            ExtendedMarketStatus::Unknown => MarketStatus::Unknown,
-            ExtendedMarketStatus::RegularHours => MarketStatus::Open,
-            _ => MarketStatus::Closed,
+impl From<MarketStatus> for ExtendedMarketStatus {
+    fn from(status: MarketStatus) -> Self {
+        match status {
+            MarketStatus::Unknown => ExtendedMarketStatus::Unknown,
+            MarketStatus::Closed => ExtendedMarketStatus::Closed,
+            MarketStatus::Open => ExtendedMarketStatus::RegularHours,
         }
     }
 }
@@ -100,13 +99,8 @@ impl Report {
         non_negative(self.ask)
     }
 
-    /// Returns the market status.
-    ///
-    /// For v11 reports, this is derived from [`ExtendedMarketStatus`]:
-    /// only [`ExtendedMarketStatus::RegularHours`] maps to [`MarketStatus::Open`];
-    /// all other states map to [`MarketStatus::Closed`].
-    /// This is a compatibility trade-off — downstream consumers that need
-    /// finer-grained control should use [`Self::extended_market_status()`] instead.
+    /// Returns the coarse market status.
+    #[deprecated(since = "0.10.0", note = "use `extended_market_status` instead")]
     pub fn market_status(&self) -> MarketStatus {
         self.market_status
     }
@@ -230,6 +224,7 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
         4 => {
             let report = ReportDataV4::decode(data)?;
             let price = bigint_to_signed(report.price)?;
+            let market_status = decode_market_status(report.market_status)?;
             Ok(Report {
                 feed_id: report.feed_id,
                 valid_from_timestamp: report.valid_from_timestamp,
@@ -243,8 +238,8 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 // of the RWA report schema (v4).
                 bid: price,
                 ask: price,
-                market_status: decode_market_status(report.market_status)?,
-                extended_market_status: None,
+                market_status,
+                extended_market_status: Some(market_status.into()),
             })
         }
         7 => {
@@ -269,6 +264,7 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
         8 => {
             let report = ReportDataV8::decode(data)?;
             let price = bigint_to_signed(report.mid_price)?;
+            let market_status = decode_market_status(report.market_status)?;
             Ok(Report {
                 feed_id: report.feed_id,
                 valid_from_timestamp: report.valid_from_timestamp,
@@ -280,14 +276,13 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 price,
                 bid: price,
                 ask: price,
-                market_status: decode_market_status(report.market_status)?,
-                extended_market_status: None,
+                market_status,
+                extended_market_status: Some(market_status.into()),
             })
         }
         11 => {
             let report = ReportDataV11::decode(data)?;
             let extended = decode_extended_market_status(report.market_status)?;
-            let market_status = MarketStatus::from(extended);
             let price = bigint_to_signed(report.mid)?;
             let bid = bigint_to_signed(report.bid)?;
             let ask = bigint_to_signed(report.ask)?;
@@ -303,7 +298,9 @@ pub fn decode(data: &[u8]) -> Result<Report, DecodeError> {
                 price,
                 bid,
                 ask,
-                market_status,
+                // v11 has no coarse status of its own; force the deprecated
+                // field to Unknown so consumers use `extended_market_status`.
+                market_status: MarketStatus::Unknown,
                 extended_market_status: Some(extended),
             })
         }
@@ -443,30 +440,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extended_market_status_to_market_status() {
+    fn test_market_status_to_extended() {
         assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::Unknown),
-            MarketStatus::Unknown
+            ExtendedMarketStatus::from(MarketStatus::Unknown),
+            ExtendedMarketStatus::Unknown
         );
         assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::RegularHours),
-            MarketStatus::Open
+            ExtendedMarketStatus::from(MarketStatus::Closed),
+            ExtendedMarketStatus::Closed
         );
         assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::Closed),
-            MarketStatus::Closed
-        );
-        assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::PreMarket),
-            MarketStatus::Closed
-        );
-        assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::PostMarket),
-            MarketStatus::Closed
-        );
-        assert_eq!(
-            MarketStatus::from(ExtendedMarketStatus::Overnight),
-            MarketStatus::Closed
+            ExtendedMarketStatus::from(MarketStatus::Open),
+            ExtendedMarketStatus::RegularHours
         );
     }
 
@@ -500,6 +485,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_decode_v11() {
         use chainlink_data_streams_report::report::v11::ReportDataV11;
         use num_bigint::BigInt;
@@ -536,7 +522,7 @@ mod tests {
         assert_eq!(report.observations_timestamp, 1000);
         assert_eq!(report.expires_at, 1100);
         assert_eq!(report.last_update_timestamp(), Some(1_000_000_000_000));
-        assert_eq!(report.market_status(), MarketStatus::Open);
+        assert_eq!(report.market_status(), MarketStatus::Unknown);
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::RegularHours)
@@ -547,6 +533,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_decode_v11_pre_market() {
         use chainlink_data_streams_report::report::v11::ReportDataV11;
         use num_bigint::BigInt;
@@ -579,7 +566,7 @@ mod tests {
         let report = decode(&encoded).unwrap();
 
         // PreMarket should map to Closed
-        assert_eq!(report.market_status(), MarketStatus::Closed);
+        assert_eq!(report.market_status(), MarketStatus::Unknown);
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::PreMarket)
@@ -587,6 +574,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_decode_v11_xau_full_report() {
         let data = hex::decode(
             "00094baebfda9b87680d8e59aa20a3e565126640ee7caeab3cd965e5568b17ee\
@@ -646,7 +634,7 @@ mod tests {
         assert!(report.non_negative_ask() == Some(ask));
 
         // market_status=5 -> Closed
-        assert_eq!(report.market_status(), MarketStatus::Closed);
+        assert_eq!(report.market_status(), MarketStatus::Unknown);
         assert_eq!(
             report.extended_market_status(),
             Some(ExtendedMarketStatus::Closed)

--- a/crates/cli/src/commands/market.rs
+++ b/crates/cli/src/commands/market.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, num::NonZeroUsize, path::PathBuf};
 
 use anchor_spl::associated_token::get_associated_token_address;
+use clap::ValueEnum;
 use either::Either;
 use eyre::OptionExt;
 use gmsol_sdk::{
@@ -9,6 +10,7 @@ use gmsol_sdk::{
         config::FactorKey,
         market::{MarketConfigFlag, VirtualInventoryFlag},
         oracle::PriceProviderKind,
+        price::market_status::MarketStatusFlag,
         token_config::{
             TokenMapAccess, UpdateTokenConfigParams, DEFAULT_HEARTBEAT_DURATION, DEFAULT_PRECISION,
             DEFAULT_TIMESTAMP_ADJUSTMENT,
@@ -122,6 +124,23 @@ enum Command {
         token: Pubkey,
         #[command(flatten)]
         toggle: ToggleValue,
+    },
+    /// Set market-status flags on the feed configs of the given tokens.
+    SetMarketStatusFlag {
+        #[arg(long)]
+        token_map: Option<Pubkey>,
+        /// The provider whose feed configs will be updated.
+        #[arg(long)]
+        provider: PriceProviderKind,
+        /// Market-status flags to enable (repeat or comma-separate).
+        #[arg(long, value_delimiter = ',')]
+        enable: Vec<MarketStatusFlag>,
+        /// Market-status flags to disable (repeat or comma-separate).
+        #[arg(long, value_delimiter = ',')]
+        disable: Vec<MarketStatusFlag>,
+        /// The tokens to update.
+        #[arg(required = true)]
+        tokens: Vec<Pubkey>,
     },
     /// Toggle the token price adjustment for the given token.
     ToggleTokenPriceAdjustment {
@@ -571,6 +590,45 @@ impl super::Command for Market {
                 client
                     .toggle_token_config(store, &token_map_address, token, toggle.is_enable())
                     .into_bundle_with_options(options)?
+            }
+            Command::SetMarketStatusFlag {
+                token_map,
+                provider,
+                enable,
+                disable,
+                tokens,
+            } => {
+                if enable.is_empty() && disable.is_empty() {
+                    eyre::bail!("at least one `--enable` or `--disable` flag must be provided");
+                }
+                if let Some(flag) = enable.iter().find(|flag| disable.contains(flag)) {
+                    eyre::bail!(
+                        "`{}` appears in both `--enable` and `--disable`",
+                        flag.to_possible_value()
+                            .expect("no skipped variants")
+                            .get_name()
+                    );
+                }
+                let token_map_address = token_map_address(client, token_map.as_ref()).await?;
+                let mut bundle = client.bundle_with_options(options);
+                for token in tokens {
+                    for (flag, value) in enable
+                        .iter()
+                        .map(|flag| (flag, true))
+                        .chain(disable.iter().map(|flag| (flag, false)))
+                    {
+                        let rpc = client.set_feed_config_market_status_flag(
+                            store,
+                            &token_map_address,
+                            token,
+                            *provider,
+                            *flag,
+                            value,
+                        );
+                        bundle.push(rpc)?;
+                    }
+                }
+                bundle
             }
             Command::ToggleTokenPriceAdjustment {
                 token,

--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -677,6 +677,24 @@ where
         }
 
         // Update open interest.
+        //
+        // Open interest is updated by exactly `-size_delta_usd` / `-size_delta_in_tokens`,
+        // which requires that the position's `size_in_usd` / `size_in_tokens` changed by
+        // exactly these amounts above. This holds because:
+        //   1. Partial decrease (the `!should_remove` branch): the sizes are set via
+        //      `checked_sub` to `size_in_usd - size_delta_usd` and
+        //      `size_in_tokens - size_delta_in_tokens`.
+        //   2. Full close (`should_remove`): both sizes are zeroed, which matches the
+        //      deltas iff the close is full on both dimensions. `check_partial_close`
+        //      (via `is_remaining_size_too_small`) promotes the order to a full close
+        //      (`size_delta_usd = size_in_usd`) whenever either the remaining
+        //      `size_in_usd` would fall below `min_position_size_usd` or
+        //      `size_delta_in_tokens(size_delta_usd) >= size_in_tokens` (i.e. the
+        //      decrease would zero out the tokens). Hence a non-full close leaves both
+        //      `size_in_usd` and `size_in_tokens` strictly positive, so `should_remove`
+        //      is reached only on a close that is full on both dimensions, and the same
+        //      `size_delta_in_tokens` helper guarantees `size_delta_in_tokens ==
+        //      size_in_tokens` there.
         self.position.update_open_interest(
             &self.size_delta_usd.to_opposite_signed()?,
             &execution.size_delta_in_tokens.to_opposite_signed()?,

--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -289,17 +289,33 @@ where
             }
 
             if *self.position.size_in_usd() > self.size_delta_usd
-                && self
-                    .position
-                    .size_in_usd()
-                    .checked_sub(&self.size_delta_usd)
-                    .expect("must success")
-                    < *params.min_position_size_usd()
+                && self.is_remaining_size_too_small(params.min_position_size_usd())?
             {
                 self.size_delta_usd = self.position.size_in_usd().clone();
             }
         }
         Ok(())
+    }
+
+    fn is_remaining_size_too_small(&self, min_position_size_usd: &P::Num) -> crate::Result<bool> {
+        if self
+            .position
+            .size_in_usd()
+            .checked_sub(&self.size_delta_usd)
+            .ok_or(crate::Error::Computation(
+                "calculating remaining size_in_usd",
+            ))?
+            < *min_position_size_usd
+        {
+            return Ok(true);
+        }
+
+        // Check whether closing could drive size_in_tokens to 0; in that case
+        // we also consider the remaining size too small.
+        // In practice, size_in_tokens >= size_delta_in_tokens should hold here;
+        // this is only to avoid making too many assumptions.
+        Ok(*self.position.size_in_tokens()
+            <= self.position.size_delta_in_tokens(&self.size_delta_usd)?)
     }
 
     fn check_close(&mut self) -> crate::Result<()> {

--- a/crates/model/src/action/increase_position.rs
+++ b/crates/model/src/action/increase_position.rs
@@ -518,6 +518,8 @@ where
         // Update borrowing fee state.
         *self.position.borrowing_factor_mut() = next_position_borrowing_factor;
 
+        // Unlike `DecreasePosition`, sizes here grow unconditionally by exactly these
+        // deltas (added just above), so open interest stays consistent by construction.
         self.position.update_open_interest(
             &self.params.size_delta_usd.to_signed()?,
             &execution.size_delta_in_tokens.to_signed()?,

--- a/crates/model/src/position.rs
+++ b/crates/model/src/position.rs
@@ -333,6 +333,27 @@ pub trait PositionExt<const DECIMALS: u8>: Position<DECIMALS> {
         Ok(collateral_value)
     }
 
+    /// Calculate size delta in tokens when decreased by the given delta size.
+    fn size_delta_in_tokens(&self, size_delta_usd: &Self::Num) -> crate::Result<Self::Num> {
+        let size_delta_in_tokens = if *self.size_in_usd() == *size_delta_usd {
+            self.size_in_tokens().clone()
+        } else if self.is_long() {
+            self.size_in_tokens()
+                .checked_mul_div_ceil(size_delta_usd, self.size_in_usd())
+                .ok_or(crate::Error::Computation(
+                    "calculating size delta in tokens for long",
+                ))?
+        } else {
+            self.size_in_tokens()
+                .checked_mul_div(size_delta_usd, self.size_in_usd())
+                .ok_or(crate::Error::Computation(
+                    "calculating size delta in tokens for short",
+                ))?
+        };
+
+        Ok(size_delta_in_tokens)
+    }
+
     /// Calculate the pnl value when decreased by the given delta size.
     ///
     /// Returns `(pnl_value, uncapped_pnl_value, size_delta_in_tokens)`
@@ -395,21 +416,7 @@ pub trait PositionExt<const DECIMALS: u8>: Position<DECIMALS> {
             }
         }
 
-        let size_delta_in_tokens = if *self.size_in_usd() == *size_delta_usd {
-            self.size_in_tokens().clone()
-        } else if self.is_long() {
-            self.size_in_tokens()
-                .checked_mul_div_ceil(size_delta_usd, self.size_in_usd())
-                .ok_or(crate::Error::Computation(
-                    "calculating size delta in tokens for long",
-                ))?
-        } else {
-            self.size_in_tokens()
-                .checked_mul_div(size_delta_usd, self.size_in_usd())
-                .ok_or(crate::Error::Computation(
-                    "calculating size delta in tokens for short",
-                ))?
-        };
+        let size_delta_in_tokens = self.size_delta_in_tokens(size_delta_usd)?;
 
         let pnl_usd = size_delta_in_tokens
             .checked_mul_div_with_signed_numerator(&total_pnl, self.size_in_tokens())

--- a/crates/programs/idls/gmsol_competition.json
+++ b/crates/programs/idls/gmsol_competition.json
@@ -2,7 +2,7 @@
   "address": "2AxuNr6euZPKQbTwNsLBjzFTZFAevA85F4PW9m9Dv8pc",
   "metadata": {
     "name": "gmsol_competition",
-    "version": "0.10.0",
+    "version": "0.10.0-beta.1",
     "spec": "0.1.0",
     "description": "GMX-Solana is an extension of GMX on the Solana blockchain.",
     "repository": "https://github.com/gmsol-labs/gmx-solana"

--- a/crates/programs/idls/gmsol_liquidity_provider.json
+++ b/crates/programs/idls/gmsol_liquidity_provider.json
@@ -2,7 +2,7 @@
   "address": "LPMWczEVgXyQ3979XaqqEttanCXmYGvtJqPVtw1PvC8",
   "metadata": {
     "name": "gmsol_liquidity_provider",
-    "version": "0.10.0",
+    "version": "0.10.0-beta.1",
     "spec": "0.1.0",
     "description": "GMX-Solana is an extension of GMX on the Solana blockchain.",
     "repository": "https://github.com/gmsol-labs/gmx-solana"

--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -2,7 +2,7 @@
   "address": "Gmso1uvJnLbawvw7yezdfCDcPydwW2s2iqG3w6MDucLo",
   "metadata": {
     "name": "gmsol_store",
-    "version": "0.10.0",
+    "version": "0.10.0-beta.1",
     "spec": "0.1.0",
     "description": "GMX-Solana is an extension of GMX on the Solana blockchain.",
     "repository": "https://github.com/gmsol-labs/gmx-solana"
@@ -19119,6 +19119,85 @@
       ]
     },
     {
+      "name": "set_feed_config_market_status_flag",
+      "docs": [
+        "Set a market-status flag on the feed config of the given provider for",
+        "the given token.",
+        "",
+        "# Accounts",
+        "[*See the documentation for the accounts*](SetFeedConfigMarketStatusFlag).",
+        "",
+        "# Arguments",
+        "- `provider`: The index of the provider whose feed config will be updated.",
+        "Must be a valid [`PriceProviderKind`] value.",
+        "- `flag`: The [`MarketStatusFlag`] index to set.",
+        "- `enable`: Enable or disable the flag.",
+        "",
+        "# Errors",
+        "- The [`authority`](SetFeedConfigMarketStatusFlag::authority) must be a",
+        "signer and a MARKET_KEEPER in the given store.",
+        "- The [`token`](SetFeedConfigMarketStatusFlag::token) must exist in the token map.",
+        "- The `provider` index must correspond to a valid [`PriceProviderKind`].",
+        "- The feed config of the `provider` for the `token` must be initialized.",
+        "- `flag` must be a valid [`MarketStatusFlag`] value."
+      ],
+      "discriminator": [
+        180,
+        215,
+        165,
+        2,
+        25,
+        121,
+        62,
+        71
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "docs": [
+            "The authority of the instruction."
+          ],
+          "signer": true
+        },
+        {
+          "name": "store",
+          "docs": [
+            "The store that owns the token map."
+          ],
+          "relations": [
+            "token_map"
+          ]
+        },
+        {
+          "name": "token_map",
+          "docs": [
+            "The token map to update."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token",
+          "docs": [
+            "The token whose feed config will be updated."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "provider",
+          "type": "u8"
+        },
+        {
+          "name": "flag",
+          "type": "u8"
+        },
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
       "name": "set_feed_config_v2",
       "docs": [
         "Set the feed config of the given provider for the given token.",
@@ -30163,11 +30242,15 @@
             }
           },
           {
+            "name": "market_status_value",
+            "type": "u8"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                2
+                1
               ]
             }
           },

--- a/crates/programs/idls/gmsol_timelock.json
+++ b/crates/programs/idls/gmsol_timelock.json
@@ -2,7 +2,7 @@
   "address": "TimeBQ7gQyWyQMD3bTteAdy7hTVDNWSwELdSVZHfSXL",
   "metadata": {
     "name": "gmsol_timelock",
-    "version": "0.10.0",
+    "version": "0.10.0-beta.1",
     "spec": "0.1.0",
     "description": "GMX-Solana is an extension of GMX on the Solana blockchain.",
     "repository": "https://github.com/gmsol-labs/gmx-solana"

--- a/crates/programs/idls/gmsol_treasury.json
+++ b/crates/programs/idls/gmsol_treasury.json
@@ -2,7 +2,7 @@
   "address": "GTuvYD5SxkTq4FLG6JV1FQ5dkczr1AfgDcBHaFsBdtBg",
   "metadata": {
     "name": "gmsol_treasury",
-    "version": "0.10.0",
+    "version": "0.10.0-beta.1",
     "spec": "0.1.0",
     "description": "GMX-Solana is an extension of GMX on the Solana blockchain.",
     "repository": "https://github.com/gmsol-labs/gmx-solana"

--- a/crates/sdk/package-lock.json
+++ b/crates/sdk/package-lock.json
@@ -13,9 +13,9 @@
         "rimraf": "^6.0.1",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.2",
-        "webpack": "5.98.0",
+        "webpack": "^5.107.2",
         "webpack-cli": "6.0.1",
-        "webpack-dev-server": "^5.2.2"
+        "webpack-dev-server": "^5.2.4"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -28,20 +28,13 @@
       }
     },
     "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
       "dev": true,
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -107,6 +100,317 @@
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/buffers": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.6.tgz",
+      "integrity": "sha512-uI++Wx6VkBJqVmkb4ZeExwAVpZiA2Do5NrEtXoDk0Pdvce3ytFXJoviT1sLOj16+qDIMnD5nWPfOhVpnDmRJKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.6.tgz",
+      "integrity": "sha512-pKkw/yC5CzSZKhIIUIsH1przOa+K5jGmZIg1sWaSF24JojyrUFbjcQv7QrcGAudriei6HQ6R0BFj+V8NbQinJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.6.tgz",
+      "integrity": "sha512-Kbn1jdkvDN4F2+BhoB6mMu7NCbhP0bgA5NcI1aJj/Q5UcU+I1JLLW+dEQean33iV4tXv35AzBVKPICnDltBpxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "@jsonjoy.com/fs-print": "4.57.6",
+        "@jsonjoy.com/fs-snapshot": "4.57.6",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.6.tgz",
+      "integrity": "sha512-V4DgEFT3Cg5S9fCMOZSCVdTxdJWWLBO0WnAazV7hnCM96u5zXHyW/ubDAfcSVwqjkMJ50W1Y44IXtxRoIwaCVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.6.tgz",
+      "integrity": "sha512-+JptNw3iifihxH2rEXrninDzX4FFVW8JD/wPR8GbJPAeL9CQUSblrlumOPB5gZuS7tYRX+PJPLtT7XzKoRhv/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.6.tgz",
+      "integrity": "sha512-foyUrfS7WmYEUzqYXSNxmJBcSj04TABrkpFabwO9SCDCpVCfJ+qG+2sk5FjfiflG2n0SDFZDCJ6vYlJAEpxJFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.57.6"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.6.tgz",
+      "integrity": "sha512-96eAn4Dudtt67LTeuU47yUD+pg9/G/oKpI10zei9ljk3X3WK4lYKc+n3cpaPCAbKPzoyfxl0mXm8f8Y7BOSFXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.6.tgz",
+      "integrity": "sha512-V57CMzbOgTzUWGOWQ8GzHQdpJP6JnrYVNCtTBNxVYEnlVRvo4uEJqHhtAT8vhDFrIuJOXLrTL1Fki4h5oI7xxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
       "engines": {
         "node": ">=10.0"
       },
@@ -119,15 +423,58 @@
       }
     },
     "node_modules/@jsonjoy.com/json-pack": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.2.0.tgz",
-      "integrity": "sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/base64": "^1.1.1",
-        "@jsonjoy.com/util": "^1.1.2",
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.2.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.2",
+        "@jsonjoy.com/util": "^1.9.0",
         "hyperdyperid": "^1.2.0",
-        "thingies": "^1.20.0"
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/util": "^1.9.0"
       },
       "engines": {
         "node": ">=10.0"
@@ -141,10 +488,32 @@
       }
     },
     "node_modules/@jsonjoy.com/util": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
-      "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
       },
@@ -160,13 +529,197 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -177,6 +730,7 @@
       "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
       "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -186,6 +740,7 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -195,66 +750,38 @@
       "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
       "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
       "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -269,16 +796,18 @@
       "dev": true
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.16",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
-      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -293,7 +822,8 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.13",
@@ -304,40 +834,34 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
-      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/qs": {
-      "version": "6.9.18",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
-      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
-      "dev": true
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -346,19 +870,32 @@
       "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
       "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*",
-        "@types/send": "*"
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/sockjs": {
@@ -366,15 +903,17 @@
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
       "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -616,10 +1155,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -627,11 +1167,25 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -680,20 +1234,9 @@
       "engines": [
         "node >= 0.8.0"
       ],
+      "license": "Apache-2.0",
       "bin": {
         "ansi-html": "bin/ansi-html"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -713,6 +1256,7 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -721,29 +1265,50 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -756,6 +1321,7 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -764,23 +1330,24 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -788,10 +1355,11 @@
       }
     },
     "node_modules/bonjour-service": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
-      "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
+      "integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "multicast-dns": "^7.2.5"
@@ -804,13 +1372,16 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -826,9 +1397,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -844,11 +1415,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -868,6 +1441,7 @@
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
@@ -887,11 +1461,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -905,6 +1490,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -927,9 +1513,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "dev": true,
       "funding": [
         {
@@ -944,7 +1530,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -965,6 +1552,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -982,18 +1570,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -1100,6 +1676,7 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
       "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -1109,6 +1686,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -1121,30 +1699,34 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1198,10 +1780,11 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
         "default-browser-id": "^5.0.0"
@@ -1214,10 +1797,11 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1230,6 +1814,7 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1242,6 +1827,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1251,6 +1837,7 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -1260,13 +1847,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
       "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       },
@@ -1353,6 +1942,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1362,12 +1952,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1375,34 +1959,31 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.124",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.124.tgz",
-      "integrity": "sha512-riELkpDUqBi00gqreV3RIGoowxGrfueEKBd6zPdOk/I8lvuFpBGNkYoHof3zUHbiTBsIU8oxdIIL/WNrAG1/7A==",
-      "dev": true
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "version": "1.5.368",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
+      "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
+      "integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -1434,6 +2015,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -1443,21 +2025,24 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1470,6 +2055,7 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1537,6 +2123,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1545,7 +2132,8 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -1557,39 +2145,40 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -1609,9 +2198,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1622,7 +2211,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -1658,17 +2248,18 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.2",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -1698,9 +2289,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -1708,6 +2299,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1738,6 +2330,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1747,6 +2340,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1757,6 +2351,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1779,6 +2374,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -1803,6 +2399,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -1812,14 +2409,16 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -1834,6 +2433,36 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob-to-regex.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -1845,6 +2474,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1862,7 +2492,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -1878,6 +2509,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1911,6 +2543,7 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "obuf": "^1.0.0",
@@ -1923,6 +2556,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1937,13 +2571,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hpack.js/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -2033,22 +2669,28 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-parser-js": {
@@ -2062,6 +2704,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -2101,6 +2744,7 @@
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
       "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.18"
       }
@@ -2110,6 +2754,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2152,10 +2797,11 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -2165,6 +2811,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -2192,6 +2839,7 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -2207,17 +2855,9 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2225,6 +2865,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2237,6 +2878,7 @@
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -2251,10 +2893,11 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
-      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -2276,6 +2919,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
       "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2296,10 +2940,11 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -2314,7 +2959,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2332,12 +2978,13 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "@isaacs/cliui": "^9.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -2384,12 +3031,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2406,22 +3047,28 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
-      "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -2437,10 +3084,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -2465,6 +3113,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2474,27 +3123,39 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/memfs": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.0.tgz",
-      "integrity": "sha512-4eirfZ7thblFmqFjywlTmuWVSvccHAJbn1r8qQLzmTO11qcqpohOjmY2mFce6x7x7WtskzRqApPD0hv+Oa74jg==",
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.6.tgz",
+      "integrity": "sha512-WQK+DGjKCnPdpSyJUXphz+COF2uEhhsxQ3VIWBSbzpbbXuch3h4FePMqXrXGdLjsTgo4JFzBFsP6AWd9pVazGw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/json-pack": "^1.0.3",
-        "@jsonjoy.com/util": "^1.3.0",
-        "tree-dump": "^1.0.1",
+        "@jsonjoy.com/fs-core": "4.57.6",
+        "@jsonjoy.com/fs-fsa": "4.57.6",
+        "@jsonjoy.com/fs-node": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "@jsonjoy.com/fs-print": "4.57.6",
+        "@jsonjoy.com/fs-snapshot": "4.57.6",
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
         "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/merge-descriptors": {
@@ -2502,6 +3163,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -2517,6 +3179,7 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2534,23 +3197,12 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -2583,18 +3235,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2620,6 +3274,7 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
       "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
@@ -2653,26 +3308,22 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2694,6 +3345,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2705,7 +3357,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -2730,15 +3383,16 @@
       }
     },
     "node_modules/open": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -2779,6 +3433,7 @@
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
       "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.2",
         "is-network-error": "^1.0.0",
@@ -2876,16 +3531,31 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -2897,6 +3567,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/pretty-error": {
@@ -2913,13 +3601,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -2933,32 +3623,45 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
     },
-    "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -2971,15 +3674,16 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -2990,6 +3694,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3004,23 +3709,12 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {
@@ -3034,6 +3728,13 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/relateurl": {
       "version": "0.2.7",
@@ -3091,7 +3792,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -3139,6 +3841,7 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -3163,10 +3866,11 @@
       }
     },
     "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3198,13 +3902,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -3223,19 +3929,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/selfsigned": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/node-forge": "^1.3.0",
-        "node-forge": "^1"
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/semver": {
@@ -3251,52 +3959,36 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
@@ -3362,15 +4054,16 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -3380,7 +4073,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -3416,10 +4110,11 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3432,6 +4127,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -3447,13 +4143,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3467,6 +4164,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3485,6 +4183,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3546,6 +4245,7 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
       "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
         "handle-thing": "^2.0.0",
@@ -3562,6 +4262,7 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
         "detect-node": "^2.0.4",
@@ -3572,10 +4273,11 @@
       }
     },
     "node_modules/spdy-transport/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3592,13 +4294,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/spdy/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3615,13 +4319,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3631,104 +4337,9 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -3756,12 +4367,17 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
@@ -3783,15 +4399,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -3805,10 +4421,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -3817,12 +4460,17 @@
       }
     },
     "node_modules/thingies": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-      "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
       },
       "peerDependencies": {
         "tslib": "^2"
@@ -3832,7 +4480,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -3851,15 +4500,17 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/tree-dump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
-      "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
       },
@@ -3976,11 +4627,32 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -4013,14 +4685,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -4036,6 +4709,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -4051,7 +4725,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utila": {
       "version": "0.4.0",
@@ -4064,6 +4739,7 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -4087,10 +4763,11 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -4104,39 +4781,41 @@
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/webpack": {
-      "version": "5.98.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
-      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+      "version": "5.107.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.6",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.14.0",
-        "browserslist": "^4.24.0",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.22.0",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.5.0",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.5.0"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -4206,14 +4885,15 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
-      "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+      "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.10",
-        "memfs": "^4.6.0",
-        "mime-types": "^2.1.31",
+        "memfs": "^4.43.1",
+        "mime-types": "^3.0.1",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.0.0"
@@ -4234,16 +4914,43 @@
         }
       }
     },
+    "node_modules/webpack-dev-middleware/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.25",
         "@types/express-serve-static-core": "^4.17.21",
         "@types/serve-index": "^1.9.4",
         "@types/serve-static": "^1.15.5",
@@ -4253,9 +4960,9 @@
         "bonjour-service": "^1.2.1",
         "chokidar": "^3.6.0",
         "colorette": "^2.0.10",
-        "compression": "^1.7.4",
+        "compression": "^1.8.1",
         "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.21.2",
+        "express": "^4.22.1",
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
@@ -4263,7 +4970,7 @@
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",
-        "selfsigned": "^2.4.1",
+        "selfsigned": "^5.5.0",
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
@@ -4292,19 +4999,6 @@
         }
       }
     },
-    "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -4320,12 +5014,23 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/websocket-driver": {
@@ -4372,132 +5077,12 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4512,6 +5097,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/crates/sdk/package-lock.json
+++ b/crates/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gmsol-labs/gmsol-sdk",
-  "version": "0.10.0-beta.0",
+  "version": "0.10.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gmsol-labs/gmsol-sdk",
-      "version": "0.10.0-beta.0",
+      "version": "0.10.0-beta.1",
       "devDependencies": {
         "@wasm-tool/wasm-pack-plugin": "1.7.0",
         "html-webpack-plugin": "^5.6.3",

--- a/crates/sdk/package.json
+++ b/crates/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmsol-labs/gmsol-sdk",
-  "version": "0.10.0-beta.0",
+  "version": "0.10.0-beta.1",
   "scripts": {
     "build": "rimraf dist pkg && webpack --mode production",
     "start": "rimraf dist pkg && webpack serve",

--- a/crates/sdk/package.json
+++ b/crates/sdk/package.json
@@ -12,9 +12,9 @@
     "rimraf": "^6.0.1",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.2",
-    "webpack": "5.98.0",
+    "webpack": "^5.107.2",
     "webpack-cli": "6.0.1",
-    "webpack-dev-server": "^5.2.2"
+    "webpack-dev-server": "^5.2.4"
   },
   "files": [
     "pkg"

--- a/crates/sdk/src/client/ops/token_config.rs
+++ b/crates/sdk/src/client/ops/token_config.rs
@@ -2,7 +2,10 @@ use std::ops::Deref;
 
 use gmsol_programs::gmsol_store::client::{accounts, args};
 use gmsol_solana_utils::transaction_builder::TransactionBuilder;
-use gmsol_utils::{oracle::PriceProviderKind, token_config::UpdateTokenConfigParams};
+use gmsol_utils::{
+    oracle::PriceProviderKind, price::market_status::MarketStatusFlag,
+    token_config::UpdateTokenConfigParams,
+};
 use solana_sdk::{pubkey::Pubkey, signer::Signer, system_program};
 
 use crate::{serde::StringPubkey, utils::Value};
@@ -49,6 +52,18 @@ pub trait TokenConfigOps<C> {
         store: &Pubkey,
         token_map: &Pubkey,
         token: &Pubkey,
+        enable: bool,
+    ) -> TransactionBuilder<C>;
+
+    /// Set a market-status flag on the feed config of the given provider for
+    /// the given token.
+    fn set_feed_config_market_status_flag(
+        &self,
+        store: &Pubkey,
+        token_map: &Pubkey,
+        token: &Pubkey,
+        provider: PriceProviderKind,
+        flag: MarketStatusFlag,
         enable: bool,
     ) -> TransactionBuilder<C>;
 
@@ -172,6 +187,30 @@ impl<C: Deref<Target = impl Signer> + Clone> TokenConfigOps<C> for crate::Client
             })
             .anchor_args(args::ToggleTokenConfig {
                 token: *token,
+                enable,
+            })
+    }
+
+    fn set_feed_config_market_status_flag(
+        &self,
+        store: &Pubkey,
+        token_map: &Pubkey,
+        token: &Pubkey,
+        provider: PriceProviderKind,
+        flag: MarketStatusFlag,
+        enable: bool,
+    ) -> TransactionBuilder<C> {
+        let authority = self.payer();
+        self.store_transaction()
+            .anchor_accounts(accounts::SetFeedConfigMarketStatusFlag {
+                authority,
+                store: *store,
+                token_map: *token_map,
+                token: *token,
+            })
+            .anchor_args(args::SetFeedConfigMarketStatusFlag {
+                provider: provider.into(),
+                flag: flag.into(),
                 enable,
             })
     }

--- a/crates/utils/src/price/feed_price.rs
+++ b/crates/utils/src/price/feed_price.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::zero_copy;
 use crate::{
     price::{
         decimal::{Decimal, DecimalError},
-        market_status::MarketStatus,
+        market_status::{MarketOpenness, MarketStatus, MarketStatusFlagContainer},
         Price, PriceFlag, MAX_PRICE_FLAG,
     },
     token_config::TokenConfig,
@@ -113,8 +113,16 @@ impl PriceFeedPrice {
         &self.price
     }
 
-    /// Returns whether the market is open.
-    pub fn is_market_open(&self, current_timestamp: i64, market_close_timeout: u32) -> bool {
+    /// Returns whether the market is open for the given per-token flags.
+    pub fn is_market_open(
+        &self,
+        current_timestamp: i64,
+        market_close_timeout: u32,
+        flags: MarketStatusFlagContainer,
+    ) -> bool {
+        if let MarketOpenness::Closed = self.market_status().openness(flags) {
+            return false;
+        }
         if !self.flags.get_flag(PriceFlag::Open) {
             return false;
         }
@@ -222,43 +230,53 @@ mod tests {
     #[test]
     fn test_is_market_open_in_nanoseconds() {
         let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
-        assert!(!price.is_market_open(i64::MAX, 0));
+        assert!(!price.is_market_open(i64::MAX, 0, MarketStatusFlagContainer::default()));
         price.set_flag(PriceFlag::Open, true);
-        assert!(price.is_market_open(i64::MAX, 0));
+        assert!(price.is_market_open(i64::MAX, 0, MarketStatusFlagContainer::default()));
 
         price.set_flag(PriceFlag::LastUpdateDiffEnabled, true);
         price.last_update_diff = u32::MAX;
 
         price.ts = i64::MIN;
-        assert!(!price.is_market_open(i64::MAX, u32::MAX));
+        assert!(!price.is_market_open(i64::MAX, u32::MAX, MarketStatusFlagContainer::default()));
 
         price.ts = i64::MAX;
-        assert!(price.is_market_open(i64::MIN, 0));
+        assert!(price.is_market_open(i64::MIN, 0, MarketStatusFlagContainer::default()));
 
         let delay = 10i64;
         price.ts = i64::MAX - delay;
-        assert!(!price.is_market_open(i64::MAX, u32::MAX / NANOS_PER_SECOND_U32 + delay as u32));
+        assert!(!price.is_market_open(
+            i64::MAX,
+            u32::MAX / NANOS_PER_SECOND_U32 + delay as u32,
+            MarketStatusFlagContainer::default()
+        ));
         assert!(price.is_market_open(
             i64::MAX,
-            u32::MAX.div_ceil(NANOS_PER_SECOND_U32) + delay as u32
+            u32::MAX.div_ceil(NANOS_PER_SECOND_U32) + delay as u32,
+            MarketStatusFlagContainer::default()
         ));
 
         let diff = 1i64;
         price.ts = i64::MAX;
         let current = i64::MAX - diff;
-        assert!(!price.is_market_open(current, u32::MAX / NANOS_PER_SECOND_U32 - diff as u32));
+        assert!(!price.is_market_open(
+            current,
+            u32::MAX / NANOS_PER_SECOND_U32 - diff as u32,
+            MarketStatusFlagContainer::default()
+        ));
         assert!(price.is_market_open(
             current,
-            u32::MAX.div_ceil(NANOS_PER_SECOND_U32) - diff as u32
+            u32::MAX.div_ceil(NANOS_PER_SECOND_U32) - diff as u32,
+            MarketStatusFlagContainer::default()
         ));
     }
 
     #[test]
     fn test_is_market_open_in_seconds() {
         let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
-        assert!(!price.is_market_open(i64::MAX, 0));
+        assert!(!price.is_market_open(i64::MAX, 0, MarketStatusFlagContainer::default()));
         price.set_flag(PriceFlag::Open, true);
-        assert!(price.is_market_open(i64::MAX, 0));
+        assert!(price.is_market_open(i64::MAX, 0, MarketStatusFlagContainer::default()));
 
         price.set_flag(PriceFlag::LastUpdateDiffEnabled, true);
         price.set_flag(PriceFlag::LastUpdateDiffSecs, true);
@@ -266,23 +284,52 @@ mod tests {
         price.last_update_diff = u32::MAX;
 
         price.ts = i64::MIN;
-        assert!(!price.is_market_open(i64::MAX, u32::MAX));
+        assert!(!price.is_market_open(i64::MAX, u32::MAX, MarketStatusFlagContainer::default()));
 
         price.ts = i64::MAX;
-        assert!(price.is_market_open(i64::MIN, 0));
+        assert!(price.is_market_open(i64::MIN, 0, MarketStatusFlagContainer::default()));
 
         let delay = 10u32;
         let max_diff = u32::MAX - delay;
         price.last_update_diff = max_diff;
         price.ts = i64::MAX - delay as i64;
-        assert!(!price.is_market_open(i64::MAX, u32::MAX - 1));
-        assert!(price.is_market_open(i64::MAX, u32::MAX));
+        assert!(!price.is_market_open(
+            i64::MAX,
+            u32::MAX - 1,
+            MarketStatusFlagContainer::default()
+        ));
+        assert!(price.is_market_open(i64::MAX, u32::MAX, MarketStatusFlagContainer::default()));
 
         let diff = 1u32;
         price.last_update_diff = u32::MAX;
         price.ts = i64::MAX;
         let current = i64::MAX - diff as i64;
-        assert!(!price.is_market_open(current, u32::MAX - diff - 1));
-        assert!(price.is_market_open(current, u32::MAX - diff));
+        assert!(!price.is_market_open(
+            current,
+            u32::MAX - diff - 1,
+            MarketStatusFlagContainer::default()
+        ));
+        assert!(price.is_market_open(
+            current,
+            u32::MAX - diff,
+            MarketStatusFlagContainer::default()
+        ));
+    }
+
+    #[test]
+    fn is_market_open_closed_status_is_closed_even_when_fresh() {
+        let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
+        price.set_flag(PriceFlag::Open, true);
+        price.set_market_status(MarketStatus::Closed);
+        assert!(!price.is_market_open(0, u32::MAX, MarketStatusFlagContainer::default()));
+    }
+
+    #[test]
+    fn is_market_open_regular_hours_follows_base() {
+        let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
+        price.set_market_status(MarketStatus::RegularHours);
+        assert!(!price.is_market_open(0, u32::MAX, MarketStatusFlagContainer::default()));
+        price.set_flag(PriceFlag::Open, true);
+        assert!(price.is_market_open(0, u32::MAX, MarketStatusFlagContainer::default()));
     }
 }

--- a/crates/utils/src/price/feed_price.rs
+++ b/crates/utils/src/price/feed_price.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::zero_copy;
 use crate::{
     price::{
         decimal::{Decimal, DecimalError},
+        market_status::MarketStatus,
         Price, PriceFlag, MAX_PRICE_FLAG,
     },
     token_config::TokenConfig,
@@ -18,7 +19,8 @@ const NANOS_PER_SECOND_U32: u32 = 1_000_000_000;
 pub struct PriceFeedPrice {
     decimals: u8,
     flags: PriceFlagContainer,
-    padding: [u8; 2],
+    market_status_value: u8,
+    padding: [u8; 1],
     last_update_diff: u32,
     ts: i64,
     price: u128,
@@ -39,7 +41,8 @@ impl PriceFeedPrice {
         Self {
             decimals,
             flags: Default::default(),
-            padding: [0; 2],
+            market_status_value: u8::from(MarketStatus::Disabled),
+            padding: [0; 1],
             last_update_diff,
             ts,
             price,
@@ -149,6 +152,16 @@ impl PriceFeedPrice {
                 .saturating_sub(current_diff)
     }
 
+    /// Returns the market status. An invalid stored value maps to [`MarketStatus::Disabled`].
+    pub fn market_status(&self) -> MarketStatus {
+        MarketStatus::try_from(self.market_status_value).unwrap_or(MarketStatus::Disabled)
+    }
+
+    /// Sets the market status.
+    pub fn set_market_status(&mut self, market_status: MarketStatus) {
+        self.market_status_value = u8::from(market_status);
+    }
+
     /// Try converting to [`Price`].
     pub fn try_to_price(&self, token_config: &TokenConfig) -> Result<Price, DecimalError> {
         let token_decimals = token_config.token_decimals();
@@ -174,6 +187,37 @@ impl PriceFeedPrice {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn market_status_round_trip() {
+        let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
+        for status in [
+            MarketStatus::Disabled,
+            MarketStatus::Unknown,
+            MarketStatus::PreMarket,
+            MarketStatus::RegularHours,
+            MarketStatus::PostMarket,
+            MarketStatus::Overnight,
+            MarketStatus::Closed,
+        ] {
+            price.set_market_status(status);
+            assert!(price.market_status() == status);
+        }
+    }
+
+    #[test]
+    fn market_status_invalid_maps_to_disabled() {
+        let mut price = PriceFeedPrice::new(0, 0, 1, 1, 1, 0);
+        price.market_status_value = 99;
+        assert!(price.market_status() == MarketStatus::Disabled);
+    }
+
+    #[test]
+    fn zeroed_price_market_status_is_disabled() {
+        use bytemuck::Zeroable;
+        let price = PriceFeedPrice::zeroed();
+        assert!(price.market_status() == MarketStatus::Disabled);
+    }
 
     #[test]
     fn test_is_market_open_in_nanoseconds() {

--- a/crates/utils/src/price/feed_price.rs
+++ b/crates/utils/src/price/feed_price.rs
@@ -113,7 +113,7 @@ impl PriceFeedPrice {
         &self.price
     }
 
-    /// Returns whether the market is open for the given per-token flags.
+    /// Returns whether the market is open for the given per-feed flags.
     pub fn is_market_open(
         &self,
         current_timestamp: i64,

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -13,7 +13,7 @@ pub const MAX_MARKET_STATUS_FLAGS: usize = 8;
 #[derive(Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum MarketStatus {
     /// No market-status information (skip).
     Disabled = 0,
@@ -41,9 +41,12 @@ pub enum MarketStatus {
 /// the only hard floor — a stale price is always closed regardless of any flag.
 /// (`AllowClosed` on a v8 feed is generally not advised, but staleness still
 /// backstops it.)
-#[derive(IntoPrimitive, TryFromPrimitive)]
+#[derive(Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 #[non_exhaustive]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", clap(rename_all = "snake_case"))]
 pub enum MarketStatusFlag {
     /// Allow trading while the status is Unknown.
     AllowUnknown,

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -1,0 +1,148 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+/// Max number of market-status flags.
+pub const MAX_MARKET_STATUS_FLAGS: usize = 8;
+
+/// Market status of a price feed.
+///
+/// `Disabled` (the zero value) means "no market-status information" — a skip
+/// sentinel, neither open nor closed. Persisted on-chain so a future Risk
+/// Oracle-driven contract can switch `MarketConfig` sets from a token's status.
+#[non_exhaustive]
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum MarketStatus {
+    /// No market-status information (skip).
+    Disabled = 0,
+    /// Unknown.
+    Unknown = 1,
+    /// Pre-market.
+    PreMarket = 2,
+    /// Regular trading hours.
+    RegularHours = 3,
+    /// Post-market.
+    PostMarket = 4,
+    /// Overnight.
+    Overnight = 5,
+    /// Closed.
+    Closed = 6,
+}
+
+/// Per-token market-status policy flags.
+///
+/// Each flag names the deviation from the default, so all-zero (unconfigured)
+/// resolves to: RegularHours open, every other status closed.
+#[derive(IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum MarketStatusFlag {
+    /// Allow trading while the status is Unknown.
+    AllowUnknown,
+    /// Allow trading during pre-market.
+    AllowPreMarket,
+    /// Force RegularHours closed. RegularHours is the one status open by
+    /// default (all-zero policy), so this is the inverted flag ("Halt", not
+    /// "Allow").
+    HaltRegularHours,
+    /// Allow trading during post-market.
+    AllowPostMarket,
+    /// Allow trading overnight.
+    AllowOvernight,
+    /// Allow trading while the status is Closed.
+    AllowClosed,
+    // CHECK: should have no more than `MAX_MARKET_STATUS_FLAGS` of flags.
+    // CHECK: append-only. Each variant's position is a persisted bitmap bit
+    // (see `MarketStatusFlagContainer`); only add new flags at the end, never
+    // reorder or remove, or stored `TokenConfig` flags will be misread.
+}
+
+crate::flags!(MarketStatusFlag, MAX_MARKET_STATUS_FLAGS, u8);
+
+/// Resolved openness of a market status under a per-token policy.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub enum MarketOpenness {
+    /// Open.
+    Open,
+    /// Closed.
+    Closed,
+    /// No status — defer to the base openness.
+    Skip,
+}
+
+impl MarketStatus {
+    /// Resolve openness under the given per-token flags.
+    pub fn openness(self, flags: MarketStatusFlagContainer) -> MarketOpenness {
+        let open_if = |open: bool| {
+            if open {
+                MarketOpenness::Open
+            } else {
+                MarketOpenness::Closed
+            }
+        };
+        match self {
+            Self::Disabled => MarketOpenness::Skip,
+            Self::Unknown => open_if(flags.get_flag(MarketStatusFlag::AllowUnknown)),
+            Self::PreMarket => open_if(flags.get_flag(MarketStatusFlag::AllowPreMarket)),
+            Self::RegularHours => open_if(!flags.get_flag(MarketStatusFlag::HaltRegularHours)),
+            Self::PostMarket => open_if(flags.get_flag(MarketStatusFlag::AllowPostMarket)),
+            Self::Overnight => open_if(flags.get_flag(MarketStatusFlag::AllowOvernight)),
+            Self::Closed => open_if(flags.get_flag(MarketStatusFlag::AllowClosed)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flags() -> MarketStatusFlagContainer {
+        MarketStatusFlagContainer::default()
+    }
+
+    #[test]
+    fn default_flags_openness() {
+        assert!(matches!(
+            MarketStatus::Disabled.openness(flags()),
+            MarketOpenness::Skip
+        ));
+        assert!(matches!(
+            MarketStatus::RegularHours.openness(flags()),
+            MarketOpenness::Open
+        ));
+        for status in [
+            MarketStatus::Unknown,
+            MarketStatus::PreMarket,
+            MarketStatus::PostMarket,
+            MarketStatus::Overnight,
+            MarketStatus::Closed,
+        ] {
+            assert!(matches!(status.openness(flags()), MarketOpenness::Closed));
+        }
+    }
+
+    #[test]
+    fn flags_flip_each_status() {
+        let mut halt = flags();
+        halt.set_flag(MarketStatusFlag::HaltRegularHours, true);
+        assert!(matches!(
+            MarketStatus::RegularHours.openness(halt),
+            MarketOpenness::Closed
+        ));
+
+        for (flag, status) in [
+            (MarketStatusFlag::AllowUnknown, MarketStatus::Unknown),
+            (MarketStatusFlag::AllowPreMarket, MarketStatus::PreMarket),
+            (MarketStatusFlag::AllowPostMarket, MarketStatus::PostMarket),
+            (MarketStatusFlag::AllowOvernight, MarketStatus::Overnight),
+            (MarketStatusFlag::AllowClosed, MarketStatus::Closed),
+        ] {
+            let mut f = flags();
+            f.set_flag(flag, true);
+            assert!(matches!(status.openness(f), MarketOpenness::Open));
+        }
+    }
+}

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -31,12 +31,12 @@ pub enum MarketStatus {
     Closed = 6,
 }
 
-/// Per-token market-status policy flags.
+/// Per-feed market-status policy flags.
 ///
 /// Each flag names the deviation from the default, so all-zero (unconfigured)
 /// resolves to: RegularHours open, every other status closed.
 ///
-/// These flags resolve openness from the stored status per token: any status,
+/// These flags resolve openness from the stored status per feed: any status,
 /// including a reported `Closed`, can be configured open or closed. Freshness is
 /// the only hard floor — a stale price is always closed regardless of any flag.
 /// (`AllowClosed` on a v8 feed is generally not advised, but staleness still
@@ -62,12 +62,12 @@ pub enum MarketStatusFlag {
     // CHECK: should have no more than `MAX_MARKET_STATUS_FLAGS` of flags.
     // CHECK: append-only. Each variant's position is a persisted bitmap bit
     // (see `MarketStatusFlagContainer`); only add new flags at the end, never
-    // reorder or remove, or stored `TokenConfig` flags will be misread.
+    // reorder or remove, or stored `FeedConfig` flags will be misread.
 }
 
 crate::flags!(MarketStatusFlag, MAX_MARKET_STATUS_FLAGS, u8);
 
-/// Resolved openness of a market status under a per-token policy.
+/// Resolved openness of a market status under a per-feed policy.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum MarketOpenness {
@@ -80,7 +80,7 @@ pub enum MarketOpenness {
 }
 
 impl MarketStatus {
-    /// Resolve openness under the given per-token flags.
+    /// Resolve openness under the given per-feed flags.
     pub fn openness(self, flags: MarketStatusFlagContainer) -> MarketOpenness {
         let open_if = |open: bool| {
             if open {

--- a/crates/utils/src/price/market_status.rs
+++ b/crates/utils/src/price/market_status.rs
@@ -35,6 +35,12 @@ pub enum MarketStatus {
 ///
 /// Each flag names the deviation from the default, so all-zero (unconfigured)
 /// resolves to: RegularHours open, every other status closed.
+///
+/// These flags resolve openness from the stored status per token: any status,
+/// including a reported `Closed`, can be configured open or closed. Freshness is
+/// the only hard floor — a stale price is always closed regardless of any flag.
+/// (`AllowClosed` on a v8 feed is generally not advised, but staleness still
+/// backstops it.)
 #[derive(IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 #[non_exhaustive]

--- a/crates/utils/src/price/mod.rs
+++ b/crates/utils/src/price/mod.rs
@@ -4,9 +4,13 @@ pub mod decimal;
 /// Price Feed Price.
 pub mod feed_price;
 
+/// Market status.
+pub mod market_status;
+
 pub use self::{
     decimal::{Decimal, DecimalError},
     feed_price::PriceFeedPrice,
+    market_status::{MarketOpenness, MarketStatus, MarketStatusFlag, MarketStatusFlagContainer},
 };
 use anchor_lang::prelude::*;
 

--- a/crates/utils/src/token_config.rs
+++ b/crates/utils/src/token_config.rs
@@ -7,6 +7,7 @@ use crate::{
     fixed_str::{bytes_to_fixed_str, FixedStrError},
     market::HasMarketMeta,
     oracle::PriceProviderKind,
+    price::market_status::{MarketStatusFlag, MarketStatusFlagContainer},
     pubkey::DEFAULT_PUBKEY,
     swap::HasSwapParams,
 };
@@ -90,8 +91,9 @@ pub struct TokenConfig {
     pub feeds: [FeedConfig; MAX_FEEDS],
     /// Heartbeat duration.
     pub heartbeat_duration: u32,
+    market_status_flags: MarketStatusFlagContainer,
     #[cfg_attr(feature = "debug", debug(skip))]
-    reserved: [u8; 32],
+    reserved: [u8; 31],
 }
 
 #[cfg(feature = "display")]
@@ -254,6 +256,16 @@ impl TokenConfig {
     /// Get token name.
     pub fn name(&self) -> TokenConfigResult<&str> {
         Ok(bytes_to_fixed_str(&self.name)?)
+    }
+
+    /// Returns the per-token market-status flags.
+    pub fn market_status_flags(&self) -> MarketStatusFlagContainer {
+        self.market_status_flags
+    }
+
+    /// Sets a per-token market-status flag.
+    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) {
+        self.market_status_flags.set_flag(flag, enable);
     }
 }
 
@@ -665,4 +677,34 @@ pub enum TokenFlag {
     /// Allow withdrawal.
     AllowWithdrawal,
     // CHECK: cannot have more than `MAX_TREASURY_TOKEN_FLAGS` flags.
+}
+
+#[cfg(test)]
+mod market_status_tests {
+    use super::*;
+    use crate::price::market_status::{MarketOpenness, MarketStatus, MarketStatusFlag};
+    use bytemuck::Zeroable;
+
+    #[test]
+    fn default_flags_open_regular_hours() {
+        let config = TokenConfig::zeroed();
+        assert!(matches!(
+            MarketStatus::RegularHours.openness(config.market_status_flags()),
+            MarketOpenness::Open
+        ));
+        assert!(matches!(
+            MarketStatus::PreMarket.openness(config.market_status_flags()),
+            MarketOpenness::Closed
+        ));
+    }
+
+    #[test]
+    fn set_flag_round_trip() {
+        let mut config = TokenConfig::zeroed();
+        config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, true);
+        assert!(matches!(
+            MarketStatus::PreMarket.openness(config.market_status_flags()),
+            MarketOpenness::Open
+        ));
+    }
 }

--- a/crates/utils/src/token_config.rs
+++ b/crates/utils/src/token_config.rs
@@ -263,9 +263,9 @@ impl TokenConfig {
         self.market_status_flags
     }
 
-    /// Sets a per-token market-status flag.
-    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) {
-        self.market_status_flags.set_flag(flag, enable);
+    /// Sets a per-token market-status flag, returning the previous value.
+    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) -> bool {
+        self.market_status_flags.set_flag(flag, enable)
     }
 }
 

--- a/crates/utils/src/token_config.rs
+++ b/crates/utils/src/token_config.rs
@@ -91,9 +91,8 @@ pub struct TokenConfig {
     pub feeds: [FeedConfig; MAX_FEEDS],
     /// Heartbeat duration.
     pub heartbeat_duration: u32,
-    market_status_flags: MarketStatusFlagContainer,
     #[cfg_attr(feature = "debug", debug(skip))]
-    reserved: [u8; 31],
+    reserved: [u8; 32],
 }
 
 #[cfg(feature = "display")]
@@ -146,6 +145,9 @@ impl TokenConfig {
     }
 
     /// Set feed config.
+    ///
+    /// Note: this replaces the whole [`FeedConfig`], including its
+    /// market-status flags.
     pub fn set_feed_config(
         &mut self,
         kind: &PriceProviderKind,
@@ -257,16 +259,6 @@ impl TokenConfig {
     pub fn name(&self) -> TokenConfigResult<&str> {
         Ok(bytes_to_fixed_str(&self.name)?)
     }
-
-    /// Returns the per-token market-status flags.
-    pub fn market_status_flags(&self) -> MarketStatusFlagContainer {
-        self.market_status_flags
-    }
-
-    /// Sets a per-token market-status flag, returning the previous value.
-    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) -> bool {
-        self.market_status_flags.set_flag(flag, enable)
-    }
 }
 
 impl crate::InitSpace for TokenConfig {
@@ -288,9 +280,10 @@ pub struct FeedConfig {
     /// The maximum allowed deviation ratio from the mid-price.
     /// A value of `0` means no restriction is applied.
     max_deviation_ratio: u32,
+    market_status_flags: MarketStatusFlagContainer,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 24],
+    reserved: [u8; 23],
 }
 
 #[cfg(feature = "display")]
@@ -315,6 +308,7 @@ impl FeedConfig {
             feed,
             timestamp_adjustment: DEFAULT_TIMESTAMP_ADJUSTMENT,
             max_deviation_ratio: DEFAULT_MAX_DEVIATION_RATIO,
+            market_status_flags: Default::default(),
             reserved: Default::default(),
         }
     }
@@ -370,6 +364,16 @@ impl FeedConfig {
         } else {
             Some(u128::from(ratio) * Self::RATIO_MULTIPLIER)
         }
+    }
+
+    /// Returns the per-feed market-status flags.
+    pub fn market_status_flags(&self) -> MarketStatusFlagContainer {
+        self.market_status_flags
+    }
+
+    /// Sets a per-feed market-status flag, returning the previous value.
+    pub fn set_market_status_flag(&mut self, flag: MarketStatusFlag, enable: bool) -> bool {
+        self.market_status_flags.set_flag(flag, enable)
     }
 }
 
@@ -686,8 +690,8 @@ mod market_status_tests {
     use bytemuck::Zeroable;
 
     #[test]
-    fn default_flags_open_regular_hours() {
-        let config = TokenConfig::zeroed();
+    fn feed_default_flags_open_regular_hours() {
+        let config = FeedConfig::zeroed();
         assert!(matches!(
             MarketStatus::RegularHours.openness(config.market_status_flags()),
             MarketOpenness::Open
@@ -699,12 +703,13 @@ mod market_status_tests {
     }
 
     #[test]
-    fn set_flag_round_trip() {
-        let mut config = TokenConfig::zeroed();
-        config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, true);
+    fn feed_set_flag_round_trip() {
+        let mut config = FeedConfig::zeroed();
+        assert!(!config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, true));
         assert!(matches!(
             MarketStatus::PreMarket.openness(config.market_status_flags()),
             MarketOpenness::Open
         ));
+        assert!(config.set_market_status_flag(MarketStatusFlag::AllowPreMarket, false));
     }
 }

--- a/programs/store/src/instructions/oracle/custom.rs
+++ b/programs/store/src/instructions/oracle/custom.rs
@@ -163,9 +163,7 @@ impl UpdatePriceFeedWithChainlink<'_> {
             msg!("Invalid report: {}", err);
             let err = match err {
                 ChainlinkError::NegativePrice(_) => CoreError::NegativePriceIsNotSupported,
-                ChainlinkError::InvalidRange(_) | ChainlinkError::UnknownMarketStatus => {
-                    CoreError::InvalidPriceReport
-                }
+                ChainlinkError::InvalidRange(_) => CoreError::InvalidPriceReport,
                 ChainlinkError::Overflow(_) => CoreError::PriceOverflow,
             };
             error!(err)

--- a/programs/store/src/instructions/token_config.rs
+++ b/programs/store/src/instructions/token_config.rs
@@ -207,9 +207,9 @@ impl<'info> internal::Authentication<'info> for ToggleTokenConfig<'info> {
     }
 }
 
-/// The accounts definition for [`set_token_config_market_status_flag`](crate::gmsol_store::set_token_config_market_status_flag).
+/// The accounts definition for [`set_feed_config_market_status_flag`](crate::gmsol_store::set_feed_config_market_status_flag).
 #[derive(Accounts)]
-pub struct SetTokenConfigMarketStatusFlag<'info> {
+pub struct SetFeedConfigMarketStatusFlag<'info> {
     /// The authority of the instruction.
     pub authority: Signer<'info>,
     /// The store that owns the token map.
@@ -217,18 +217,20 @@ pub struct SetTokenConfigMarketStatusFlag<'info> {
     /// The token map to update.
     #[account(mut, has_one = store)]
     pub token_map: AccountLoader<'info, TokenMapHeader>,
-    /// The token whose config will be updated.
+    /// The token whose feed config will be updated.
     /// CHECK: used only as the key into the token map; not deserialized.
     pub token: UncheckedAccount<'info>,
 }
 
-impl SetTokenConfigMarketStatusFlag<'_> {
-    /// Set a per-token market-status flag, returning the previous value.
+impl SetFeedConfigMarketStatusFlag<'_> {
+    /// Set a market-status flag on the feed config of the given provider,
+    /// returning the previous value.
     ///
     /// ## CHECK
     /// - Only [`MARKET_KEEPER`](crate::states::RoleKey::MARKET_KEEPER) can perform this action.
     pub(crate) fn invoke_unchecked(
         ctx: Context<Self>,
+        provider: &PriceProviderKind,
         flag: MarketStatusFlag,
         enable: bool,
     ) -> Result<bool> {
@@ -239,12 +241,15 @@ impl SetTokenConfigMarketStatusFlag<'_> {
             .load_token_map_mut()?
             .get_mut(&token)
             .ok_or_else(|| error!(CoreError::NotFound))?
+            .get_feed_config_mut(provider)
+            .map_err(CoreError::from)
+            .map_err(|err| error!(err))?
             .set_market_status_flag(flag, enable);
         Ok(previous)
     }
 }
 
-impl<'info> internal::Authentication<'info> for SetTokenConfigMarketStatusFlag<'info> {
+impl<'info> internal::Authentication<'info> for SetFeedConfigMarketStatusFlag<'info> {
     fn authority(&self) -> &Signer<'info> {
         &self.authority
     }
@@ -347,6 +352,7 @@ impl SetFeedConfig<'_> {
             .map_err(CoreError::from)
             .map_err(|err| error!(err))?;
 
+        let previous_feed = *feed_config.feed();
         let mut new_config = *feed_config;
 
         if let Some(feed) = feed {
@@ -369,6 +375,13 @@ impl SetFeedConfig<'_> {
         }
 
         *feed_config = new_config;
+
+        if *new_config.feed() != previous_feed {
+            msg!(
+                "[Set Feed Config] feed changed: market status flags are NOT reset (current: {})",
+                new_config.market_status_flags().into_value(),
+            );
+        }
 
         Ok(())
     }

--- a/programs/store/src/instructions/token_config.rs
+++ b/programs/store/src/instructions/token_config.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::Mint;
+use gmsol_utils::price::market_status::MarketStatusFlag;
 use gmsol_utils::token_config::TokenConfigFlag;
 
 use crate::{
@@ -197,6 +198,53 @@ impl ToggleTokenConfig<'_> {
 }
 
 impl<'info> internal::Authentication<'info> for ToggleTokenConfig<'info> {
+    fn authority(&self) -> &Signer<'info> {
+        &self.authority
+    }
+
+    fn store(&self) -> &AccountLoader<'info, Store> {
+        &self.store
+    }
+}
+
+/// The accounts definition for [`set_token_config_market_status_flag`](crate::gmsol_store::set_token_config_market_status_flag).
+#[derive(Accounts)]
+pub struct SetTokenConfigMarketStatusFlag<'info> {
+    /// The authority of the instruction.
+    pub authority: Signer<'info>,
+    /// The store that owns the token map.
+    pub store: AccountLoader<'info, Store>,
+    /// The token map to update.
+    #[account(mut, has_one = store)]
+    pub token_map: AccountLoader<'info, TokenMapHeader>,
+    /// The token whose config will be updated.
+    /// CHECK: used only as the key into the token map; not deserialized.
+    pub token: UncheckedAccount<'info>,
+}
+
+impl SetTokenConfigMarketStatusFlag<'_> {
+    /// Set a per-token market-status flag, returning the previous value.
+    ///
+    /// ## CHECK
+    /// - Only [`MARKET_KEEPER`](crate::states::RoleKey::MARKET_KEEPER) can perform this action.
+    pub(crate) fn invoke_unchecked(
+        ctx: Context<Self>,
+        flag: MarketStatusFlag,
+        enable: bool,
+    ) -> Result<bool> {
+        let token = ctx.accounts.token.key();
+        let previous = ctx
+            .accounts
+            .token_map
+            .load_token_map_mut()?
+            .get_mut(&token)
+            .ok_or_else(|| error!(CoreError::NotFound))?
+            .set_market_status_flag(flag, enable);
+        Ok(previous)
+    }
+}
+
+impl<'info> internal::Authentication<'info> for SetTokenConfigMarketStatusFlag<'info> {
     fn authority(&self) -> &Signer<'info> {
         &self.authority
     }

--- a/programs/store/src/instructions/token_config.rs
+++ b/programs/store/src/instructions/token_config.rs
@@ -472,7 +472,9 @@ fn do_push_token_map<'info>(
                     new_rent_minimum.saturating_sub(current_lamports),
                 )?;
             }
-            token_map_loader.as_ref().realloc(new_space, false)?;
+            // NOTE: zero_init is set to true as a tentative fix for the realloc issue.
+            // If this proves correct, replace this note with an explanation of the root cause.
+            token_map_loader.as_ref().realloc(new_space, true)?;
         }
     }
 

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -84,6 +84,7 @@
 //! - [`toggle_token_config`]: Enable or disable a token config of the given token map.
 //! - [`set_expected_provider`]: Set the expected provider for the given token.
 //! - [`set_feed_config_v2`]: Set the feed config of the given provider for the given token.
+//! - [`set_feed_config_market_status_flag`]: Set a market-status flag on the feed config of the given provider for the given token.
 //! - [`is_token_config_enabled`](gmsol_store::is_token_config_enabled): Check if the config for the given token is enabled.
 //! - [`token_expected_provider`](gmsol_store::token_expected_provider): Get the expected provider set for the given token.
 //! - [`token_feed`](gmsol_store::token_feed): Get the feed address of the given provider set for the given token.
@@ -880,36 +881,52 @@ pub mod gmsol_store {
         )
     }
 
-    /// Set a per-token market-status flag.
+    /// Set a market-status flag on the feed config of the given provider for
+    /// the given token.
     ///
     /// # Accounts
-    /// [*See the documentation for the accounts*](SetTokenConfigMarketStatusFlag).
+    /// [*See the documentation for the accounts*](SetFeedConfigMarketStatusFlag).
     ///
     /// # Arguments
+    /// - `provider`: The index of the provider whose feed config will be updated.
+    ///   Must be a valid [`PriceProviderKind`] value.
     /// - `flag`: The [`MarketStatusFlag`] index to set.
     /// - `enable`: Enable or disable the flag.
     ///
     /// # Errors
-    /// - The [`authority`](SetTokenConfigMarketStatusFlag::authority) must be a
+    /// - The [`authority`](SetFeedConfigMarketStatusFlag::authority) must be a
     ///   signer and a MARKET_KEEPER in the given store.
-    /// - The [`token`](SetTokenConfigMarketStatusFlag::token) must exist in the token map.
+    /// - The [`token`](SetFeedConfigMarketStatusFlag::token) must exist in the token map.
+    /// - The `provider` index must correspond to a valid [`PriceProviderKind`].
+    /// - The feed config of the `provider` for the `token` must be initialized.
     /// - `flag` must be a valid [`MarketStatusFlag`] value.
     #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
-    pub fn set_token_config_market_status_flag(
-        ctx: Context<SetTokenConfigMarketStatusFlag>,
+    pub fn set_feed_config_market_status_flag(
+        ctx: Context<SetFeedConfigMarketStatusFlag>,
+        provider: u8,
         flag: u8,
         enable: bool,
     ) -> Result<()> {
         let token = ctx.accounts.token.key();
         let authorized =
             ctx.accounts.store.load()?.token_map() == Some(&ctx.accounts.token_map.key());
+        let kind = PriceProviderKind::try_from(provider)
+            .map_err(|_| CoreError::InvalidProviderKindIndex)?;
         let market_status_flag =
             MarketStatusFlag::try_from(flag).map_err(|_| error!(CoreError::InvalidArgument))?;
-        let previous =
-            SetTokenConfigMarketStatusFlag::invoke_unchecked(ctx, market_status_flag, enable)?;
+        if !matches!(kind, PriceProviderKind::ChainlinkDataStreams) {
+            msg!("set market status flag: note: this provider does not report market status; the flag has no effect for now");
+        }
+        let previous = SetFeedConfigMarketStatusFlag::invoke_unchecked(
+            ctx,
+            &kind,
+            market_status_flag,
+            enable,
+        )?;
         msg!(
-            "set market status flag: token={}, flag={}, {} -> {}, authorized_token_map={}",
+            "set market status flag: token={}, provider={}, flag={}, {} -> {}, authorized_token_map={}",
             token,
+            kind,
             flag,
             previous,
             enable,

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -257,6 +257,7 @@ declare_id!("Gmso1uvJnLbawvw7yezdfCDcPydwW2s2iqG3w6MDucLo");
 #[program]
 /// Instructions definitions of the GMSOL Store Program.
 pub mod gmsol_store {
+    use gmsol_utils::price::market_status::MarketStatusFlag;
     use gmsol_utils::token_config::TokenConfigFlag;
 
     use super::*;
@@ -877,6 +878,44 @@ pub mod gmsol_store {
             TokenConfigFlag::AllowPriceAdjustment,
             enable,
         )
+    }
+
+    /// Set a per-token market-status flag.
+    ///
+    /// # Accounts
+    /// [*See the documentation for the accounts*](SetTokenConfigMarketStatusFlag).
+    ///
+    /// # Arguments
+    /// - `flag`: The [`MarketStatusFlag`] index to set.
+    /// - `enable`: Enable or disable the flag.
+    ///
+    /// # Errors
+    /// - The [`authority`](SetTokenConfigMarketStatusFlag::authority) must be a
+    ///   signer and a MARKET_KEEPER in the given store.
+    /// - The [`token`](SetTokenConfigMarketStatusFlag::token) must exist in the token map.
+    /// - `flag` must be a valid [`MarketStatusFlag`] value.
+    #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
+    pub fn set_token_config_market_status_flag(
+        ctx: Context<SetTokenConfigMarketStatusFlag>,
+        flag: u8,
+        enable: bool,
+    ) -> Result<()> {
+        let token = ctx.accounts.token.key();
+        let authorized =
+            ctx.accounts.store.load()?.token_map() == Some(&ctx.accounts.token_map.key());
+        let market_status_flag =
+            MarketStatusFlag::try_from(flag).map_err(|_| error!(CoreError::InvalidArgument))?;
+        let previous =
+            SetTokenConfigMarketStatusFlag::invoke_unchecked(ctx, market_status_flag, enable)?;
+        msg!(
+            "set market status flag: token={}, flag={}, {} -> {}, authorized_token_map={}",
+            token,
+            flag,
+            previous,
+            enable,
+            authorized,
+        );
+        Ok(())
     }
 
     /// Set the expected provider for the given token.

--- a/programs/store/src/states/oracle/feed.rs
+++ b/programs/store/src/states/oracle/feed.rs
@@ -157,15 +157,21 @@ impl PriceFeed {
             provider
         );
 
-        let feed_id = token_config.get_feed(&provider).map_err(CoreError::from)?;
-        require_keys_eq!(self.feed_id, feed_id, CoreError::InvalidPriceFeedAccount);
+        let feed_config = token_config
+            .get_feed_config(&provider)
+            .map_err(CoreError::from)?;
+        require_keys_eq!(
+            self.feed_id,
+            *feed_config.feed(),
+            CoreError::InvalidPriceFeedAccount
+        );
 
         let current = clock.unix_timestamp;
         let heartbeat_duration = token_config.heartbeat_duration();
         let is_open = self.price.is_market_open(
             current,
             heartbeat_duration,
-            token_config.market_status_flags(),
+            feed_config.market_status_flags(),
         );
 
         if !allow_closed {

--- a/programs/store/src/states/oracle/feed.rs
+++ b/programs/store/src/states/oracle/feed.rs
@@ -162,7 +162,11 @@ impl PriceFeed {
 
         let current = clock.unix_timestamp;
         let heartbeat_duration = token_config.heartbeat_duration();
-        let is_open = self.price.is_market_open(current, heartbeat_duration);
+        let is_open = self.price.is_market_open(
+            current,
+            heartbeat_duration,
+            token_config.market_status_flags(),
+        );
 
         if !allow_closed {
             require!(is_open, CoreError::MarketNotOpen);

--- a/programs/store/src/states/oracle/mod.rs
+++ b/programs/store/src/states/oracle/mod.rs
@@ -407,7 +407,9 @@ impl OraclePrice {
                 parsed.ok_or_else(|| error!(CoreError::Internal))?
             }
             PriceProviderKind::Pyth => {
-                // `allow_closed` is not used for Pyth, since all Pyth feeds are considered open.
+                // Market status is not supported by this provider: prices are always
+                // treated as open (as if the status were `MarketStatus::Disabled`), so
+                // `allow_closed` and per-feed market-status flags have no effect here.
                 Pyth::check_and_get_price(clock, token_config, account, feed_id)?
             }
             PriceProviderKind::Chainlink => {
@@ -415,7 +417,9 @@ impl OraclePrice {
                 return err!(CoreError::Deprecated);
             }
             PriceProviderKind::Switchboard => {
-                // `allow_closed` is not used for Switchboard, since all Switchboard feeds are considered open.
+                // Market status is not supported by this provider: prices are always
+                // treated as open (as if the status were `MarketStatus::Disabled`), so
+                // `allow_closed` and per-feed market-status flags have no effect here.
                 require_keys_eq!(*feed_id, account.key(), CoreError::InvalidPriceFeedAccount);
                 Switchboard::check_and_get_price(clock, token_config, account)?
             }

--- a/programs/store/src/states/token_config.rs
+++ b/programs/store/src/states/token_config.rs
@@ -108,6 +108,9 @@ impl TokenConfigExt for TokenConfig {
             .collect::<Vec<_>>()
             .try_into()
             .map_err(|_| error!(CoreError::InvalidArgument))?;
+        if !init {
+            msg!("[Token Config] feeds are rebuilt: market status flags and max deviation ratios are reset");
+        }
         self.expected_provider = expected_provider.unwrap_or(PriceProviderKind::default() as u8);
         self.heartbeat_duration = heartbeat_duration;
         Ok(())

--- a/tests/anchor_test/competition.rs
+++ b/tests/anchor_test/competition.rs
@@ -50,7 +50,7 @@ async fn competition() -> eyre::Result<()> {
         .get_block_time(slot)
         .await
         .unwrap_or_else(|_| OffsetDateTime::now_utc().unix_timestamp());
-    let start_time = now + 1;
+    let start_time = now + 5;
     let competition = Pubkey::find_program_address(
         &[COMPETITION_SEED, payer.as_ref(), &start_time.to_le_bytes()],
         &COMPETITION_PROGRAM_ID,
@@ -85,7 +85,7 @@ async fn competition() -> eyre::Result<()> {
     tracing::info!(%signature, "initialized competition");
 
     // Wait for competition to start
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    tokio::time::sleep(Duration::from_secs(8)).await;
 
     // Verify competition initialization
     let competition_account = client

--- a/tests/anchor_test/market_status.rs
+++ b/tests/anchor_test/market_status.rs
@@ -1,0 +1,98 @@
+use gmsol_sdk::client::ops::TokenConfigOps;
+use gmsol_store::CoreError;
+use gmsol_utils::{
+    oracle::PriceProviderKind, price::market_status::MarketStatusFlag, token_config::TokenMapAccess,
+};
+
+use crate::anchor_test::setup::{current_deployment, Deployment};
+
+#[tokio::test]
+async fn set_feed_config_market_status_flag() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("set_feed_config_market_status_flag");
+    let _enter = span.enter();
+
+    let store = &deployment.store;
+    let token_map = deployment.token_map();
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let user = deployment.user_client(Deployment::DEFAULT_USER)?;
+
+    let token = deployment.token("fETH").expect("must exist").address;
+    let provider = PriceProviderKind::ChainlinkDataStreams;
+    let flag = MarketStatusFlag::AllowClosed;
+
+    // Only a MARKET_KEEPER can set the flag.
+    let err = user
+        .set_feed_config_market_status_flag(store, &token_map, &token, provider, flag, true)
+        .send()
+        .await
+        .expect_err("should throw error when called by a non-market-keeper");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(CoreError::PermissionDenied.into())
+    );
+
+    // Enable the flag and read it back from the token map.
+    let signature = keeper
+        .set_feed_config_market_status_flag(store, &token_map, &token, provider, flag, true)
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "enabled the flag");
+    let map = keeper.token_map(&token_map).await?;
+    let feed_config = map
+        .get(&token)
+        .expect("must exist")
+        .get_feed_config(&provider)
+        .expect("must exist");
+    assert!(feed_config.market_status_flags().get_flag(flag));
+
+    // Disable the flag and read it back.
+    let signature = keeper
+        .set_feed_config_market_status_flag(store, &token_map, &token, provider, flag, false)
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "disabled the flag");
+    let map = keeper.token_map(&token_map).await?;
+    let feed_config = map
+        .get(&token)
+        .expect("must exist")
+        .get_feed_config(&provider)
+        .expect("must exist");
+    assert!(!feed_config.market_status_flags().get_flag(flag));
+
+    // Setting a flag for a provider without a configured feed fails.
+    let err = keeper
+        .set_feed_config_market_status_flag(
+            store,
+            &token_map,
+            &token,
+            PriceProviderKind::Switchboard,
+            flag,
+            true,
+        )
+        .send()
+        .await
+        .expect_err("should throw error for an unconfigured provider feed");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(CoreError::NotFound.into())
+    );
+
+    // Providers that do not report market status are still accepted.
+    let pyth_token = deployment.token("fBTC").expect("must exist").address;
+    let signature = keeper
+        .set_feed_config_market_status_flag(
+            store,
+            &token_map,
+            &pyth_token,
+            PriceProviderKind::Pyth,
+            flag,
+            true,
+        )
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "enabled the flag for a non-status provider");
+
+    Ok(())
+}

--- a/tests/anchor_test/mod.rs
+++ b/tests/anchor_test/mod.rs
@@ -17,6 +17,8 @@ mod shift;
 
 mod market;
 
+mod market_status;
+
 mod glv;
 
 mod oracle;

--- a/tests/anchor_test/setup.rs
+++ b/tests/anchor_test/setup.rs
@@ -75,6 +75,14 @@ const ENV_GMSOL_EXTRA_USERS: &str = "GMSOL_EXTRA_USERS";
 
 const MAX_DEVIATION_FACTOR: u128 = MARKET_USD_UNIT / 100_000;
 
+const PYTH_FETCH_MAX_RETRIES: usize = 3;
+const PYTH_FETCH_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Delay before fetching Pyth prices so the validator clock advances past the
+/// action's creation time; otherwise the freshly fetched price can be rejected
+/// on-chain as `OracleTimestampsAreSmallerThanRequired`.
+const PYTH_EXECUTE_CLOCK_ADVANCE_DELAY: Duration = Duration::from_secs(5);
+
 /// Deployment.
 pub struct Deployment {
     rng: StdRng,
@@ -1695,11 +1703,29 @@ impl Deployment {
     where
         T: PullOraclePriceConsumer + MakeBundleBuilder<'a, SignerRef>,
     {
-        sleep(Duration::from_secs(2)).await;
+        sleep(PYTH_EXECUTE_CLOCK_ADVANCE_DELAY).await;
 
-        let oracle = PythPullOracleWithHermes::from_parts(&self.client, &self.hermes, &self.pyth);
-        let res = WithPullOracle::new(oracle, execute, None)
-            .await?
+        let mut with_oracle = {
+            let mut attempt = 0;
+            loop {
+                let oracle =
+                    PythPullOracleWithHermes::from_parts(&self.client, &self.hermes, &self.pyth);
+                // `execute` is `&mut T` and `WithPullOracle::new` takes the
+                // consumer by value, so reborrow with `&mut *execute` to keep
+                // `execute` usable across retry iterations.
+                match WithPullOracle::new(oracle, &mut *execute, None).await {
+                    Ok(with_oracle) => break with_oracle,
+                    Err(err) if attempt < PYTH_FETCH_MAX_RETRIES => {
+                        attempt += 1;
+                        tracing::warn!(%err, attempt, "pyth fetch failed, retrying");
+                        sleep(PYTH_FETCH_RETRY_DELAY).await;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        };
+
+        let res = with_oracle
             .build()
             .await?
             .build()?


### PR DESCRIPTION
Rolls up all PRs labeled `beta-backport` onto `beta`, bumps versions to `0.10.0-beta.1`, and rebuilds the IDLs.

Backports (in main merge order):

- #362
- #363
- #364
- #365
- #368
- #369
- #370
- #371
- #373
- #375
- #376

Also backports the webpack dev-dependency updates that rode in the 0.11.0 bump on main.

Merge with a merge commit to preserve the cherry-pick structure.