### PR TITLE
test: GLV deposit market-count ramp — execution fails at 26 markets (CU limit)

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -25,7 +25,10 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "cargo test --test anchor --features anchor-test -- $GMSOL_TEST $EXTRA_CARGO_ARGS"
+# `RUST_LOG` is scoped to the test process here on purpose: exporting it in the
+# environment would also reach the spawned `solana-test-validator` and break its
+# startup. Set `GMSOL_TEST_LOG` (e.g. to `error,anchor=info`) to see the test logs.
+test = "RUST_LOG=${GMSOL_TEST_LOG:-error} cargo test --test anchor --features anchor-test -- $GMSOL_TEST $EXTRA_CARGO_ARGS"
 
 [test]
 startup_wait = 15000

--- a/tests/anchor_test/glv.rs
+++ b/tests/anchor_test/glv.rs
@@ -1,5 +1,6 @@
 use gmsol_programs::anchor_lang;
 use gmsol_sdk::client::ops::{ExchangeOps, GlvOps};
+use gmsol_sdk::utils::zero_copy::ZeroCopy;
 use gmsol_store::CoreError;
 use tracing::Instrument;
 
@@ -153,6 +154,123 @@ async fn glv_deposit() -> eyre::Result<()> {
         .send_without_preflight()
         .await?;
     tracing::info!(%signature, %market_token, "restored market config in the GLV");
+
+    Ok(())
+}
+
+/// Ramp up the number of markets in the many-markets GLV one by one, executing
+/// a GLV deposit at every count, to find the market count at which the
+/// execution starts to fail.
+///
+/// The test does not fail when a limit is found; it reports the last
+/// successful market count and the error via tracing instead.
+#[tokio::test]
+async fn glv_deposit_with_increasing_markets() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("glv_deposit_with_increasing_markets");
+    let _enter = span.enter();
+
+    let user = deployment.user_client(Deployment::DEFAULT_USER)?;
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+
+    let store = &deployment.store;
+    let oracle = &deployment.oracle();
+    let glv_token = &deployment.many_markets_glv_token;
+    let market_token = deployment
+        .market_token(&Deployment::many_markets_glv_index_token(1), "fBTC", "USDG")
+        .unwrap();
+
+    let long_token_amount = 1_000;
+
+    deployment
+        .mint_or_transfer_to_user(
+            "fBTC",
+            Deployment::DEFAULT_USER,
+            Deployment::MANY_MARKETS_GLV_MAX_MARKET_COUNT as u64 * long_token_amount,
+        )
+        .await?;
+
+    let glv = keeper
+        .account::<ZeroCopy<gmsol_programs::gmsol_store::accounts::Glv>>(
+            &keeper.find_glv_address(glv_token),
+        )
+        .await?
+        .expect("the many-markets GLV must exist")
+        .0;
+    let initial_count = glv.market_tokens().count();
+    assert_eq!(initial_count, 2);
+
+    for count in initial_count..=Deployment::MANY_MARKETS_GLV_MAX_MARKET_COUNT {
+        if count > initial_count {
+            let market_token_to_insert = deployment
+                .market_token(
+                    &Deployment::many_markets_glv_index_token(count),
+                    "fBTC",
+                    "USDG",
+                )
+                .unwrap();
+            let signature = keeper
+                .insert_glv_market(store, glv_token, market_token_to_insert, None)
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, %market_token_to_insert, "inserted market {count} into the GLV");
+        }
+
+        let (rpc, deposit) = user
+            .create_glv_deposit(store, glv_token, market_token)
+            .long_token_deposit(long_token_amount, None, None)
+            .build_with_address()
+            .await?;
+        let signature = rpc.send_without_preflight().await?;
+        tracing::info!(%signature, %deposit, "created a glv deposit with {count} markets");
+
+        let mut execute = keeper.execute_glv_deposit(oracle, &deposit, false);
+        let result = deployment
+            .execute_with_pyth(
+                execute
+                    .add_alt(deployment.common_alt().clone())
+                    .add_alt(deployment.market_alt().clone()),
+                None,
+                false,
+                true,
+            )
+            .instrument(tracing::info_span!("executing glv deposit", glv_deposit=%deposit, %count))
+            .await;
+
+        match result {
+            Ok(()) => {
+                tracing::info!("glv deposit executed successfully with {count} markets");
+            }
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    "glv deposit execution failed with {count} markets; last successful market count = {}",
+                    count - 1,
+                );
+                // Close the pending deposit so that it does not leak into
+                // other tests.
+                match user.close_glv_deposit(&deposit).build().await {
+                    Ok(txn) => {
+                        let _ = txn.send_without_preflight().await;
+                    }
+                    Err(err) => {
+                        tracing::warn!(%err, "failed to build the close instruction for the pending deposit");
+                    }
+                }
+                assert!(
+                    count > initial_count,
+                    "executing a glv deposit must work with the initial market count: {err}"
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    tracing::info!(
+        "glv deposit executed successfully with all {} markets",
+        Deployment::MANY_MARKETS_GLV_MAX_MARKET_COUNT
+    );
 
     Ok(())
 }

--- a/tests/anchor_test/setup.rs
+++ b/tests/anchor_test/setup.rs
@@ -106,6 +106,9 @@ pub struct Deployment {
     oracle: Keypair,
     /// GLV mint.
     pub glv_token: Pubkey,
+    /// GLV mint of the many-markets GLV
+    /// (see [`Self::MANY_MARKETS_GLV_MAX_MARKET_COUNT`]).
+    pub many_markets_glv_token: Pubkey,
     /// Tokens.
     tokens: HashMap<String, Token>,
     /// Synthetic tokens.
@@ -184,6 +187,30 @@ impl Deployment {
         Self::TOKEN_FOR_SWAP_TEST,
     ];
 
+    /// GLV index of the many-markets GLV used by the GLV deposit
+    /// market-count ramp test.
+    pub const MANY_MARKETS_GLV_INDEX: u16 = 1;
+
+    /// Number of candidate markets created for the many-markets GLV. The GLV
+    /// itself is initialized with only the first two markets; the ramp test
+    /// inserts the remaining ones one by one.
+    pub const MANY_MARKETS_GLV_MAX_MARKET_COUNT: usize = 40;
+
+    /// Returns the name of the synthetic index token used by the `idx`-th market
+    /// of the many-markets GLV.
+    pub fn many_markets_glv_index_token(idx: usize) -> String {
+        format!("fI{idx:02}")
+    }
+
+    /// Returns the market selector for the `idx`-th market of the many-markets GLV.
+    pub fn many_markets_glv_market(idx: usize) -> [String; 3] {
+        [
+            Self::many_markets_glv_index_token(idx),
+            "fBTC".to_string(),
+            "USDG".to_string(),
+        ]
+    }
+
     const SOL_PYTH_FEED_ID: [u8; 32] = [
         0xef, 0x0d, 0x8b, 0x6f, 0xda, 0x2c, 0xeb, 0xa4, 0x1d, 0xa1, 0x5d, 0x40, 0x95, 0xd1, 0xda,
         0x39, 0x2a, 0x0d, 0x2f, 0x8e, 0xd0, 0xc6, 0xc7, 0xbc, 0x0f, 0x4c, 0xfa, 0xc8, 0xc2, 0x80,
@@ -246,6 +273,7 @@ impl Deployment {
             token_map,
             oracle,
             glv_token: Default::default(),
+            many_markets_glv_token: Default::default(),
             tokens: Default::default(),
             synthetic_tokens: Default::default(),
             market_tokens: Default::default(),
@@ -354,6 +382,19 @@ impl Deployment {
                 max_deviation_factor: Some(MAX_DEVIATION_FACTOR),
             },
         )]);
+        self.add_synthetic_tokens((1..=Self::MANY_MARKETS_GLV_MAX_MARKET_COUNT).map(|idx| {
+            (
+                Self::many_markets_glv_index_token(idx),
+                Pubkey::new_unique(),
+                TokenConfig {
+                    provider: PriceProviderKind::Pyth,
+                    decimals: 9,
+                    feed_id: Pubkey::new_from_array(Self::SOL_PYTH_FEED_ID),
+                    precision: 4,
+                    max_deviation_factor: Some(MAX_DEVIATION_FACTOR),
+                },
+            )
+        }));
         // self.create_token_accounts().await?;
         self.initialize_store().await?;
         self.initialize_token_map().await?;
@@ -378,6 +419,15 @@ impl Deployment {
         ])
         .await?;
         self.initialize_glv("fBTC", "USDG").await?;
+
+        // The markets for the many-markets GLV are created after the primary GLV
+        // is initialized, so that the primary GLV keeps collecting only the two
+        // original fBTC/USDG markets.
+        self.initialize_markets(
+            (1..=Self::MANY_MARKETS_GLV_MAX_MARKET_COUNT).map(Self::many_markets_glv_market),
+        )
+        .await?;
+        self.initialize_many_markets_glv().await?;
 
         self.initialize_alts().await?;
 
@@ -1154,6 +1204,21 @@ impl Deployment {
             );
         }
 
+        // Cover the many-markets GLV addresses so that its execute transactions
+        // stay within the packet size limit.
+        {
+            use anchor_spl::associated_token::get_associated_token_address;
+
+            let glv = self.client.find_glv_address(&self.many_markets_glv_token);
+            addresses.push(glv);
+            addresses.push(self.many_markets_glv_token);
+            for idx in 1..=Self::MANY_MARKETS_GLV_MAX_MARKET_COUNT {
+                let name = Self::many_markets_glv_market(idx);
+                let market_token = self.market_tokens[&name];
+                addresses.push(get_associated_token_address(&glv, &market_token));
+            }
+        }
+
         let signatures = self
             .client
             .extend_alt(&self.market_alt.key, addresses.clone(), None)?
@@ -1211,6 +1276,54 @@ impl Deployment {
                 tracing::error!(%err, %glv_token, "enabling GLV deposit failed, signatures: {signatures:#?}");
             }
         }
+
+        Ok(())
+    }
+
+    async fn initialize_many_markets_glv(&mut self) -> eyre::Result<()> {
+        let keeper = self.user_client(Self::DEFAULT_KEEPER)?;
+
+        // The GLV starts with only the first two markets; the GLV deposit
+        // market-count ramp test inserts the remaining candidate markets one
+        // by one.
+        let market_tokens = (1..=2)
+            .map(|idx| {
+                let name = Self::many_markets_glv_market(idx);
+                self.market_tokens
+                    .get(&name)
+                    .copied()
+                    .ok_or_eyre("market for the many-markets GLV is not initialized")
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+
+        let (rpc, glv_token) = keeper.initialize_glv(
+            &self.store,
+            Self::MANY_MARKETS_GLV_INDEX,
+            market_tokens.iter().copied(),
+        )?;
+        let signature = rpc.send_without_preflight().await?;
+        tracing::info!(%signature, %glv_token, "initialized the many-markets GLV token");
+        self.many_markets_glv_token = glv_token;
+
+        let mut txn = keeper.bundle();
+        for market_token in &market_tokens {
+            txn.push(keeper.toggle_glv_market_flag(
+                &self.store,
+                &glv_token,
+                market_token,
+                GlvMarketFlag::IsDepositAllowed,
+                true,
+            ))?;
+        }
+        let signatures = txn
+            .build()?
+            .send_all(true)
+            .await
+            .map_err(|(signatures, err)| {
+                tracing::error!(%glv_token, "enabling many-markets GLV deposit failed, signatures: {signatures:#?}");
+                err
+            })?;
+        tracing::info!(%glv_token, "many-markets GLV deposit enabled, signatures: {signatures:#?}");
 
         Ok(())
     }
@@ -1412,7 +1525,9 @@ impl Deployment {
     }
 
     async fn fund_users(&self) -> eyre::Result<()> {
-        const LAMPORTS: u64 = 2_000_000_000;
+        // The keeper pays the rent for the candidate markets of the
+        // many-markets GLV, which does not fit in the previous budget of 2 SOL.
+        const LAMPORTS: u64 = 20_000_000_000;
 
         let client = self.client.store_program().rpc();
         let payer = self.client.payer();


### PR DESCRIPTION
## What

Adds a **many-markets GLV** (index 1) to the anchor test deployment with 40 candidate markets backed by synthetic index tokens (reusing the SOL Pyth feed, so the oracle side stays flat), plus a new test `glv_deposit_with_increasing_markets` that inserts markets into the GLV **one by one**, executing a GLV deposit at every count to find where execution breaks.

The primary 2-market GLV and the existing `glv_deposit` test are unchanged; the ramp uses its own GLV.

## Findings (localnet, pinned toolchain)

- GLV deposit execution succeeds at **every count from 2 to 25 markets**.
- It **fails at 26 markets** by exhausting the compute budget: `ExecuteGlvDeposit` consumes **949,265 CU of the 999,700 granted** at 25 markets, and each additional market costs ~35–40k CU in GLV valuation. At 26 the instruction gets only the transaction's remaining ~50k CU and dies mid-execution.
- Transaction size and account locks are not the binding constraint (the execute path uses v0 transactions with the market ALT).
- Extrapolation: raising the compute budget toward the 1.4M cap would buy roughly 10 more markets (~35); beyond that a single-transaction execution cannot value the GLV, well below the state-level cap of 96 markets.

The test does not fail when it finds the limit — it logs the last successful count and the error (visible with `GMSOL_TEST_LOG=error,anchor=info` and `EXTRA_CARGO_ARGS=--nocapture`).

## Supporting changes

- Test users are funded with 20 SOL (the keeper pays rent for the 40 candidate markets, which no longer fits in 2 SOL).
- The market ALT also covers the many-markets GLV addresses (GLV, GLV token, per-market vault ATAs).
- `RUST_LOG` is scoped to the test process inside the Anchor.toml test script: exporting it in the environment reaches the spawned `solana-test-validator` and breaks its startup (set `GMSOL_TEST_LOG` instead).

## Verification

- `cargo check` clean; GLV test group green (6/6) including the reverted original `glv_deposit`.
- Full suite run in progress at time of writing; the 24-market variant of this setup was fully green (39 passed + the 2 pre-existing flaky tests passing on isolated retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)