### PR TITLE
feat(xtask): guardian-set check and rotate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --quiet --package xtask --"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -98,37 +98,35 @@ address = "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"
 [[test.validator.clone]]
 address = "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX"
 
-# Wormhole Guardian Set account (index = 0)
-[[test.validator.clone]]
-address = "C7RmcKdjeFscYSyekkmCjvHcnBQd7qJDkeB9RmRtuB3L"
-
+# BEGIN guardian-sets (managed by xtask; run `just rotate-guardian-set`)
 # Wormhole Guardian Set account (index = 1)
-[[test.validator.clone]]
-address = "8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5"
+# [[test.validator.clone]]
+# address = "8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5"
 
 # Wormhole Guardian Set account (index = 2)
-[[test.validator.clone]]
-address = "izDSKeLVBe4fT3HawjGfnwbMwUQSw1LLoFG9QvZ9Asz"
+# [[test.validator.clone]]
+# address = "izDSKeLVBe4fT3HawjGfnwbMwUQSw1LLoFG9QvZ9Asz"
 
 # Wormhole Guardian Set account (index = 3)
-[[test.validator.clone]]
-address = "D2JSt6eTTzsmmap3HtCmcQCM3gBcsz6EiB36zYWNRN3k"
+# [[test.validator.clone]]
+# address = "D2JSt6eTTzsmmap3HtCmcQCM3gBcsz6EiB36zYWNRN3k"
 
 # Wormhole Guardian Set account (index = 4)
-[[test.validator.clone]]
-address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"
+# [[test.validator.clone]]
+# address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"
 
 # Wormhole Guardian Set account (index = 5)
-[[test.validator.clone]]
-address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni"
+# [[test.validator.clone]]
+# address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni"
 
 # Wormhole Guardian Set account (index = 6)
 [[test.validator.clone]]
 address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf"
 
-# # Wormhole Guardian Set account (index = 7)
-# [[test.validator.clone]]
-# address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"
+# Wormhole Guardian Set account (index = 7)
+[[test.validator.clone]]
+address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"
+# END guardian-sets
 
 # Pyth Config account
 [[test.validator.clone]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9045,6 +9045,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "solana-client",
+ "solana-sdk",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9048,8 +9048,8 @@ dependencies = [
 name = "xtask"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "clap",
+ "eyre",
  "solana-client",
  "solana-sdk",
  "toml 0.8.23",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/*", "programs/*", "examples", "tests"]
+members = ["crates/*", "programs/*", "examples", "tests", "xtask"]
 
 [workspace.package]
 version = "0.11.0"

--- a/justfile
+++ b/justfile
@@ -36,10 +36,16 @@ test: test-crates test-programs
 test-crates:
   cargo test --features {{FEATURES}}
 
-test-programs *ARGS:
+check-guardian-set:
+  cargo xtask guardian-set check
+
+rotate-guardian-set:
+  cargo xtask guardian-set rotate
+
+test-programs *ARGS: check-guardian-set
   anchor test {{ARGS}} -- --features mock --features {{DEVNET_FEATURES}}
 
-test-programs-debug *ARGS:
+test-programs-debug *ARGS: check-guardian-set
   anchor test {{ARGS}} -- --features mock,debug-msg --features {{DEVNET_FEATURES}}
 
 it config="scripts/resources/config/integration_test.toml":

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+eyre = { workspace = true }
 solana-sdk = { workspace = true }
 solana-client = { workspace = true }
 toml = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+solana-sdk = { workspace = true }
+solana-client = { workspace = true }
+toml = { workspace = true }

--- a/xtask/src/anchor_toml.rs
+++ b/xtask/src/anchor_toml.rs
@@ -1,1 +1,158 @@
 // Pure text helpers for the Anchor.toml managed guardian-set block.
+
+use anyhow::{bail, Result};
+
+pub const BEGIN_MARKER: &str =
+    "# BEGIN guardian-sets (managed by xtask; run `just rotate-guardian-set`)";
+pub const END_MARKER: &str = "# END guardian-sets";
+
+/// Read `test.validator.url` from an Anchor.toml string.
+pub fn validator_url(contents: &str) -> Option<String> {
+    let value: toml::Value = contents.parse().ok()?;
+    value
+        .get("test")?
+        .get("validator")?
+        .get("url")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Replace the text strictly between the BEGIN and END marker lines.
+pub fn splice_managed_block(contents: &str, new_interior: &str) -> Result<String> {
+    let begin = match contents.find(BEGIN_MARKER) {
+        Some(i) => i,
+        None => bail!(
+            "managed guardian-set block not found (missing `{BEGIN_MARKER}`); \
+             run `just rotate-guardian-set` after adding the markers"
+        ),
+    };
+    // End of the BEGIN marker line (include its trailing newline).
+    let after_begin = contents[begin..]
+        .find('\n')
+        .map(|n| begin + n + 1)
+        .unwrap_or(contents.len());
+    let end = match contents[after_begin..].find(END_MARKER) {
+        Some(i) => after_begin + i,
+        None => bail!("managed guardian-set block malformed (missing `{END_MARKER}`)"),
+    };
+    let mut out = String::with_capacity(contents.len());
+    out.push_str(&contents[..after_begin]);
+    out.push_str(new_interior);
+    if !new_interior.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&contents[end..]);
+    Ok(out)
+}
+
+/// Collect addresses from uncommented `address = "..."` lines inside the managed block.
+pub fn uncommented_addresses(contents: &str) -> Result<Vec<String>> {
+    let begin = contents
+        .find(BEGIN_MARKER)
+        .ok_or_else(|| anyhow::anyhow!("managed guardian-set block not found"))?;
+    let end = contents[begin..]
+        .find(END_MARKER)
+        .map(|i| begin + i)
+        .ok_or_else(|| anyhow::anyhow!("managed guardian-set block malformed"))?;
+    let mut addrs = Vec::new();
+    for line in contents[begin..end].lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("address") {
+            if let Some(q1) = rest.find('"') {
+                if let Some(q2) = rest[q1 + 1..].find('"') {
+                    addrs.push(rest[q1 + 1..q1 + 1 + q2].to_string());
+                }
+            }
+        }
+    }
+    Ok(addrs)
+}
+
+/// Render the interior of the managed block: one entry per existing index (ascending),
+/// uncommented iff the index is `active` or `active - 1`, otherwise commented out.
+pub fn render_interior(existing: &[u32], active: u32, addr_of: impl Fn(u32) -> String) -> String {
+    let previous = active.saturating_sub(1);
+    let mut indices: Vec<u32> = existing.to_vec();
+    indices.sort_unstable();
+    let mut out = String::new();
+    for (n, &i) in indices.iter().enumerate() {
+        if n > 0 {
+            out.push('\n');
+        }
+        let addr = addr_of(i);
+        out.push_str(&format!("# Wormhole Guardian Set account (index = {i})\n"));
+        if i == active || i == previous {
+            out.push_str(&format!("[[test.validator.clone]]\naddress = \"{addr}\"\n"));
+        } else {
+            out.push_str(&format!(
+                "# [[test.validator.clone]]\n# address = \"{addr}\"\n"
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+prefix line
+# BEGIN guardian-sets (managed by xtask; run `just rotate-guardian-set`)
+# Wormhole Guardian Set account (index = 5)
+# [[test.validator.clone]]
+# address = \"AAA5\"
+
+# Wormhole Guardian Set account (index = 6)
+[[test.validator.clone]]
+address = \"AAA6\"
+# END guardian-sets
+suffix line
+";
+
+    #[test]
+    fn parses_validator_url() {
+        let toml = "[test.validator]\nurl = \"https://api.devnet.solana.com\"\n";
+        assert_eq!(
+            validator_url(toml).as_deref(),
+            Some("https://api.devnet.solana.com")
+        );
+        assert_eq!(validator_url("nothing = 1\n"), None);
+    }
+
+    #[test]
+    fn lists_only_uncommented_addresses_in_block() {
+        assert_eq!(
+            uncommented_addresses(SAMPLE).unwrap(),
+            vec!["AAA6".to_string()]
+        );
+    }
+
+    #[test]
+    fn splice_replaces_only_interior() {
+        let out = splice_managed_block(SAMPLE, "NEW INTERIOR").unwrap();
+        assert!(out.starts_with("prefix line\n"));
+        assert!(out.ends_with("suffix line\n"));
+        assert!(out.contains(&format!("{BEGIN_MARKER}\nNEW INTERIOR\n{END_MARKER}")));
+        assert!(!out.contains("AAA6"));
+    }
+
+    #[test]
+    fn splice_errors_without_markers() {
+        assert!(splice_managed_block("no markers here\n", "x").is_err());
+    }
+
+    #[test]
+    fn renders_active_and_previous_uncommented() {
+        let out = render_interior(&[5, 6, 7], 7, |i| format!("ADDR{i}"));
+        // index 7 (active) uncommented
+        assert!(out.contains("# Wormhole Guardian Set account (index = 7)\n[[test.validator.clone]]\naddress = \"ADDR7\""));
+        // index 6 (previous) uncommented
+        assert!(out.contains("# Wormhole Guardian Set account (index = 6)\n[[test.validator.clone]]\naddress = \"ADDR6\""));
+        // index 5 (older) commented
+        assert!(out.contains("# Wormhole Guardian Set account (index = 5)\n# [[test.validator.clone]]\n# address = \"ADDR5\""));
+    }
+}

--- a/xtask/src/anchor_toml.rs
+++ b/xtask/src/anchor_toml.rs
@@ -1,0 +1,1 @@
+// Pure text helpers for the Anchor.toml managed guardian-set block.

--- a/xtask/src/anchor_toml.rs
+++ b/xtask/src/anchor_toml.rs
@@ -146,6 +146,13 @@ suffix line
     }
 
     #[test]
+    fn splice_does_not_double_newline_when_interior_already_ends_with_one() {
+        let out = splice_managed_block(SAMPLE, "NEW INTERIOR\n").unwrap();
+        assert!(out.contains(&format!("NEW INTERIOR\n{END_MARKER}")));
+        assert!(!out.contains(&format!("NEW INTERIOR\n\n{END_MARKER}")));
+    }
+
+    #[test]
     fn renders_active_and_previous_uncommented() {
         let out = render_interior(&[5, 6, 7], 7, |i| format!("ADDR{i}"));
         // index 7 (active) uncommented
@@ -154,5 +161,21 @@ suffix line
         assert!(out.contains("# Wormhole Guardian Set account (index = 6)\n[[test.validator.clone]]\naddress = \"ADDR6\""));
         // index 5 (older) commented
         assert!(out.contains("# Wormhole Guardian Set account (index = 5)\n# [[test.validator.clone]]\n# address = \"ADDR5\""));
+    }
+
+    #[test]
+    fn render_interior_sorts_ascending_regardless_of_input_order() {
+        let out = render_interior(&[7, 5, 6], 6, |i| format!("ADDR{i}"));
+        let pos5 = out
+            .find("# Wormhole Guardian Set account (index = 5)")
+            .unwrap();
+        let pos6 = out
+            .find("# Wormhole Guardian Set account (index = 6)")
+            .unwrap();
+        let pos7 = out
+            .find("# Wormhole Guardian Set account (index = 7)")
+            .unwrap();
+        assert!(pos5 < pos6, "expected index 5 to appear before index 6");
+        assert!(pos6 < pos7, "expected index 6 to appear before index 7");
     }
 }

--- a/xtask/src/anchor_toml.rs
+++ b/xtask/src/anchor_toml.rs
@@ -1,6 +1,6 @@
 // Pure text helpers for the Anchor.toml managed guardian-set block.
 
-use anyhow::{bail, Result};
+use eyre::{bail, OptionExt, Result};
 
 pub const BEGIN_MARKER: &str =
     "# BEGIN guardian-sets (managed by xtask; run `just rotate-guardian-set`)";
@@ -49,11 +49,11 @@ pub fn splice_managed_block(contents: &str, new_interior: &str) -> Result<String
 pub fn uncommented_addresses(contents: &str) -> Result<Vec<String>> {
     let begin = contents
         .find(BEGIN_MARKER)
-        .ok_or_else(|| anyhow::anyhow!("managed guardian-set block not found"))?;
+        .ok_or_eyre("managed guardian-set block not found")?;
     let end = contents[begin..]
         .find(END_MARKER)
         .map(|i| begin + i)
-        .ok_or_else(|| anyhow::anyhow!("managed guardian-set block malformed"))?;
+        .ok_or_eyre("managed guardian-set block malformed")?;
     let mut addrs = Vec::new();
     for line in contents[begin..end].lines() {
         let trimmed = line.trim_start();

--- a/xtask/src/guardian_set.rs
+++ b/xtask/src/guardian_set.rs
@@ -2,7 +2,7 @@
 
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use eyre::{eyre, OptionExt, Result};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
 
@@ -37,7 +37,7 @@ pub fn detect(rpc_url: &str, max_probe: u32) -> Result<Detected> {
     let addresses: Vec<Pubkey> = indices.iter().map(|&i| guardian_set_address(i)).collect();
     let accounts = client
         .get_multiple_accounts(&addresses)
-        .with_context(|| format!("getMultipleAccounts against {rpc_url}"))?;
+        .map_err(|e| eyre!("getMultipleAccounts against {rpc_url}: {e}"))?;
     let existing: Vec<u32> = indices
         .iter()
         .zip(accounts.iter())
@@ -47,7 +47,7 @@ pub fn detect(rpc_url: &str, max_probe: u32) -> Result<Detected> {
         .iter()
         .copied()
         .max()
-        .context("no guardian-set accounts found on cluster")?;
+        .ok_or_eyre("no guardian-set accounts found on cluster")?;
     if existing.contains(&max_probe) {
         eprintln!(
             "warning: highest probed guardian-set index ({max_probe}) exists; a newer set \

--- a/xtask/src/guardian_set.rs
+++ b/xtask/src/guardian_set.rs
@@ -1,1 +1,74 @@
 // Guardian-set PDA derivation and active-index detection.
+
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+
+/// Pyth Solana Wormhole receiver program.
+/// Source of truth: gmsol SDK `pyth/pull_oracle/wormhole/mod.rs` (WORMHOLE_PROGRAM_ID).
+const WORMHOLE_PROGRAM_ID: &str = "HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ";
+
+pub fn program_id() -> Pubkey {
+    Pubkey::from_str(WORMHOLE_PROGRAM_ID).expect("valid program id")
+}
+
+/// PDA for the guardian set at `index`: seeds = [b"GuardianSet", index.to_be_bytes()].
+pub fn guardian_set_address(index: u32) -> Pubkey {
+    Pubkey::find_program_address(&[b"GuardianSet", &index.to_be_bytes()], &program_id()).0
+}
+
+pub struct Detected {
+    /// Highest existing guardian-set index (= the active set).
+    pub active: u32,
+    /// All indices in `1..=max_probe` whose account exists on the cluster.
+    pub existing: Vec<u32>,
+}
+
+/// One `getMultipleAccounts` call over indices `1..=max_probe`; the highest existing
+/// index is the active set (indices increment by +1 per rotation, newest is active).
+/// Index 0 (the 2021 genesis set) is intentionally skipped: it is never used to sign
+/// current VAAs, and skipping it keeps `existing` deterministic regardless of whether
+/// the genesis account sits at the standard PDA.
+pub fn detect(rpc_url: &str, max_probe: u32) -> Result<Detected> {
+    let client = RpcClient::new(rpc_url.to_string());
+    let indices: Vec<u32> = (1..=max_probe).collect();
+    let addresses: Vec<Pubkey> = indices.iter().map(|&i| guardian_set_address(i)).collect();
+    let accounts = client
+        .get_multiple_accounts(&addresses)
+        .with_context(|| format!("getMultipleAccounts against {rpc_url}"))?;
+    let existing: Vec<u32> = indices
+        .iter()
+        .zip(accounts.iter())
+        .filter_map(|(&i, acc)| acc.as_ref().map(|_| i))
+        .collect();
+    let active = existing
+        .iter()
+        .copied()
+        .max()
+        .context("no guardian-set accounts found on cluster")?;
+    Ok(Detected { active, existing })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_known_guardian_set_addresses() {
+        let cases = [
+            (1u32, "8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5"),
+            (4, "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"),
+            (6, "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf"),
+            (7, "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"),
+        ];
+        for (index, expected) in cases {
+            assert_eq!(
+                guardian_set_address(index).to_string(),
+                expected,
+                "index {index}"
+            );
+        }
+    }
+}

--- a/xtask/src/guardian_set.rs
+++ b/xtask/src/guardian_set.rs
@@ -48,6 +48,12 @@ pub fn detect(rpc_url: &str, max_probe: u32) -> Result<Detected> {
         .copied()
         .max()
         .context("no guardian-set accounts found on cluster")?;
+    if existing.contains(&max_probe) {
+        eprintln!(
+            "warning: highest probed guardian-set index ({max_probe}) exists; a newer set \
+             may be unprobed. Raise MAX_PROBE in xtask if a rotation is not detected."
+        );
+    }
     Ok(Detected { active, existing })
 }
 

--- a/xtask/src/guardian_set.rs
+++ b/xtask/src/guardian_set.rs
@@ -1,0 +1,1 @@
+// Guardian-set PDA derivation and active-index detection.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,47 @@
+mod anchor_toml;
+mod guardian_set;
+
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+/// Developer tasks for gmx-solana.
+#[derive(Parser)]
+#[command(name = "xtask")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Wormhole guardian-set clone management for the test validator.
+    GuardianSet {
+        #[command(subcommand)]
+        action: GuardianSetAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum GuardianSetAction {
+    /// Fail if the active guardian set is not cloned in Anchor.toml.
+    Check,
+    /// Rewrite Anchor.toml's managed guardian-set block to the current + previous set.
+    Rotate,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::GuardianSet { action } => match action {
+            GuardianSetAction::Check => {
+                println!("check: not implemented yet");
+                ExitCode::SUCCESS
+            }
+            GuardianSetAction::Rotate => {
+                println!("rotate: not implemented yet");
+                ExitCode::SUCCESS
+            }
+        },
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,6 +5,10 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 
+const ANCHOR_TOML: &str = "Anchor.toml";
+const DEFAULT_RPC: &str = "https://api.devnet.solana.com";
+const MAX_PROBE: u32 = 15;
+
 /// Developer tasks for gmx-solana.
 #[derive(Parser)]
 #[command(name = "xtask")]
@@ -30,14 +34,60 @@ enum GuardianSetAction {
     Rotate,
 }
 
+fn read_anchor_toml() -> anyhow::Result<String> {
+    std::fs::read_to_string(ANCHOR_TOML)
+        .map_err(|e| anyhow::anyhow!("failed to read {ANCHOR_TOML}: {e}"))
+}
+
+fn cmd_check() -> ExitCode {
+    let contents = match read_anchor_toml() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let rpc = anchor_toml::validator_url(&contents).unwrap_or_else(|| DEFAULT_RPC.to_string());
+
+    let detected = match guardian_set::detect(&rpc, MAX_PROBE) {
+        Ok(d) => d,
+        Err(e) => {
+            // Soft-pass: a network blip must not masquerade as "rotation needed".
+            eprintln!(
+                "warning: could not check guardian set ({e}); skipping. \
+                       anchor's --clone will surface a real outage."
+            );
+            return ExitCode::SUCCESS;
+        }
+    };
+
+    let active_addr = guardian_set::guardian_set_address(detected.active).to_string();
+    let cloned = match anchor_toml::uncommented_addresses(&contents) {
+        Ok(addrs) => addrs,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if cloned.iter().any(|a| a == &active_addr) {
+        println!("guardian set {} is active and cloned; ok.", detected.active);
+        ExitCode::SUCCESS
+    } else {
+        eprintln!(
+            "error: Wormhole guardian set {} is active but not cloned in {ANCHOR_TOML}.\n\
+             Run `just rotate-guardian-set` to update it.",
+            detected.active
+        );
+        ExitCode::FAILURE
+    }
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     match cli.command {
         Command::GuardianSet { action } => match action {
-            GuardianSetAction::Check => {
-                println!("check: not implemented yet");
-                ExitCode::SUCCESS
-            }
+            GuardianSetAction::Check => cmd_check(),
             GuardianSetAction::Rotate => {
                 println!("rotate: not implemented yet");
                 ExitCode::SUCCESS

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,9 +36,9 @@ enum GuardianSetAction {
     Rotate,
 }
 
-fn read_anchor_toml() -> anyhow::Result<String> {
+fn read_anchor_toml() -> eyre::Result<String> {
     std::fs::read_to_string(ANCHOR_TOML)
-        .map_err(|e| anyhow::anyhow!("failed to read {ANCHOR_TOML}: {e}"))
+        .map_err(|e| eyre::eyre!("failed to read {ANCHOR_TOML}: {e}"))
 }
 
 fn cmd_check() -> ExitCode {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -83,15 +83,61 @@ fn cmd_check() -> ExitCode {
     }
 }
 
+fn cmd_rotate() -> ExitCode {
+    let contents = match read_anchor_toml() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let rpc = anchor_toml::validator_url(&contents).unwrap_or_else(|| DEFAULT_RPC.to_string());
+
+    let detected = match guardian_set::detect(&rpc, MAX_PROBE) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("error: could not query guardian sets: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let interior = anchor_toml::render_interior(&detected.existing, detected.active, |i| {
+        guardian_set::guardian_set_address(i).to_string()
+    });
+    let updated = match anchor_toml::splice_managed_block(&contents, &interior) {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if updated == contents {
+        println!(
+            "guardian set {} already current; no change.",
+            detected.active
+        );
+        return ExitCode::SUCCESS;
+    }
+    if let Err(e) = std::fs::write(ANCHOR_TOML, &updated) {
+        eprintln!("error: failed to write {ANCHOR_TOML}: {e}");
+        return ExitCode::FAILURE;
+    }
+    let previous = detected.active.saturating_sub(1);
+    println!(
+        "updated {ANCHOR_TOML}: guardian set {} active, {previous} kept as previous \
+         (older commented). Review and commit.",
+        detected.active
+    );
+    ExitCode::SUCCESS
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     match cli.command {
         Command::GuardianSet { action } => match action {
             GuardianSetAction::Check => cmd_check(),
-            GuardianSetAction::Rotate => {
-                println!("rotate: not implemented yet");
-                ExitCode::SUCCESS
-            }
+            GuardianSetAction::Rotate => cmd_rotate(),
         },
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,8 @@ use clap::{Parser, Subcommand};
 
 const ANCHOR_TOML: &str = "Anchor.toml";
 const DEFAULT_RPC: &str = "https://api.devnet.solana.com";
+// Probe ceiling. Kept well under getMultipleAccounts' 100-address cap; growing it past
+// ~100 would require batching detect's RPC call.
 const MAX_PROBE: u32 = 15;
 
 /// Developer tasks for gmx-solana.


### PR DESCRIPTION
- Adds cargo xtask guardian-set check / rotate to manage the wormhole guardian-set clones pinned in Anchor.toml (PDA derivation + active-index detection)
- just test-programs now gates on check-guardian-set; rotate-guardian-set updates the managed block in place