### PR TITLE
ci: enable just test coverage

### DIFF
--- a/.github/workflows/ci-programs.yml
+++ b/.github/workflows/ci-programs.yml
@@ -55,7 +55,16 @@ jobs:
           sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.solana_version }}/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
       - name: Install Anchor ${{ env.anchor_version }}
-        run: npm install -g "@coral-xyz/anchor-cli@${{ env.anchor_version }}"
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSfL "https://github.com/coral-xyz/anchor/releases/download/v${{ env.anchor_version }}/anchor-${{ env.anchor_version }}-x86_64-unknown-linux-gnu" -o "$HOME/.local/bin/anchor"
+          chmod +x "$HOME/.local/bin/anchor"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Verify toolchain versions
+        run: |
+          solana --version
+          anchor --version
+          anchor --version | grep -q "anchor-cli ${{ env.anchor_version }}"
       - name: Create test wallet
         run: solana-keygen new --no-bip39-passphrase --silent
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci-programs.yml
+++ b/.github/workflows/ci-programs.yml
@@ -70,8 +70,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: "just test-programs (one retry)"
-        run: just test-programs || { echo "::warning::first attempt failed, retrying once"; pkill -f solana-test-validator || true; sleep 2; just test-programs; }
+          # keep workspace crates (the SBF program builds) in the cache, and
+          # cache the solana platform-tools download as well
+          cache-workspace-crates: true
+          cache-directories: |
+            ~/.cache/solana
+      - name: Build programs
+        run: just build-test-programs
+      - name: "just test-programs (one retry, skip build)"
+        run: just test-programs --skip-build || { echo "::warning::first attempt failed, retrying once"; pkill -f solana-test-validator || true; sleep 2; just test-programs --skip-build; }
       - name: Upload anchor logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-programs.yml
+++ b/.github/workflows/ci-programs.yml
@@ -1,0 +1,71 @@
+on:
+  push:
+    branches:
+      - main
+      - v*
+  pull_request:
+    branches:
+      - main
+      - v*
+
+name: CI for Programs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+  rust_stable: "1.88"
+  solana_version: "2.1.21"
+  anchor_version: "0.31.1"
+  libudev: "1.0"
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  # NOT part of ci-sdk.yml's tests-pass on purpose: the validator clones
+  # accounts from devnet and tests fetch live Pyth data, so failures have a
+  # structural floor. Treat results as signal, not a gate.
+  test-programs:
+    name: test programs
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libudev-dev
+          version: ${{ env.libudev }}
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Install Solana ${{ env.solana_version }}
+        run: |
+          sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.solana_version }}/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+      - name: Install Anchor ${{ env.anchor_version }}
+        run: npm install -g "@coral-xyz/anchor-cli@${{ env.anchor_version }}"
+      - name: Create test wallet
+        run: solana-keygen new --no-bip39-passphrase --silent
+      - uses: Swatinem/rust-cache@v2
+      - name: "just test-programs (one retry)"
+        run: just test-programs || { echo "::warning::first attempt failed, retrying once"; just test-programs; }
+      - name: Upload anchor logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: anchor-logs
+          path: |
+            .anchor/program-logs/
+            .anchor/test-ledger/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/ci-programs.yml
+++ b/.github/workflows/ci-programs.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   RUST_BACKTRACE: 1
   rust_stable: "1.88"
+  # keep in sync with Anchor.toml [toolchain]
   solana_version: "2.1.21"
   anchor_version: "0.31.1"
   libudev: "1.0"
@@ -58,8 +59,10 @@ jobs:
       - name: Create test wallet
         run: solana-keygen new --no-bip39-passphrase --silent
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: "just test-programs (one retry)"
-        run: just test-programs || { echo "::warning::first attempt failed, retrying once"; just test-programs; }
+        run: just test-programs || { echo "::warning::first attempt failed, retrying once"; pkill -f solana-test-validator || true; sleep 2; just test-programs; }
       - name: Upload anchor logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-sdk.yml
+++ b/.github/workflows/ci-sdk.yml
@@ -139,7 +139,7 @@ jobs:
     name: test crates
     needs: basics
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Cache apt packages
@@ -154,6 +154,8 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: "just test-crates"
         run: just test-crates
         env:

--- a/.github/workflows/ci-sdk.yml
+++ b/.github/workflows/ci-sdk.yml
@@ -41,6 +41,7 @@ jobs:
       - fmt
       - minrust
       - features
+      - test
     steps:
       - run: exit 0
 
@@ -133,3 +134,27 @@ jobs:
         # depth 2 (pairwise) takes ~35 min and dominates PR latency; PRs check
         # each feature alone, pushes to main keep the full pairwise sweep
         run: cargo hack check --workspace ${{ env.exclude_packages }} --feature-powerset --depth ${{ github.event_name == 'pull_request' && '1' || '2' }} --keep-going
+
+  test:
+    name: test crates
+    needs: basics
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libudev-dev
+          version: ${{ env.libudev }}
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - uses: Swatinem/rust-cache@v2
+      - name: "just test-crates"
+        run: just test-crates
+        env:
+          RUSTFLAGS: "" # remove -Dwarnings: program crates are not warning-gated (excluded from clippy)

--- a/.github/workflows/ci-sdk.yml
+++ b/.github/workflows/ci-sdk.yml
@@ -156,6 +156,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Create placeholder wallet file
+        # gmsol-cli's wallet::tests::test_parse_url_or_path canonicalizes
+        # ~/.config/solana/id.json and fails when the file does not exist
+        run: mkdir -p ~/.config/solana && touch ~/.config/solana/id.json
       - name: "just test-crates"
         run: just test-crates
         env:

--- a/justfile
+++ b/justfile
@@ -42,6 +42,9 @@ check-guardian-set:
 rotate-guardian-set:
   cargo xtask guardian-set rotate
 
+build-test-programs:
+  anchor build -- --features mock --features {{DEVNET_FEATURES}}
+
 test-programs *ARGS: check-guardian-set
   anchor test {{ARGS}} -- --features mock --features {{DEVNET_FEATURES}}
 


### PR DESCRIPTION
- Adds a required test-crates job to the SDK workflow (joins tests-pass)
- Adds a standalone non-blocking workflow running just test-programs with one retry; anchor logs uploaded on failure
- The programs job intentionally stays out of tests-pass: devnet account cloning and live Pyth fetches are structurally flaky
- Note: two sdk client tests in the required job also touch devnet (feature unification pulls in the client feature); accepted for now
- First runs are cold (per-job caches); expect the test job to be slow until caches are seeded