### PR TITLE
feat(model): add builder fees to the position fee pipeline

### DIFF
--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -3,7 +3,7 @@ use num_traits::{CheckedAdd, CheckedDiv, CheckedSub, Zero};
 use crate::{
     market::{PerpMarket, PerpMarketExt, SwapMarketMutExt},
     num::{MulDiv, Unsigned},
-    params::fee::PositionFees,
+    params::fee::{BuilderFees, PositionFees},
     pool::delta::PriceImpact,
     position::{
         CollateralDelta, Position, PositionExt, PositionMut, PositionMutExt, PositionStateExt,
@@ -34,6 +34,7 @@ pub struct DecreasePosition<P: Position<DECIMALS>, const DECIMALS: u8> {
     params: DecreasePositionParams<P::Num>,
     withdrawable_collateral_amount: P::Num,
     size_delta_usd: P::Num,
+    builder_fee_factor: Option<P::Num>,
 }
 
 /// Swap Type for the decrease position action.
@@ -209,12 +210,19 @@ where
                 .min(position.collateral_amount().clone()),
             size_delta_usd,
             position,
+            builder_fee_factor: None,
         })
     }
 
     /// Set the swap type.
     pub fn set_swap(mut self, kind: DecreasePositionSwapType) -> Self {
         self.params.swap = kind;
+        self
+    }
+
+    /// Set the builder fee factor.
+    pub fn with_builder_fee_factor(mut self, factor: Option<P::Num>) -> Self {
+        self.builder_fee_factor = factor;
         self
     }
 
@@ -384,6 +392,16 @@ where
             price_impact.balance_change,
             self.params.is_liquidation_order(),
         )?;
+
+        if let Some(factor) = &self.builder_fee_factor {
+            fees = fees.set_builder_fees(BuilderFees::try_new(
+                self.params
+                    .prices
+                    .collateral_token_price(is_output_token_long),
+                &self.size_delta_usd,
+                factor,
+            )?);
+        }
 
         let remaining_collateral_amount = self.position.collateral_amount().clone();
 

--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -836,4 +836,145 @@ mod tests {
         println!("{market:#?}");
         Ok(())
     }
+
+    #[test]
+    fn builder_fee_charged_on_decrease() -> crate::Result<()> {
+        const SIZE_DELTA_USD: u64 = 4_000_000_000;
+        const FACTOR: u64 = 5_000_000; // 0.5%
+        const COLLATERAL_PRICE: u64 = 125;
+
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 1_000_000_000, prices)?.execute()?;
+        let mut position = TestPosition::long(true);
+        let _ = position
+            .ops(&mut market)
+            .increase(
+                Prices::new_for_test(123, 123, 1),
+                100_000_000,
+                8_000_000_000,
+                None,
+            )?
+            .execute()?;
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .decrease(
+                    Prices::new_for_test(125, 125, 1),
+                    SIZE_DELTA_USD,
+                    None,
+                    50_000_000,
+                    Default::default(),
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        let baseline = run(None)?;
+        let report = run(Some(FACTOR))?;
+
+        assert!(baseline.fees().builder_fees().fee_value().is_zero());
+        assert!(baseline.fees().builder_fees().fee_amount().is_zero());
+
+        // Computation parity with the order fee: value from the size delta
+        // with the factor applied, amount converted with the min collateral
+        // token price, rounding down.
+        let expected_value =
+            crate::utils::apply_factor::<u64, 9>(&SIZE_DELTA_USD, &FACTOR).unwrap();
+        let expected_amount = expected_value / COLLATERAL_PRICE;
+        assert!(!expected_amount.is_zero());
+        let builder_fees = report.fees().builder_fees();
+        assert_eq!(*builder_fees.fee_value(), expected_value);
+        assert_eq!(*builder_fees.fee_amount(), expected_amount);
+
+        // The order fee is unaffected by the builder fee.
+        assert_eq!(
+            baseline.fees().order_fees().fee_value(),
+            report.fees().order_fees().fee_value()
+        );
+
+        // The builder fee is paid at the order-fee rung, from the output:
+        // the output amount is reduced by exactly the builder fee amount.
+        assert_eq!(
+            *baseline.output_amount() - expected_amount,
+            *report.output_amount()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn builder_fee_cancelled_with_order_fee_on_shortfall() -> crate::Result<()> {
+        // Use a position with short-token collateral and long-token profit:
+        // fees must be paid in the collateral (output) token, and a builder
+        // fee exceeding the remaining collateral forces a partial payment
+        // from the secondary output, which cancels the fees entirely (the
+        // paid amount is credited to the pool instead) — the same semantics
+        // as an order-fee shortfall.
+        const SIZE_DELTA_USD: u64 = 8_000_000_000;
+        const FACTOR: u64 = 400_000_000; // 40%
+
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 6_000_000_000, prices)?.execute()?;
+        let mut position = TestPosition::long(false);
+        let _ = position
+            .ops(&mut market)
+            .increase(prices, 3_000_000_000, SIZE_DELTA_USD, None)?
+            .execute()?;
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .decrease(
+                    Prices::new_for_test(240, 240, 1),
+                    SIZE_DELTA_USD,
+                    None,
+                    0,
+                    Default::default(),
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        // Without the builder fee, the order fee is payable and charged.
+        let baseline = run(None)?;
+        assert!(!baseline.fees().order_fees().fee_value().is_zero());
+        assert!(!baseline
+            .fees()
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_pool()
+            .is_zero());
+
+        // With the oversized builder fee, the full close still executes, but
+        // both the order fee and the builder fee are cancelled.
+        let report = run(Some(FACTOR))?;
+        assert!(report.should_remove());
+        assert!(report.insolvent_close_step().is_none());
+        let fees = report.fees();
+        assert!(fees.builder_fees().fee_value().is_zero());
+        assert!(fees.builder_fees().fee_amount().is_zero());
+        assert!(fees.order_fees().fee_value().is_zero());
+        assert!(fees
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_pool()
+            .is_zero());
+        assert!(fees
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_receiver()
+            .is_zero());
+        assert!(fees.paid_order_and_borrowing_fee_value().is_zero());
+
+        Ok(())
+    }
 }

--- a/crates/model/src/action/increase_position.rs
+++ b/crates/model/src/action/increase_position.rs
@@ -610,4 +610,131 @@ mod tests {
         println!("{position:#?}");
         Ok(())
     }
+
+    fn market_for_builder_fee_tests() -> crate::Result<TestMarket<u64, 9>> {
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 1_000_000_000, prices)?.execute()?;
+        Ok(market)
+    }
+
+    #[test]
+    fn builder_fee_zero_factor_is_identity() -> crate::Result<()> {
+        let market = market_for_builder_fee_tests()?;
+        let position = TestPosition::long(true);
+
+        let run = |factor: Option<u64>| -> crate::Result<(String, String, String)> {
+            let mut market = market.clone();
+            let mut position = position;
+            let report = position
+                .ops(&mut market)
+                .increase(
+                    Prices::new_for_test(123, 123, 1),
+                    100_000_000,
+                    8_000_000_000,
+                    None,
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()?;
+            Ok((
+                format!("{report:?}"),
+                format!("{market:?}"),
+                format!("{position:?}"),
+            ))
+        };
+
+        let baseline = run(None)?;
+        let with_zero_factor = run(Some(0))?;
+        assert_eq!(baseline, with_zero_factor);
+        Ok(())
+    }
+
+    #[test]
+    fn builder_fee_charged_on_increase() -> crate::Result<()> {
+        const SIZE_DELTA_USD: u64 = 8_000_000_000;
+        const FACTOR: u64 = 5_000_000; // 0.5%
+        const COLLATERAL_PRICE: u64 = 123;
+
+        let market = market_for_builder_fee_tests()?;
+        let position = TestPosition::long(true);
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .increase(
+                    Prices::new_for_test(123, 123, 1),
+                    100_000_000,
+                    SIZE_DELTA_USD,
+                    None,
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        let baseline = run(None)?;
+        let report = run(Some(FACTOR))?;
+
+        assert!(baseline.fees().builder_fees().fee_value().is_zero());
+        assert!(baseline.fees().builder_fees().fee_amount().is_zero());
+
+        // The fee value is the size delta with the factor applied, and the
+        // amount is converted with the min collateral token price, rounding
+        // down, in parity with the order fee computation.
+        let expected_value =
+            crate::utils::apply_factor::<u64, 9>(&SIZE_DELTA_USD, &FACTOR).unwrap();
+        let expected_amount = expected_value / COLLATERAL_PRICE;
+        assert!(!expected_amount.is_zero());
+        let builder_fees = report.fees().builder_fees();
+        assert_eq!(*builder_fees.fee_value(), expected_value);
+        assert_eq!(*builder_fees.fee_amount(), expected_amount);
+
+        // The order fee is unaffected by the builder fee.
+        assert_eq!(
+            baseline.fees().order_fees().fee_value(),
+            report.fees().order_fees().fee_value()
+        );
+        assert_eq!(
+            baseline
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_pool(),
+            report
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_pool()
+        );
+        assert_eq!(
+            baseline
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_receiver(),
+            report
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_receiver()
+        );
+
+        // The builder fee does not mint GT: the paid order and borrowing fee
+        // value must be unchanged.
+        assert_eq!(
+            baseline.fees().paid_order_and_borrowing_fee_value(),
+            report.fees().paid_order_and_borrowing_fee_value()
+        );
+
+        // The collateral added to the position is reduced by exactly the
+        // builder fee amount.
+        assert_eq!(
+            *baseline.collateral_delta_amount() - *report.collateral_delta_amount(),
+            expected_amount as i64
+        );
+
+        Ok(())
+    }
 }

--- a/crates/model/src/action/increase_position.rs
+++ b/crates/model/src/action/increase_position.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::{
     market::{BaseMarketExt, BaseMarketMutExt, PerpMarketExt, PositionImpactMarketMutExt},
     num::Unsigned,
-    params::fee::PositionFees,
+    params::fee::{BuilderFees, PositionFees},
     pool::delta::PriceImpact,
     position::{CollateralDelta, Position, PositionExt},
     price::{Price, Prices},
@@ -18,6 +18,7 @@ use super::MarketAction;
 pub struct IncreasePosition<P: Position<DECIMALS>, const DECIMALS: u8> {
     position: P,
     params: IncreasePositionParams<P::Num>,
+    builder_fee_factor: Option<P::Num>,
 }
 
 /// Increase Position Params.
@@ -229,7 +230,14 @@ where
                 acceptable_price,
                 prices,
             },
+            builder_fee_factor: None,
         })
+    }
+
+    /// Set the builder fee factor.
+    pub fn with_builder_fee_factor(mut self, factor: Option<P::Num>) -> Self {
+        self.builder_fee_factor = factor;
+        self
     }
 
     fn initialize_position_if_empty(&mut self) -> crate::Result<()> {
@@ -370,12 +378,20 @@ where
 
         let mut collateral_delta_amount = self.params.collateral_increment_amount.to_signed()?;
 
-        let fees = self.position.position_fees(
+        let mut fees = self.position.position_fees(
             self.collateral_price(),
             &self.params.size_delta_usd,
             price_impact.balance_change,
             false,
         )?;
+
+        if let Some(factor) = &self.builder_fee_factor {
+            fees = fees.set_builder_fees(BuilderFees::try_new(
+                self.collateral_price(),
+                &self.params.size_delta_usd,
+                factor,
+            )?);
+        }
 
         collateral_delta_amount = collateral_delta_amount
             .checked_sub(&fees.total_cost_amount()?.to_signed()?)

--- a/crates/model/src/params/fee.rs
+++ b/crates/model/src/params/fee.rs
@@ -139,6 +139,7 @@ impl<T> FeeParams<T> {
             borrowing: Default::default(),
             funding: Default::default(),
             liquidation: Default::default(),
+            builder: Default::default(),
         })
     }
 }
@@ -673,6 +674,47 @@ impl<T> LiquidationFees<T> {
     }
 }
 
+/// Builder Fees.
+///
+/// Unlike other fees, the entire amount is paid to the builder, so there is
+/// no pool / receiver split.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor-lang",
+    derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)
+)]
+#[derive(Debug, Clone, Copy)]
+pub struct BuilderFees<T> {
+    fee_value: T,
+    fee_amount: T,
+}
+
+#[cfg(feature = "gmsol-utils")]
+impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for BuilderFees<T> {
+    const INIT_SPACE: usize = 2 * T::INIT_SPACE;
+}
+
+impl<T> BuilderFees<T> {
+    /// Get builder fee amount.
+    pub fn fee_amount(&self) -> &T {
+        &self.fee_amount
+    }
+
+    /// Get builder fee value.
+    pub fn fee_value(&self) -> &T {
+        &self.fee_value
+    }
+}
+
+impl<T: Zero> Default for BuilderFees<T> {
+    fn default() -> Self {
+        Self {
+            fee_value: Zero::zero(),
+            fee_amount: Zero::zero(),
+        }
+    }
+}
+
 /// Position Fees.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -686,6 +728,7 @@ pub struct PositionFees<T> {
     borrowing: BorrowingFees<T>,
     funding: FundingFees<T>,
     liquidation: Option<LiquidationFees<T>>,
+    builder: BuilderFees<T>,
 }
 
 #[cfg(feature = "gmsol-utils")]
@@ -695,7 +738,8 @@ impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for PositionFees<T> {
         + BorrowingFees::<T>::INIT_SPACE
         + FundingFees::<T>::INIT_SPACE
         + 1
-        + LiquidationFees::<T>::INIT_SPACE;
+        + LiquidationFees::<T>::INIT_SPACE
+        + BuilderFees::<T>::INIT_SPACE;
 }
 
 impl<T> PositionFees<T> {
@@ -766,6 +810,11 @@ impl<T> PositionFees<T> {
         self.liquidation.as_ref()
     }
 
+    /// Get builder fees.
+    pub fn builder_fees(&self) -> &BuilderFees<T> {
+        &self.builder
+    }
+
     /// Get total cost amount in collateral tokens.
     pub fn total_cost_amount(&self) -> crate::Result<T>
     where
@@ -814,6 +863,7 @@ impl<T> PositionFees<T> {
         self.order = Default::default();
         self.borrowing = BorrowingFees::default();
         self.liquidation = None;
+        self.builder = Default::default();
     }
 
     /// Set borrowing fees.
@@ -865,6 +915,7 @@ impl<T: Zero> Default for PositionFees<T> {
             borrowing: Default::default(),
             funding: Default::default(),
             liquidation: None,
+            builder: Default::default(),
         }
     }
 }

--- a/crates/model/src/params/fee.rs
+++ b/crates/model/src/params/fee.rs
@@ -695,6 +695,31 @@ impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for BuilderFees<T> {
 }
 
 impl<T> BuilderFees<T> {
+    /// Compute builder fees for the given size delta with the given factor.
+    pub(crate) fn try_new<const DECIMALS: u8>(
+        collateral_token_price: &Price<T>,
+        size_delta_usd: &T,
+        factor: &T,
+    ) -> crate::Result<Self>
+    where
+        T: FixedPointOps<DECIMALS>,
+    {
+        if collateral_token_price.has_zero() {
+            return Err(crate::Error::InvalidPrices);
+        }
+
+        let fee_value = utils::apply_factor(size_delta_usd, factor)
+            .ok_or(crate::Error::Computation("calculating builder fee value"))?;
+        let fee_amount = fee_value
+            .checked_div(collateral_token_price.pick_price(false))
+            .ok_or(crate::Error::Computation("calculating builder fee amount"))?;
+
+        Ok(Self {
+            fee_value,
+            fee_amount,
+        })
+    }
+
     /// Get builder fee amount.
     pub fn fee_amount(&self) -> &T {
         &self.fee_amount
@@ -842,6 +867,7 @@ impl<T> PositionFees<T> {
                     Some(acc)
                 }
             })
+            .and_then(|acc| acc.checked_add(self.builder.fee_amount()))
             .ok_or(crate::Error::Computation(
                 "overflow while calculating total cost excluding funding",
             ))
@@ -897,6 +923,12 @@ impl<T> PositionFees<T> {
     /// Set funding fees.
     pub fn set_funding_fees(mut self, fees: FundingFees<T>) -> Self {
         self.funding = fees;
+        self
+    }
+
+    /// Set builder fees.
+    pub fn set_builder_fees(mut self, fees: BuilderFees<T>) -> Self {
+        self.builder = fees;
         self
     }
 


### PR DESCRIPTION
Implements the pure-math layer of **ADR-1 (Order Builder Fee)**: a transaction builder (UI/aggregator) may charge users an extra fee on Orders, computed from the order's size delta and charged from collateral alongside the existing order fee. This is PR 1 of the builder-fee stack and touches only `gmsol-model` — no Solana types, no state, no instructions. **The change is inert**: the factor is `Option`-al and nothing sets it yet, so behavior is unchanged until the store program threads a factor in (a later PR in the stack).

## What this adds

- `BuilderFees<T>` (`params/fee.rs`): value/amount pair for the builder fee. Unlike `OrderFees`, there is **no pool/receiver split** — the entire amount belongs to the builder. It is deliberately *not* part of `FeeParams`: the factor is a per-order runtime input (checkpointed on the order at set time), not market configuration.
- `PositionFees<T>` gains a `builder` component with accessors, wired into `total_cost_excluding_funding()` and `clear_fees_excluding_funding()`.
- `IncreasePosition` / `DecreasePosition` gain `with_builder_fee_factor(Option<Num>)`; when a factor is present, `process_collateral` computes and attaches the builder fees.

## Fee semantics 

- **Formula**: `fee_value = apply_factor(size_delta_usd, factor)`, mirroring the order fee. The collateral amount is `fee_value / collateral_price.min` (`pick_price(false)`, rounding down); zero prices are rejected.
- **`None` vs zero factor**: `None` (default) means "no builder" and is byte-identical to current behavior. An explicit zero factor is a charged no-op (fee of zero) — tested as an identity on the full report.
- **Payment priority and cancellation are inherited, not reimplemented.** By adding the builder amount to `total_cost_excluding_funding()`, the increase path deducts it from collateral together with the order fee, and the decrease path pays it through the existing `pay_for_cost` ladder at order-fee priority. On an insolvent close / shortfall, the existing `clear_fees_excluding_funding()` cancels it exactly like the order fee. `collateral_processor.rs` is untouched.

## Compatibility note (same-release requirement)

`PositionFees` is borsh-serialized inside the trade-event reports (`PositionIncreased` / decreased). The new field is appended last, so the serialized prefix is unchanged, but **decoders must be updated in the same release** — the IDL regeneration and SDK/decode updates land in the later PRs of this stack.

## Tests

- `builder_fee_zero_factor_is_identity` — zero factor leaves the full increase report unchanged.
- `builder_fee_charged_on_increase` — fee computed and deducted from collateral on increase.
- `builder_fee_charged_on_decrease` — fee paid through the decrease cost ladder.
- `builder_fee_cancelled_with_order_fee_on_shortfall` — on shortfall the builder fee is cancelled together with the order fee.
