### PR TITLE
test: mint enough for the first-deposit flow

### DIFF
--- a/tests/anchor_test/deposit.rs
+++ b/tests/anchor_test/deposit.rs
@@ -227,8 +227,11 @@ async fn first_deposit() -> eyre::Result<()> {
     let amount = 1_000_000_013;
     let min_amount = 1u64;
 
+    // Three deposits are created below, each escrowing `amount`; the first one
+    // intentionally fails execution and is never cancelled, so its escrow is
+    // not refunded within this test.
     deployment
-        .mint_or_transfer_to_user(long_token, Deployment::DEFAULT_USER, amount * 2)
+        .mint_or_transfer_to_user(long_token, Deployment::DEFAULT_USER, amount * 3)
         .await?;
 
     let signature = keeper


### PR DESCRIPTION
- The intentionally-failed first deposit is never cancelled, so its escrow keeps one amount locked; the three deposits in this test need three amounts
- With exactly two, the last deposit creation fails with insufficient funds whenever the shared test user starts from a clean balance -- deterministic in CI, masked locally by leftover balances from other tests
- Verified in isolation: the test now passes (was failing deterministically)