### PR TITLE
feat(store): add builder fee state, config, and feature fla

### DIFF
--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -3,7 +3,7 @@ use num_traits::{CheckedAdd, CheckedDiv, CheckedSub, Zero};
 use crate::{
     market::{PerpMarket, PerpMarketExt, SwapMarketMutExt},
     num::{MulDiv, Unsigned},
-    params::fee::PositionFees,
+    params::fee::{BuilderFees, PositionFees},
     pool::delta::PriceImpact,
     position::{
         CollateralDelta, Position, PositionExt, PositionMut, PositionMutExt, PositionStateExt,
@@ -34,6 +34,7 @@ pub struct DecreasePosition<P: Position<DECIMALS>, const DECIMALS: u8> {
     params: DecreasePositionParams<P::Num>,
     withdrawable_collateral_amount: P::Num,
     size_delta_usd: P::Num,
+    builder_fee_factor: Option<P::Num>,
 }
 
 /// Swap Type for the decrease position action.
@@ -209,12 +210,19 @@ where
                 .min(position.collateral_amount().clone()),
             size_delta_usd,
             position,
+            builder_fee_factor: None,
         })
     }
 
     /// Set the swap type.
     pub fn set_swap(mut self, kind: DecreasePositionSwapType) -> Self {
         self.params.swap = kind;
+        self
+    }
+
+    /// Set the builder fee factor.
+    pub fn with_builder_fee_factor(mut self, factor: Option<P::Num>) -> Self {
+        self.builder_fee_factor = factor;
         self
     }
 
@@ -384,6 +392,16 @@ where
             price_impact.balance_change,
             self.params.is_liquidation_order(),
         )?;
+
+        if let Some(factor) = &self.builder_fee_factor {
+            fees = fees.set_builder_fees(BuilderFees::try_new(
+                self.params
+                    .prices
+                    .collateral_token_price(is_output_token_long),
+                &self.size_delta_usd,
+                factor,
+            )?);
+        }
 
         let remaining_collateral_amount = self.position.collateral_amount().clone();
 

--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -836,4 +836,145 @@ mod tests {
         println!("{market:#?}");
         Ok(())
     }
+
+    #[test]
+    fn builder_fee_charged_on_decrease() -> crate::Result<()> {
+        const SIZE_DELTA_USD: u64 = 4_000_000_000;
+        const FACTOR: u64 = 5_000_000; // 0.5%
+        const COLLATERAL_PRICE: u64 = 125;
+
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 1_000_000_000, prices)?.execute()?;
+        let mut position = TestPosition::long(true);
+        let _ = position
+            .ops(&mut market)
+            .increase(
+                Prices::new_for_test(123, 123, 1),
+                100_000_000,
+                8_000_000_000,
+                None,
+            )?
+            .execute()?;
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .decrease(
+                    Prices::new_for_test(125, 125, 1),
+                    SIZE_DELTA_USD,
+                    None,
+                    50_000_000,
+                    Default::default(),
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        let baseline = run(None)?;
+        let report = run(Some(FACTOR))?;
+
+        assert!(baseline.fees().builder_fees().fee_value().is_zero());
+        assert!(baseline.fees().builder_fees().fee_amount().is_zero());
+
+        // Computation parity with the order fee: value from the size delta
+        // with the factor applied, amount converted with the min collateral
+        // token price, rounding down.
+        let expected_value =
+            crate::utils::apply_factor::<u64, 9>(&SIZE_DELTA_USD, &FACTOR).unwrap();
+        let expected_amount = expected_value / COLLATERAL_PRICE;
+        assert!(!expected_amount.is_zero());
+        let builder_fees = report.fees().builder_fees();
+        assert_eq!(*builder_fees.fee_value(), expected_value);
+        assert_eq!(*builder_fees.fee_amount(), expected_amount);
+
+        // The order fee is unaffected by the builder fee.
+        assert_eq!(
+            baseline.fees().order_fees().fee_value(),
+            report.fees().order_fees().fee_value()
+        );
+
+        // The builder fee is paid at the order-fee rung, from the output:
+        // the output amount is reduced by exactly the builder fee amount.
+        assert_eq!(
+            *baseline.output_amount() - expected_amount,
+            *report.output_amount()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn builder_fee_cancelled_with_order_fee_on_shortfall() -> crate::Result<()> {
+        // Use a position with short-token collateral and long-token profit:
+        // fees must be paid in the collateral (output) token, and a builder
+        // fee exceeding the remaining collateral forces a partial payment
+        // from the secondary output, which cancels the fees entirely (the
+        // paid amount is credited to the pool instead) — the same semantics
+        // as an order-fee shortfall.
+        const SIZE_DELTA_USD: u64 = 8_000_000_000;
+        const FACTOR: u64 = 400_000_000; // 40%
+
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 6_000_000_000, prices)?.execute()?;
+        let mut position = TestPosition::long(false);
+        let _ = position
+            .ops(&mut market)
+            .increase(prices, 3_000_000_000, SIZE_DELTA_USD, None)?
+            .execute()?;
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .decrease(
+                    Prices::new_for_test(240, 240, 1),
+                    SIZE_DELTA_USD,
+                    None,
+                    0,
+                    Default::default(),
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        // Without the builder fee, the order fee is payable and charged.
+        let baseline = run(None)?;
+        assert!(!baseline.fees().order_fees().fee_value().is_zero());
+        assert!(!baseline
+            .fees()
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_pool()
+            .is_zero());
+
+        // With the oversized builder fee, the full close still executes, but
+        // both the order fee and the builder fee are cancelled.
+        let report = run(Some(FACTOR))?;
+        assert!(report.should_remove());
+        assert!(report.insolvent_close_step().is_none());
+        let fees = report.fees();
+        assert!(fees.builder_fees().fee_value().is_zero());
+        assert!(fees.builder_fees().fee_amount().is_zero());
+        assert!(fees.order_fees().fee_value().is_zero());
+        assert!(fees
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_pool()
+            .is_zero());
+        assert!(fees
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_receiver()
+            .is_zero());
+        assert!(fees.paid_order_and_borrowing_fee_value().is_zero());
+
+        Ok(())
+    }
 }

--- a/crates/model/src/action/increase_position.rs
+++ b/crates/model/src/action/increase_position.rs
@@ -610,4 +610,131 @@ mod tests {
         println!("{position:#?}");
         Ok(())
     }
+
+    fn market_for_builder_fee_tests() -> crate::Result<TestMarket<u64, 9>> {
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 1_000_000_000, prices)?.execute()?;
+        Ok(market)
+    }
+
+    #[test]
+    fn builder_fee_zero_factor_is_identity() -> crate::Result<()> {
+        let market = market_for_builder_fee_tests()?;
+        let position = TestPosition::long(true);
+
+        let run = |factor: Option<u64>| -> crate::Result<(String, String, String)> {
+            let mut market = market.clone();
+            let mut position = position;
+            let report = position
+                .ops(&mut market)
+                .increase(
+                    Prices::new_for_test(123, 123, 1),
+                    100_000_000,
+                    8_000_000_000,
+                    None,
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()?;
+            Ok((
+                format!("{report:?}"),
+                format!("{market:?}"),
+                format!("{position:?}"),
+            ))
+        };
+
+        let baseline = run(None)?;
+        let with_zero_factor = run(Some(0))?;
+        assert_eq!(baseline, with_zero_factor);
+        Ok(())
+    }
+
+    #[test]
+    fn builder_fee_charged_on_increase() -> crate::Result<()> {
+        const SIZE_DELTA_USD: u64 = 8_000_000_000;
+        const FACTOR: u64 = 5_000_000; // 0.5%
+        const COLLATERAL_PRICE: u64 = 123;
+
+        let market = market_for_builder_fee_tests()?;
+        let position = TestPosition::long(true);
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .increase(
+                    Prices::new_for_test(123, 123, 1),
+                    100_000_000,
+                    SIZE_DELTA_USD,
+                    None,
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        let baseline = run(None)?;
+        let report = run(Some(FACTOR))?;
+
+        assert!(baseline.fees().builder_fees().fee_value().is_zero());
+        assert!(baseline.fees().builder_fees().fee_amount().is_zero());
+
+        // The fee value is the size delta with the factor applied, and the
+        // amount is converted with the min collateral token price, rounding
+        // down, in parity with the order fee computation.
+        let expected_value =
+            crate::utils::apply_factor::<u64, 9>(&SIZE_DELTA_USD, &FACTOR).unwrap();
+        let expected_amount = expected_value / COLLATERAL_PRICE;
+        assert!(!expected_amount.is_zero());
+        let builder_fees = report.fees().builder_fees();
+        assert_eq!(*builder_fees.fee_value(), expected_value);
+        assert_eq!(*builder_fees.fee_amount(), expected_amount);
+
+        // The order fee is unaffected by the builder fee.
+        assert_eq!(
+            baseline.fees().order_fees().fee_value(),
+            report.fees().order_fees().fee_value()
+        );
+        assert_eq!(
+            baseline
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_pool(),
+            report
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_pool()
+        );
+        assert_eq!(
+            baseline
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_receiver(),
+            report
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_receiver()
+        );
+
+        // The builder fee does not mint GT: the paid order and borrowing fee
+        // value must be unchanged.
+        assert_eq!(
+            baseline.fees().paid_order_and_borrowing_fee_value(),
+            report.fees().paid_order_and_borrowing_fee_value()
+        );
+
+        // The collateral added to the position is reduced by exactly the
+        // builder fee amount.
+        assert_eq!(
+            *baseline.collateral_delta_amount() - *report.collateral_delta_amount(),
+            expected_amount as i64
+        );
+
+        Ok(())
+    }
 }

--- a/crates/model/src/action/increase_position.rs
+++ b/crates/model/src/action/increase_position.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::{
     market::{BaseMarketExt, BaseMarketMutExt, PerpMarketExt, PositionImpactMarketMutExt},
     num::Unsigned,
-    params::fee::PositionFees,
+    params::fee::{BuilderFees, PositionFees},
     pool::delta::PriceImpact,
     position::{CollateralDelta, Position, PositionExt},
     price::{Price, Prices},
@@ -18,6 +18,7 @@ use super::MarketAction;
 pub struct IncreasePosition<P: Position<DECIMALS>, const DECIMALS: u8> {
     position: P,
     params: IncreasePositionParams<P::Num>,
+    builder_fee_factor: Option<P::Num>,
 }
 
 /// Increase Position Params.
@@ -229,7 +230,14 @@ where
                 acceptable_price,
                 prices,
             },
+            builder_fee_factor: None,
         })
+    }
+
+    /// Set the builder fee factor.
+    pub fn with_builder_fee_factor(mut self, factor: Option<P::Num>) -> Self {
+        self.builder_fee_factor = factor;
+        self
     }
 
     fn initialize_position_if_empty(&mut self) -> crate::Result<()> {
@@ -370,12 +378,20 @@ where
 
         let mut collateral_delta_amount = self.params.collateral_increment_amount.to_signed()?;
 
-        let fees = self.position.position_fees(
+        let mut fees = self.position.position_fees(
             self.collateral_price(),
             &self.params.size_delta_usd,
             price_impact.balance_change,
             false,
         )?;
+
+        if let Some(factor) = &self.builder_fee_factor {
+            fees = fees.set_builder_fees(BuilderFees::try_new(
+                self.collateral_price(),
+                &self.params.size_delta_usd,
+                factor,
+            )?);
+        }
 
         collateral_delta_amount = collateral_delta_amount
             .checked_sub(&fees.total_cost_amount()?.to_signed()?)

--- a/crates/model/src/params/fee.rs
+++ b/crates/model/src/params/fee.rs
@@ -139,6 +139,7 @@ impl<T> FeeParams<T> {
             borrowing: Default::default(),
             funding: Default::default(),
             liquidation: Default::default(),
+            builder: Default::default(),
         })
     }
 }
@@ -673,6 +674,47 @@ impl<T> LiquidationFees<T> {
     }
 }
 
+/// Builder Fees.
+///
+/// Unlike other fees, the entire amount is paid to the builder, so there is
+/// no pool / receiver split.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor-lang",
+    derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)
+)]
+#[derive(Debug, Clone, Copy)]
+pub struct BuilderFees<T> {
+    fee_value: T,
+    fee_amount: T,
+}
+
+#[cfg(feature = "gmsol-utils")]
+impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for BuilderFees<T> {
+    const INIT_SPACE: usize = 2 * T::INIT_SPACE;
+}
+
+impl<T> BuilderFees<T> {
+    /// Get builder fee amount.
+    pub fn fee_amount(&self) -> &T {
+        &self.fee_amount
+    }
+
+    /// Get builder fee value.
+    pub fn fee_value(&self) -> &T {
+        &self.fee_value
+    }
+}
+
+impl<T: Zero> Default for BuilderFees<T> {
+    fn default() -> Self {
+        Self {
+            fee_value: Zero::zero(),
+            fee_amount: Zero::zero(),
+        }
+    }
+}
+
 /// Position Fees.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -686,6 +728,7 @@ pub struct PositionFees<T> {
     borrowing: BorrowingFees<T>,
     funding: FundingFees<T>,
     liquidation: Option<LiquidationFees<T>>,
+    builder: BuilderFees<T>,
 }
 
 #[cfg(feature = "gmsol-utils")]
@@ -695,7 +738,8 @@ impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for PositionFees<T> {
         + BorrowingFees::<T>::INIT_SPACE
         + FundingFees::<T>::INIT_SPACE
         + 1
-        + LiquidationFees::<T>::INIT_SPACE;
+        + LiquidationFees::<T>::INIT_SPACE
+        + BuilderFees::<T>::INIT_SPACE;
 }
 
 impl<T> PositionFees<T> {
@@ -766,6 +810,11 @@ impl<T> PositionFees<T> {
         self.liquidation.as_ref()
     }
 
+    /// Get builder fees.
+    pub fn builder_fees(&self) -> &BuilderFees<T> {
+        &self.builder
+    }
+
     /// Get total cost amount in collateral tokens.
     pub fn total_cost_amount(&self) -> crate::Result<T>
     where
@@ -814,6 +863,7 @@ impl<T> PositionFees<T> {
         self.order = Default::default();
         self.borrowing = BorrowingFees::default();
         self.liquidation = None;
+        self.builder = Default::default();
     }
 
     /// Set borrowing fees.
@@ -865,6 +915,7 @@ impl<T: Zero> Default for PositionFees<T> {
             borrowing: Default::default(),
             funding: Default::default(),
             liquidation: None,
+            builder: Default::default(),
         }
     }
 }

--- a/crates/model/src/params/fee.rs
+++ b/crates/model/src/params/fee.rs
@@ -695,6 +695,31 @@ impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for BuilderFees<T> {
 }
 
 impl<T> BuilderFees<T> {
+    /// Compute builder fees for the given size delta with the given factor.
+    pub(crate) fn try_new<const DECIMALS: u8>(
+        collateral_token_price: &Price<T>,
+        size_delta_usd: &T,
+        factor: &T,
+    ) -> crate::Result<Self>
+    where
+        T: FixedPointOps<DECIMALS>,
+    {
+        if collateral_token_price.has_zero() {
+            return Err(crate::Error::InvalidPrices);
+        }
+
+        let fee_value = utils::apply_factor(size_delta_usd, factor)
+            .ok_or(crate::Error::Computation("calculating builder fee value"))?;
+        let fee_amount = fee_value
+            .checked_div(collateral_token_price.pick_price(false))
+            .ok_or(crate::Error::Computation("calculating builder fee amount"))?;
+
+        Ok(Self {
+            fee_value,
+            fee_amount,
+        })
+    }
+
     /// Get builder fee amount.
     pub fn fee_amount(&self) -> &T {
         &self.fee_amount
@@ -842,6 +867,7 @@ impl<T> PositionFees<T> {
                     Some(acc)
                 }
             })
+            .and_then(|acc| acc.checked_add(self.builder.fee_amount()))
             .ok_or(crate::Error::Computation(
                 "overflow while calculating total cost excluding funding",
             ))
@@ -897,6 +923,12 @@ impl<T> PositionFees<T> {
     /// Set funding fees.
     pub fn set_funding_fees(mut self, fees: FundingFees<T>) -> Self {
         self.funding = fees;
+        self
+    }
+
+    /// Set builder fees.
+    pub fn set_builder_fees(mut self, fees: BuilderFees<T>) -> Self {
+        self.builder = fees;
         self
     }
 

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -50,6 +50,8 @@ pub enum DomainDisabledFlag {
     GlvWithdrawal = 13,
     /// GLV shift.
     GlvShift = 14,
+    /// Builder fee.
+    BuilderFee = 15,
 }
 
 impl TryFrom<OrderKind> for DomainDisabledFlag {

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -146,6 +146,8 @@ pub enum FactorKey {
     OracleRefPriceDeviation,
     /// Order fee discount for referred user.
     OrderFeeDiscountForReferredUser,
+    /// Max builder fee factor.
+    MaxBuilderFeeFactor,
 }
 
 /// Address keys.

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -1,0 +1,62 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::Mint;
+
+use crate::{
+    states::{builder_fee::BuilderFeeTokenController, Seed, Store},
+    utils::internal,
+};
+
+use gmsol_utils::InitSpace;
+
+/// The accounts definition for
+/// [`initialize_builder_fee_token_controller`](crate::gmsol_store::initialize_builder_fee_token_controller).
+#[derive(Accounts)]
+pub struct InitializeBuilderFeeTokenController<'info> {
+    /// The caller.
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    /// Store.
+    pub store: AccountLoader<'info, Store>,
+    /// The token mint to initialize the controller for.
+    pub token_mint: InterfaceAccount<'info, Mint>,
+    /// The controller account to initialize.
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + BuilderFeeTokenController::INIT_SPACE,
+        seeds = [
+            BuilderFeeTokenController::SEED,
+            store.key().as_ref(),
+            token_mint.key().as_ref(),
+        ],
+        bump,
+    )]
+    pub controller: AccountLoader<'info, BuilderFeeTokenController>,
+    /// System program.
+    pub system_program: Program<'info, System>,
+}
+
+/// Initialize the per-token access control account for builder fees.
+///
+/// ## CHECK
+/// - Only MARKET_KEEPER can initialize the controller.
+pub(crate) fn unchecked_initialize_builder_fee_token_controller(
+    ctx: Context<InitializeBuilderFeeTokenController>,
+) -> Result<()> {
+    ctx.accounts.controller.load_init()?.init(
+        &ctx.accounts.store.key(),
+        &ctx.accounts.token_mint.key(),
+        ctx.bumps.controller,
+    );
+    Ok(())
+}
+
+impl<'info> internal::Authentication<'info> for InitializeBuilderFeeTokenController<'info> {
+    fn authority(&self) -> &Signer<'info> {
+        &self.authority
+    }
+
+    fn store(&self) -> &AccountLoader<'info, Store> {
+        &self.store
+    }
+}

--- a/programs/store/src/instructions/mod.rs
+++ b/programs/store/src/instructions/mod.rs
@@ -43,6 +43,10 @@ pub mod callback;
 /// Instructions for virtual inventories.
 pub mod virtual_inventory;
 
+/// Instructions for builder fees.
+pub mod builder_fee;
+
+pub use builder_fee::*;
 pub use callback::*;
 pub use config::*;
 pub use exchange::*;

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -127,6 +127,8 @@
 //!
 //! #### Instructions for token accounts
 //! - [`initialize_market_vault`]: Initialize the market vault for the given token.
+//! - [`initialize_builder_fee_token_controller`]: Initialize the per-token access control
+//!   account for builder fees.
 //! - [`use_claimable_account`]: Prepare a claimable account to receive tokens during the order execution.
 //! - [`close_empty_claimable_account`]: Close a empty claimable account.
 //! - [`prepare_associated_token_account`](gmsol_store::prepare_associated_token_account): Prepare an ATA.
@@ -1824,6 +1826,29 @@ pub mod gmsol_store {
     #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
     pub fn initialize_market_vault(ctx: Context<InitializeMarketVault>) -> Result<()> {
         instructions::unchecked_initialize_market_vault(ctx)
+    }
+
+    /// Initialize the per-token access control account for builder fees.
+    ///
+    /// Its existence is required before a builder fee denominated in the given
+    /// token can be set on an order. The account currently carries no behavior:
+    /// it is a placeholder intended to support future access control on builder
+    /// fee withdrawal (e.g. a withdrawal timelock).
+    ///
+    /// # Accounts
+    /// [*See the documentation for the accounts.*](InitializeBuilderFeeTokenController)
+    ///
+    /// # Errors
+    /// - The [`authority`](InitializeBuilderFeeTokenController::authority) must be a signer and have
+    ///   MARKET_KEEPER permissions in the store.
+    /// - The [`store`](InitializeBuilderFeeTokenController::store) must be an initialized store account.
+    /// - The [`controller`](InitializeBuilderFeeTokenController::controller) must be an uninitialized
+    ///   account and its address must match the PDA derived from the expected seeds.
+    #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
+    pub fn initialize_builder_fee_token_controller(
+        ctx: Context<InitializeBuilderFeeTokenController>,
+    ) -> Result<()> {
+        instructions::unchecked_initialize_builder_fee_token_controller(ctx)
     }
 
     /// Prepare a claimable account to receive tokens during order execution.

--- a/programs/store/src/states/builder_fee.rs
+++ b/programs/store/src/states/builder_fee.rs
@@ -1,0 +1,58 @@
+use anchor_lang::prelude::*;
+
+use super::Seed;
+
+/// Per-token access control account for builder fees.
+///
+/// One account exists per `(store, token_mint)` pair, and its existence is
+/// required before a builder fee denominated in that token can be set on an
+/// order.
+///
+/// This account is currently a placeholder and carries no behavior: it is
+/// intended to support future access control on builder fee withdrawal
+/// (e.g. a withdrawal timelock).
+#[account(zero_copy)]
+#[cfg_attr(feature = "debug", derive(derive_more::Debug))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BuilderFeeTokenController {
+    version: u8,
+    /// Bump seed.
+    pub(crate) bump: u8,
+    #[cfg_attr(feature = "debug", debug(skip))]
+    padding_0: [u8; 14],
+    /// The store.
+    pub(crate) store: Pubkey,
+    /// The token mint this controller is for.
+    pub(crate) token_mint: Pubkey,
+    #[cfg_attr(feature = "debug", debug(skip))]
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
+    reserved: [u8; 176],
+}
+
+static_assertions::const_assert_eq!(std::mem::size_of::<BuilderFeeTokenController>(), 256);
+
+impl BuilderFeeTokenController {
+    pub(crate) fn init(&mut self, store: &Pubkey, token_mint: &Pubkey, bump: u8) {
+        self.bump = bump;
+        self.store = *store;
+        self.token_mint = *token_mint;
+    }
+
+    /// Get the store.
+    pub fn store(&self) -> &Pubkey {
+        &self.store
+    }
+
+    /// Get the token mint this controller is for.
+    pub fn token_mint(&self) -> &Pubkey {
+        &self.token_mint
+    }
+}
+
+impl Seed for BuilderFeeTokenController {
+    const SEED: &'static [u8] = b"builder_fee_token_controller";
+}
+
+impl gmsol_utils::InitSpace for BuilderFeeTokenController {
+    const INIT_SPACE: usize = std::mem::size_of::<Self>();
+}

--- a/programs/store/src/states/mod.rs
+++ b/programs/store/src/states/mod.rs
@@ -46,6 +46,9 @@ pub mod gt;
 /// Definitions related to callback.
 pub mod callback;
 
+/// Definitions related to builder fees.
+pub mod builder_fee;
+
 /// Permission stores and related definitions.
 pub mod permissions;
 

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -325,9 +325,38 @@ pub struct Order {
     pub(crate) gt_reward: u64,
     #[cfg_attr(feature = "debug", debug(skip))]
     padding_1: [u8; 8],
+    /// The builder fee beneficiary (the builder's User Account address).
+    pub(crate) builder: Pubkey,
+    /// The checkpointed builder fee factor.
+    pub(crate) builder_fee_factor: u128,
+    /// The builder fee amount pending settlement, denominated in the
+    /// collateral token.
+    pub(crate) builder_fee_amount: u64,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 128],
+    reserved: [u8; 72],
+}
+
+// The builder fee fields are carved out of previously reserved bytes: the
+// total size and the offsets of all fields must remain unchanged.
+static_assertions::const_assert_eq!(std::mem::size_of::<Order>(), 2464);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, builder), 2336);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, builder_fee_factor), 2368);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, builder_fee_amount), 2384);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, reserved), 2392);
+
+impl Order {
+    pub fn builder(&self) -> Option<&Pubkey> {
+        crate::utils::pubkey::optional_address(&self.builder)
+    }
+
+    pub fn builder_fee_factor(&self) -> u128 {
+        self.builder_fee_factor
+    }
+
+    pub fn builder_fee_amount(&self) -> u64 {
+        self.builder_fee_amount
+    }
 }
 
 impl Seed for Order {

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -619,8 +619,9 @@ impl Amounts {
 pub struct Factors {
     pub(crate) oracle_ref_price_deviation: Factor,
     pub(crate) order_fee_discount_for_referred_user: Factor,
+    pub(crate) max_builder_fee_factor: Factor,
     #[cfg_attr(feature = "debug", debug(skip))]
-    reserved: [Factor; 64],
+    reserved: [Factor; 63],
 }
 
 impl Factors {
@@ -635,6 +636,7 @@ impl Factors {
             FactorKey::OrderFeeDiscountForReferredUser => {
                 &self.order_fee_discount_for_referred_user
             }
+            FactorKey::MaxBuilderFeeFactor => &self.max_builder_fee_factor,
             _ => return None,
         };
         Some(value)
@@ -647,6 +649,7 @@ impl Factors {
             FactorKey::OrderFeeDiscountForReferredUser => {
                 &mut self.order_fee_discount_for_referred_user
             }
+            FactorKey::MaxBuilderFeeFactor => &mut self.max_builder_fee_factor,
             _ => return None,
         };
         Some(value)

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -397,6 +397,30 @@ impl Store {
         }
     }
 
+    /// Is the builder fee feature enabled for the given action.
+    /// [`toggle_feature`](crate::gmsol_store::toggle_feature).
+    pub fn is_builder_fee_feature_enabled(&self, action: ActionDisabledFlag) -> bool {
+        matches!(
+            self.get_feature_disabled(DomainDisabledFlag::BuilderFee, action),
+            Some(false)
+        )
+    }
+
+    /// Validate whether the builder fee feature is enabled for the given
+    /// action. See [`is_builder_fee_feature_enabled`](Self::is_builder_fee_feature_enabled)
+    /// for the default behavior.
+    pub fn validate_builder_fee_feature_enabled(&self, action: ActionDisabledFlag) -> Result<()> {
+        if self.is_builder_fee_feature_enabled(action) {
+            Ok(())
+        } else {
+            msg!(
+                "Feature `{}` is not enabled (builder fee features are disabled by default)",
+                display_feature(DomainDisabledFlag::BuilderFee, action)
+            );
+            err!(CoreError::FeatureDisabled)
+        }
+    }
+
     /// Set features disabled.
     pub(crate) fn set_feature_disabled(
         &mut self,

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -31,9 +31,24 @@ pub struct UserHeader {
     pub(crate) referral: Referral,
     /// GT State.
     pub(crate) gt: UserGtState,
+    /// The builder fee factor advertised by this user as a builder.
+    pub(crate) builder_fee_factor: u128,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 128],
+    reserved: [u8; 112],
+}
+
+// The builder fee factor is carved out of previously reserved bytes: the
+// total size and the offsets of all fields must remain unchanged.
+static_assertions::const_assert_eq!(std::mem::size_of::<UserHeader>(), 512);
+static_assertions::const_assert_eq!(std::mem::offset_of!(UserHeader, builder_fee_factor), 384);
+static_assertions::const_assert_eq!(std::mem::offset_of!(UserHeader, reserved), 400);
+
+impl UserHeader {
+    /// Get the builder fee factor advertised by this user as a builder.
+    pub fn builder_fee_factor(&self) -> u128 {
+        self.builder_fee_factor
+    }
 }
 
 gmsol_utils::flags!(UserFlag, MAX_USER_FLAGS, u8);


### PR DESCRIPTION

State layer of **ADR-1 (Order Builder Fee)**, PR 2 of the stack (on top of the `gmsol-model` fee pipeline from PR 1). This PR adds every account field, config key, and flag the feature needs — and nothing that uses them: no instruction reads or writes any of these yet, and the feature flag is **disabled by default**, so the store's behavior is unchanged.

## What this adds

- **`MaxBuilderFeeFactor` factor key** (`gmsol-utils`) and the backing `max_builder_fee_factor` slot in the store's `Factors` (carved from `reserved`, 64 → 63). A store-level cap on the factor a builder may charge, runtime-updatable through the existing CONFIG_KEEPER factor-amendment path — no new instruction.
- **`Order` fields**: `builder` (the builder's User Account address; `Pubkey::default()` encodes "no builder" via `optional_address`), `builder_fee_factor: u128` (the factor checkpointed at set time — the order is charged what was advertised when the user signed, even if the builder later changes their factor), and `builder_fee_amount: u64` (written on successful execution, denominated in the collateral token, zeroed on settlement).
- **`UserHeader.builder_fee_factor: u128`**: the factor a builder advertises on their User Account (permissionless set lands in a later PR).
- **`BuilderFeeTokenController`**: a 256-byte per-token placeholder account (PDA of `"builder_fee_token_controller"` + store + mint) with a MARKET_KEEPER-gated init instruction. It carries **no behavior yet** — it exists so future withdrawal access control (e.g. a timelock) can land without changing any instruction's account layout.
- **`DomainDisabledFlag::BuilderFee` (= 15)** plus `is_builder_fee_feature_enabled` / `validate_builder_fee_feature_enabled` on `Store`.

## Layout safety 

All new fields are carved out of existing `reserved` byte ranges, so **account sizes and every existing field offset are unchanged — no migration**. Existing accounts read the new bytes as zeros, which decode exactly as the intended defaults: no builder, zero factor, zero pending amount. Each touched struct is locked by `static_assertions::const_assert_eq!` on `size_of` and the new `offset_of`s (`Order` = 2464, `UserHeader` = 512, controller = 256), so any accidental layout drift fails the build. Carve points are 16-byte aligned, so the `u128` fields need no padding.

## Feature-flag semantics 

The feature system stores *disabled* flags, meaning an untouched flag reads as "enabled" — the wrong default for a brand-new feature. The builder fee flag therefore inverts the check: `is_builder_fee_feature_enabled` returns true **only when the flag has been explicitly set to `Some(false)`** (i.e. ops must deliberately enable it via `toggle_feature`). This is what keeps the instruction PRs (settlement, set, execution) inert on deployment until ops flips the flag.

## Compatibility note

`Order`, `UserHeader`, and `Factors` change shape in the IDL; the regenerated IDL and SDK updates ride with the later PRs of this stack (same release).


