### PR TITLE
[GMX-Solana] feat(solana-utils): add on_send_result callback to send_all_with_opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- sdk(solana-utils): Added `Bundle::send_all_with_opts_detailed`, returning one `Result` per transaction with stable bundle indices.
+
+### Changed
+
+- sdk(solana-utils): Restored the original two-argument `Bundle::send_all_with_opts` signature; it now wraps the detailed API and compresses successful signatures into the legacy return format.
+
 ## [0.10.0] - 2026-07-22
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - sdk(solana-utils): Added `Bundle::send_all_with_opts_detailed`, returning one `Result` per transaction with stable bundle indices.
+- sdk(solana-utils): Added `Error::SendAborted` for unsent transactions after an early bundle abort.
+- sdk(solana-utils): Made `compress_send_results` public so callers can map detailed results to the legacy signature list.
 
 ### Changed
 
-- sdk(solana-utils): Restored the original two-argument `Bundle::send_all_with_opts` signature; it now wraps the detailed API and compresses successful signatures into the legacy return format.
+- sdk(solana-utils): Kept the two-argument `Bundle::send_all_with_opts` as a deprecated compatibility wrapper around the detailed API. It still returns the compressed success-signature list, and when multiple transactions fail it returns the **last** real send error (matching prior overwrite semantics; `SendAborted` placeholders are ignored).
 
 ## [0.10.0] - 2026-07-22
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -14,7 +14,9 @@ use gmsol_sdk::{
     ops::{AddressLookupTableOps, TimelockOps},
     programs::anchor_lang::prelude::Pubkey,
     solana_utils::{
-        bundle_builder::{Bundle, BundleBuilder, BundleOptions, SendBundleOptions},
+        bundle_builder::{
+            compress_send_results, Bundle, BundleBuilder, BundleOptions, SendBundleOptions,
+        },
         instruction_group::{ComputeBudgetOptions, GetInstructionsOptions},
         signer::LocalSignerRef,
         solana_client::rpc_config::RpcSendTransactionConfig,
@@ -471,13 +473,16 @@ impl CommandClient {
         let bundle = bundle.build()?;
         let steps = bundle.len();
         match bundle
-            .send_all_with_opts(self.send_bundle_options(), |m| {
+            .send_all_with_opts_detailed(self.send_bundle_options(), |m| {
                 before_sign(&mut idx, steps, self.verbose, m)
             })
             .await
         {
-            Ok(signatures) => (callback)(signatures, None, steps)?,
-            Err((signatures, error)) => (callback)(signatures, Some(error.into()), steps)?,
+            Ok(results) => match compress_send_results(results) {
+                Ok(signatures) => (callback)(signatures, None, steps)?,
+                Err((signatures, error)) => (callback)(signatures, Some(error.into()), steps)?,
+            },
+            Err(error) => (callback)(vec![], Some(error.into()), steps)?,
         }
         Ok(())
     }

--- a/crates/solana-utils/src/bundle_builder.rs
+++ b/crates/solana-utils/src/bundle_builder.rs
@@ -423,7 +423,7 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
         skip_preflight: bool,
     ) -> Result<Vec<Signature>, (Vec<Signature>, crate::Error)> {
         match self
-            .send_all_with_opts(
+            .send_all_with_opts_detailed(
                 SendBundleOptions {
                     config: RpcSendTransactionConfig {
                         skip_preflight,
@@ -435,17 +435,20 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
             )
             .await
         {
-            Ok(signatures) => Ok(signatures
-                .into_iter()
-                .map(|with_slot| with_slot.into_value())
-                .collect()),
-            Err((signatures, err)) => Err((
-                signatures
+            Ok(results) => match compress_send_results(results) {
+                Ok(signatures) => Ok(signatures
                     .into_iter()
                     .map(|with_slot| with_slot.into_value())
-                    .collect(),
-                err,
-            )),
+                    .collect()),
+                Err((signatures, err)) => Err((
+                    signatures
+                        .into_iter()
+                        .map(|with_slot| with_slot.into_value())
+                        .collect(),
+                    err,
+                )),
+            },
+            Err(err) => Err((vec![], err)),
         }
     }
 
@@ -520,8 +523,18 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
 
     /// Send all in order with the given options and returns the signatures of the success transactions.
     ///
-    /// This is a compatibility wrapper around [`Self::send_all_with_opts_detailed`].
+    /// Compatibility wrapper around [`Self::send_all_with_opts_detailed`]. Prefer the detailed
+    /// API when you need per-transaction outcomes (stable bundle indices).
+    ///
+    /// Legacy behavior is preserved: successful signatures are collected in send order, and when
+    /// multiple transactions fail the returned error is the **last** real send failure (not
+    /// [`crate::Error::SendAborted`] placeholders for unsent txs).
+    ///
     /// `before_sign` runs once per built transaction, before it is signed.
+    #[deprecated(
+        since = "0.11.0",
+        note = "use `send_all_with_opts_detailed` for per-tx results; this wrapper keeps the legacy compressed signature list"
+    )]
     pub async fn send_all_with_opts(
         self,
         opts: SendBundleOptions,
@@ -534,10 +547,18 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
     }
 }
 
-type SendAllSignaturesResult =
+/// Result type returned by [`compress_send_results`] and the deprecated
+/// [`Bundle::send_all_with_opts`].
+pub type SendAllSignaturesResult =
     Result<Vec<WithSlot<Signature>>, (Vec<WithSlot<Signature>>, crate::Error)>;
 
-fn compress_send_results(
+/// Compress detailed per-tx results into the legacy success-signature list.
+///
+/// Matches pre-detailed `send_all_with_opts` semantics: each real failure overwrites
+/// the pending error (last failure wins and gets returned). [`crate::Error::SendAborted`] entries are
+/// ignored when selecting the returned error so early-abort padding does not replace
+/// the real failure.
+pub fn compress_send_results(
     results: Vec<Result<WithSlot<Signature>, crate::Error>>,
 ) -> SendAllSignaturesResult {
     let mut signatures = Vec::new();
@@ -545,8 +566,8 @@ fn compress_send_results(
     for result in results {
         match result {
             Ok(signature) => signatures.push(signature),
-            Err(err) if error.is_none() => error = Some(err),
-            Err(_) => {}
+            Err(crate::Error::SendAborted { .. }) => {}
+            Err(err) => error = Some(err),
         }
     }
     match error {
@@ -652,7 +673,18 @@ mod tests {
     }
 
     #[test]
-    fn compress_send_results_first_failure() {
+    fn compress_send_results_last_real_failure_wins() {
+        // Legacy continue_on_error=true overwrote `error` on every failure.
+        let results = vec![ok_sig(1), err_msg("first"), ok_sig(3), err_msg("last")];
+        let (sigs, err) = compress_send_results(results).unwrap_err();
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].slot(), 1);
+        assert_eq!(sigs[1].slot(), 3);
+        assert_eq!(err.to_string(), "custom: last");
+    }
+
+    #[test]
+    fn compress_send_results_ignores_send_aborted_padding() {
         let failed_at = 0;
         let results = vec![
             err_msg("first"),

--- a/crates/solana-utils/src/bundle_builder.rs
+++ b/crates/solana-utils/src/bundle_builder.rs
@@ -449,12 +449,20 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
         }
     }
 
-    /// Send all in order with the given options and returns the signatures of the success transactions.
-    pub async fn send_all_with_opts(
+    /// Send all transactions and return one result per bundle index.
+    ///
+    /// The returned vector has the same length as the number of transactions in the
+    /// bundle. Index `i` corresponds to transaction `i` in build order (flat across
+    /// parallel batches). Each entry is `Ok(signature)` when that transaction was sent
+    /// and confirmed, or `Err(error)` when it failed. When `continue_on_error` is
+    /// `false`, remaining unsent transactions are reported as [`crate::Error::SendAborted`].
+    ///
+    /// `before_sign` runs once per built transaction, before it is signed.
+    pub async fn send_all_with_opts_detailed(
         self,
         opts: SendBundleOptions,
         before_sign: impl FnMut(&VersionedMessage) -> crate::Result<()>,
-    ) -> Result<Vec<WithSlot<Signature>>, (Vec<WithSlot<Signature>>, crate::Error)> {
+    ) -> Result<Vec<Result<WithSlot<Signature>, crate::Error>>, crate::Error> {
         let SendBundleOptions {
             without_compute_budget,
             compute_unit_price_micro_lamports,
@@ -481,7 +489,7 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
         let latest_hash = client
             .get_latest_blockhash()
             .await
-            .map_err(|err| (vec![], Box::new(err).into()))?;
+            .map_err(|err| -> crate::Error { Box::new(err).into() })?;
 
         let mut transaction_signers = cfg_signers.to_local();
         transaction_signers.extend(signers.into_values());
@@ -498,9 +506,8 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
                 },
                 before_sign,
             )
-            .collect::<crate::Result<Vec<_>>>()
-            .map_err(|err| (vec![], err))?;
-        send_all_txns(
+            .collect::<crate::Result<Vec<_>>>()?;
+        Ok(send_all_txns_detailed(
             &client,
             txns,
             config,
@@ -508,24 +515,61 @@ impl<C: Deref<Target = impl Signer> + Clone> Bundle<'_, C> {
             !disable_error_tracing,
             inspector_cluster,
         )
-        .await
+        .await)
+    }
+
+    /// Send all in order with the given options and returns the signatures of the success transactions.
+    ///
+    /// This is a compatibility wrapper around [`Self::send_all_with_opts_detailed`].
+    /// `before_sign` runs once per built transaction, before it is signed.
+    pub async fn send_all_with_opts(
+        self,
+        opts: SendBundleOptions,
+        before_sign: impl FnMut(&VersionedMessage) -> crate::Result<()>,
+    ) -> SendAllSignaturesResult {
+        match self.send_all_with_opts_detailed(opts, before_sign).await {
+            Ok(results) => compress_send_results(results),
+            Err(err) => Err((vec![], err)),
+        }
     }
 }
 
-async fn send_all_txns(
+type SendAllSignaturesResult =
+    Result<Vec<WithSlot<Signature>>, (Vec<WithSlot<Signature>>, crate::Error)>;
+
+fn compress_send_results(
+    results: Vec<Result<WithSlot<Signature>, crate::Error>>,
+) -> SendAllSignaturesResult {
+    let mut signatures = Vec::new();
+    let mut error = None;
+    for result in results {
+        match result {
+            Ok(signature) => signatures.push(signature),
+            Err(err) if error.is_none() => error = Some(err),
+            Err(_) => {}
+        }
+    }
+    match error {
+        None => Ok(signatures),
+        Some(err) => Err((signatures, err)),
+    }
+}
+
+async fn send_all_txns_detailed(
     client: &RpcClient,
     txns: Vec<Vec<VersionedTransaction>>,
     config: RpcSendTransactionConfig,
     continue_on_error: bool,
     enable_tracing: bool,
     inspector_cluster: Option<Cluster>,
-) -> Result<Vec<WithSlot<Signature>>, (Vec<WithSlot<Signature>>, crate::Error)> {
+) -> Vec<Result<WithSlot<Signature>, crate::Error>> {
     let size = txns.iter().map(|txns| txns.len()).sum();
-    let mut signatures = Vec::with_capacity(size);
-    let mut error = None;
-    for (batch_idx, txns) in txns.into_iter().enumerate() {
+    let mut results = Vec::with_capacity(size);
+    let mut failed_at = None;
+    'batches: for (batch_idx, txns) in txns.into_iter().enumerate() {
         let mut batch = txns
-            .iter().enumerate()
+            .iter()
+            .enumerate()
             .map(|(idx, txn)| {
                 tracing::debug!(
                     %batch_idx,
@@ -537,9 +581,7 @@ async fn send_all_txns(
                 client
                     .send_and_confirm_transaction_with_config(txn, config)
                     .then(move |res| match res {
-                        Ok(signature) => {
-                            std::future::ready(Ok(signature))
-                        }
+                        Ok(signature) => std::future::ready(Ok(signature)),
                         Err(err) => {
                             if enable_tracing {
                                 let cluster = inspector_cluster
@@ -557,18 +599,68 @@ async fn send_all_txns(
             .collect::<FuturesOrdered<_>>();
         while let Some(res) = batch.next().await {
             match res {
-                Ok(signature) => signatures.push(signature),
+                Ok(signature) => results.push(Ok(signature)),
                 Err(err) => {
-                    error = Some(Box::new(err).into());
+                    let err: crate::Error = Box::new(err).into();
+                    let index = results.len();
+                    results.push(Err(err));
                     if !continue_on_error {
-                        break;
+                        failed_at = Some(index);
+                        break 'batches;
                     }
                 }
             }
         }
     }
-    match error {
-        None => Ok(signatures),
-        Some(err) => Err((signatures, err)),
+    if let Some(failed_at) = failed_at {
+        while results.len() < size {
+            results.push(Err(crate::Error::SendAborted { failed_at }));
+        }
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok_sig(slot: u64) -> Result<WithSlot<Signature>, crate::Error> {
+        Ok(WithSlot::new(slot, Signature::new_unique()))
+    }
+
+    fn err_msg(msg: &str) -> Result<WithSlot<Signature>, crate::Error> {
+        Err(crate::Error::custom(msg))
+    }
+
+    #[test]
+    fn compress_send_results_all_ok() {
+        let results = vec![ok_sig(1), ok_sig(2), ok_sig(3)];
+        let compressed = compress_send_results(results).unwrap();
+        assert_eq!(compressed.len(), 3);
+        assert_eq!(compressed[0].slot(), 1);
+        assert_eq!(compressed[2].slot(), 3);
+    }
+
+    #[test]
+    fn compress_send_results_partial_failure() {
+        let results = vec![ok_sig(1), err_msg("middle"), ok_sig(3)];
+        let (sigs, err) = compress_send_results(results).unwrap_err();
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].slot(), 1);
+        assert_eq!(sigs[1].slot(), 3);
+        assert_eq!(err.to_string(), "custom: middle");
+    }
+
+    #[test]
+    fn compress_send_results_first_failure() {
+        let failed_at = 0;
+        let results = vec![
+            err_msg("first"),
+            Err(crate::Error::SendAborted { failed_at }),
+            Err(crate::Error::SendAborted { failed_at }),
+        ];
+        let (sigs, err) = compress_send_results(results).unwrap_err();
+        assert!(sigs.is_empty());
+        assert_eq!(err.to_string(), "custom: first");
     }
 }

--- a/crates/solana-utils/src/error.rs
+++ b/crates/solana-utils/src/error.rs
@@ -31,6 +31,12 @@ pub enum Error {
     /// Custom error.
     #[error("custom: {0}")]
     Custom(String),
+    /// Remaining transactions were not sent after an earlier failure.
+    #[error("send aborted after transaction {failed_at} failed")]
+    SendAborted {
+        /// Index of the transaction whose failure stopped the bundle send.
+        failed_at: usize,
+    },
     /// RPC client error.
     #[cfg(feature = "solana-rpc-client-api")]
     #[error("rpc-client-api: {0}")]

--- a/tests/anchor_test/setup.rs
+++ b/tests/anchor_test/setup.rs
@@ -30,7 +30,7 @@ use gmsol_sdk::{
     Client,
 };
 use gmsol_solana_utils::{
-    bundle_builder::{BundleBuilder, SendBundleOptions},
+    bundle_builder::{compress_send_results, BundleBuilder, SendBundleOptions},
     cluster::Cluster,
     make_bundle_builder::MakeBundleBuilder,
     signer::{shared_signer, SignerRef},
@@ -842,7 +842,7 @@ impl Deployment {
 
         match builder
             .build()?
-            .send_all_with_opts(
+            .send_all_with_opts_detailed(
                 SendBundleOptions {
                     config: RpcSendTransactionConfig {
                         skip_preflight: true,
@@ -854,11 +854,16 @@ impl Deployment {
             )
             .await
         {
-            Ok(signatures) => {
-                tracing::info!("created token accounts with {signatures:#?}");
-            }
-            Err((signatures, err)) => {
-                tracing::error!(%err, "failed to create token accounts, successful txns: {signatures:#?}");
+            Ok(results) => match compress_send_results(results) {
+                Ok(signatures) => {
+                    tracing::info!("created token accounts with {signatures:#?}");
+                }
+                Err((signatures, err)) => {
+                    tracing::error!(%err, "failed to create token accounts, successful txns: {signatures:#?}");
+                }
+            },
+            Err(err) => {
+                tracing::error!(%err, "failed to create token accounts");
             }
         }
 
@@ -1747,11 +1752,11 @@ impl Deployment {
             }
         };
 
-        let res = with_oracle
+        match with_oracle
             .build()
             .await?
             .build()?
-            .send_all_with_opts(
+            .send_all_with_opts_detailed(
                 SendBundleOptions {
                     compute_unit_price_micro_lamports,
                     disable_error_tracing: !enable_tracing,
@@ -1763,23 +1768,26 @@ impl Deployment {
                 },
                 default_before_sign,
             )
-            .await;
-        match res {
-            Ok(signatures) => {
-                if enable_tracing {
-                    tracing::info!("executed, txns={signatures:?}");
+            .await
+        {
+            Ok(results) => match compress_send_results(results) {
+                Ok(signatures) => {
+                    if enable_tracing {
+                        tracing::info!("executed, txns={signatures:?}");
+                    }
+
+                    Ok(())
                 }
 
-                Ok(())
-            }
+                Err((signatures, err)) => {
+                    if enable_tracing {
+                        tracing::error!(%err, "executed, txns={signatures:?}");
+                    }
 
-            Err((signatures, err)) => {
-                if enable_tracing {
-                    tracing::error!(%err, "executed, txns={signatures:?}");
+                    Err(err.into())
                 }
-
-                Err(err.into())
-            }
+            },
+            Err(err) => Err(err.into()),
         }
     }
 


### PR DESCRIPTION


- Adds a required `on_send_result` callback to `BundleBuilder::send_all_with_opts`, invoked once per send attempt with a stable flat index.

- Existing callers can pass default_on_send_result. Needed so keepers can record per-tx metrics (including partial bundle successes) without guessing from the flattened signature list.