### PR TITLE
ci: powerset depth 1 on PRs, depth 2 on main

### DIFF
--- a/.github/workflows/ci-sdk.yml
+++ b/.github/workflows/ci-sdk.yml
@@ -130,4 +130,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
       - name: check --feature-powerset
-        run: cargo hack check --workspace ${{ env.exclude_packages }} --feature-powerset --depth 2 --keep-going
+        # depth 2 (pairwise) takes ~35 min and dominates PR latency; PRs check
+        # each feature alone, pushes to main keep the full pairwise sweep
+        run: cargo hack check --workspace ${{ env.exclude_packages }} --feature-powerset --depth ${{ github.event_name == 'pull_request' && '1' || '2' }} --keep-going


### PR DESCRIPTION
- The pairwise feature powerset takes ~35 min warm and sets the latency floor for every PR
- PRs now check each feature alone (depth 1); pushes to main keep the full pairwise sweep, so combination breaks still surface immediately after merge