### PR TITLE
feat(store): add builder fee settlement and claim

### DIFF
--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -3,7 +3,7 @@ use num_traits::{CheckedAdd, CheckedDiv, CheckedSub, Zero};
 use crate::{
     market::{PerpMarket, PerpMarketExt, SwapMarketMutExt},
     num::{MulDiv, Unsigned},
-    params::fee::PositionFees,
+    params::fee::{BuilderFees, PositionFees},
     pool::delta::PriceImpact,
     position::{
         CollateralDelta, Position, PositionExt, PositionMut, PositionMutExt, PositionStateExt,
@@ -34,6 +34,7 @@ pub struct DecreasePosition<P: Position<DECIMALS>, const DECIMALS: u8> {
     params: DecreasePositionParams<P::Num>,
     withdrawable_collateral_amount: P::Num,
     size_delta_usd: P::Num,
+    builder_fee_factor: Option<P::Num>,
 }
 
 /// Swap Type for the decrease position action.
@@ -209,12 +210,19 @@ where
                 .min(position.collateral_amount().clone()),
             size_delta_usd,
             position,
+            builder_fee_factor: None,
         })
     }
 
     /// Set the swap type.
     pub fn set_swap(mut self, kind: DecreasePositionSwapType) -> Self {
         self.params.swap = kind;
+        self
+    }
+
+    /// Set the builder fee factor.
+    pub fn with_builder_fee_factor(mut self, factor: Option<P::Num>) -> Self {
+        self.builder_fee_factor = factor;
         self
     }
 
@@ -384,6 +392,16 @@ where
             price_impact.balance_change,
             self.params.is_liquidation_order(),
         )?;
+
+        if let Some(factor) = &self.builder_fee_factor {
+            fees = fees.set_builder_fees(BuilderFees::try_new(
+                self.params
+                    .prices
+                    .collateral_token_price(is_output_token_long),
+                &self.size_delta_usd,
+                factor,
+            )?);
+        }
 
         let remaining_collateral_amount = self.position.collateral_amount().clone();
 

--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -836,4 +836,145 @@ mod tests {
         println!("{market:#?}");
         Ok(())
     }
+
+    #[test]
+    fn builder_fee_charged_on_decrease() -> crate::Result<()> {
+        const SIZE_DELTA_USD: u64 = 4_000_000_000;
+        const FACTOR: u64 = 5_000_000; // 0.5%
+        const COLLATERAL_PRICE: u64 = 125;
+
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 1_000_000_000, prices)?.execute()?;
+        let mut position = TestPosition::long(true);
+        let _ = position
+            .ops(&mut market)
+            .increase(
+                Prices::new_for_test(123, 123, 1),
+                100_000_000,
+                8_000_000_000,
+                None,
+            )?
+            .execute()?;
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .decrease(
+                    Prices::new_for_test(125, 125, 1),
+                    SIZE_DELTA_USD,
+                    None,
+                    50_000_000,
+                    Default::default(),
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        let baseline = run(None)?;
+        let report = run(Some(FACTOR))?;
+
+        assert!(baseline.fees().builder_fees().fee_value().is_zero());
+        assert!(baseline.fees().builder_fees().fee_amount().is_zero());
+
+        // Computation parity with the order fee: value from the size delta
+        // with the factor applied, amount converted with the min collateral
+        // token price, rounding down.
+        let expected_value =
+            crate::utils::apply_factor::<u64, 9>(&SIZE_DELTA_USD, &FACTOR).unwrap();
+        let expected_amount = expected_value / COLLATERAL_PRICE;
+        assert!(!expected_amount.is_zero());
+        let builder_fees = report.fees().builder_fees();
+        assert_eq!(*builder_fees.fee_value(), expected_value);
+        assert_eq!(*builder_fees.fee_amount(), expected_amount);
+
+        // The order fee is unaffected by the builder fee.
+        assert_eq!(
+            baseline.fees().order_fees().fee_value(),
+            report.fees().order_fees().fee_value()
+        );
+
+        // The builder fee is paid at the order-fee rung, from the output:
+        // the output amount is reduced by exactly the builder fee amount.
+        assert_eq!(
+            *baseline.output_amount() - expected_amount,
+            *report.output_amount()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn builder_fee_cancelled_with_order_fee_on_shortfall() -> crate::Result<()> {
+        // Use a position with short-token collateral and long-token profit:
+        // fees must be paid in the collateral (output) token, and a builder
+        // fee exceeding the remaining collateral forces a partial payment
+        // from the secondary output, which cancels the fees entirely (the
+        // paid amount is credited to the pool instead) — the same semantics
+        // as an order-fee shortfall.
+        const SIZE_DELTA_USD: u64 = 8_000_000_000;
+        const FACTOR: u64 = 400_000_000; // 40%
+
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 6_000_000_000, prices)?.execute()?;
+        let mut position = TestPosition::long(false);
+        let _ = position
+            .ops(&mut market)
+            .increase(prices, 3_000_000_000, SIZE_DELTA_USD, None)?
+            .execute()?;
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .decrease(
+                    Prices::new_for_test(240, 240, 1),
+                    SIZE_DELTA_USD,
+                    None,
+                    0,
+                    Default::default(),
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        // Without the builder fee, the order fee is payable and charged.
+        let baseline = run(None)?;
+        assert!(!baseline.fees().order_fees().fee_value().is_zero());
+        assert!(!baseline
+            .fees()
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_pool()
+            .is_zero());
+
+        // With the oversized builder fee, the full close still executes, but
+        // both the order fee and the builder fee are cancelled.
+        let report = run(Some(FACTOR))?;
+        assert!(report.should_remove());
+        assert!(report.insolvent_close_step().is_none());
+        let fees = report.fees();
+        assert!(fees.builder_fees().fee_value().is_zero());
+        assert!(fees.builder_fees().fee_amount().is_zero());
+        assert!(fees.order_fees().fee_value().is_zero());
+        assert!(fees
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_pool()
+            .is_zero());
+        assert!(fees
+            .order_fees()
+            .fee_amounts()
+            .fee_amount_for_receiver()
+            .is_zero());
+        assert!(fees.paid_order_and_borrowing_fee_value().is_zero());
+
+        Ok(())
+    }
 }

--- a/crates/model/src/action/increase_position.rs
+++ b/crates/model/src/action/increase_position.rs
@@ -610,4 +610,131 @@ mod tests {
         println!("{position:#?}");
         Ok(())
     }
+
+    fn market_for_builder_fee_tests() -> crate::Result<TestMarket<u64, 9>> {
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 1_000_000_000, prices)?.execute()?;
+        Ok(market)
+    }
+
+    #[test]
+    fn builder_fee_zero_factor_is_identity() -> crate::Result<()> {
+        let market = market_for_builder_fee_tests()?;
+        let position = TestPosition::long(true);
+
+        let run = |factor: Option<u64>| -> crate::Result<(String, String, String)> {
+            let mut market = market.clone();
+            let mut position = position;
+            let report = position
+                .ops(&mut market)
+                .increase(
+                    Prices::new_for_test(123, 123, 1),
+                    100_000_000,
+                    8_000_000_000,
+                    None,
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()?;
+            Ok((
+                format!("{report:?}"),
+                format!("{market:?}"),
+                format!("{position:?}"),
+            ))
+        };
+
+        let baseline = run(None)?;
+        let with_zero_factor = run(Some(0))?;
+        assert_eq!(baseline, with_zero_factor);
+        Ok(())
+    }
+
+    #[test]
+    fn builder_fee_charged_on_increase() -> crate::Result<()> {
+        const SIZE_DELTA_USD: u64 = 8_000_000_000;
+        const FACTOR: u64 = 5_000_000; // 0.5%
+        const COLLATERAL_PRICE: u64 = 123;
+
+        let market = market_for_builder_fee_tests()?;
+        let position = TestPosition::long(true);
+
+        let run = |factor: Option<u64>| {
+            let mut market = market.clone();
+            let mut position = position;
+            position
+                .ops(&mut market)
+                .increase(
+                    Prices::new_for_test(123, 123, 1),
+                    100_000_000,
+                    SIZE_DELTA_USD,
+                    None,
+                )?
+                .with_builder_fee_factor(factor)
+                .execute()
+        };
+
+        let baseline = run(None)?;
+        let report = run(Some(FACTOR))?;
+
+        assert!(baseline.fees().builder_fees().fee_value().is_zero());
+        assert!(baseline.fees().builder_fees().fee_amount().is_zero());
+
+        // The fee value is the size delta with the factor applied, and the
+        // amount is converted with the min collateral token price, rounding
+        // down, in parity with the order fee computation.
+        let expected_value =
+            crate::utils::apply_factor::<u64, 9>(&SIZE_DELTA_USD, &FACTOR).unwrap();
+        let expected_amount = expected_value / COLLATERAL_PRICE;
+        assert!(!expected_amount.is_zero());
+        let builder_fees = report.fees().builder_fees();
+        assert_eq!(*builder_fees.fee_value(), expected_value);
+        assert_eq!(*builder_fees.fee_amount(), expected_amount);
+
+        // The order fee is unaffected by the builder fee.
+        assert_eq!(
+            baseline.fees().order_fees().fee_value(),
+            report.fees().order_fees().fee_value()
+        );
+        assert_eq!(
+            baseline
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_pool(),
+            report
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_pool()
+        );
+        assert_eq!(
+            baseline
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_receiver(),
+            report
+                .fees()
+                .order_fees()
+                .fee_amounts()
+                .fee_amount_for_receiver()
+        );
+
+        // The builder fee does not mint GT: the paid order and borrowing fee
+        // value must be unchanged.
+        assert_eq!(
+            baseline.fees().paid_order_and_borrowing_fee_value(),
+            report.fees().paid_order_and_borrowing_fee_value()
+        );
+
+        // The collateral added to the position is reduced by exactly the
+        // builder fee amount.
+        assert_eq!(
+            *baseline.collateral_delta_amount() - *report.collateral_delta_amount(),
+            expected_amount as i64
+        );
+
+        Ok(())
+    }
 }

--- a/crates/model/src/action/increase_position.rs
+++ b/crates/model/src/action/increase_position.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::{
     market::{BaseMarketExt, BaseMarketMutExt, PerpMarketExt, PositionImpactMarketMutExt},
     num::Unsigned,
-    params::fee::PositionFees,
+    params::fee::{BuilderFees, PositionFees},
     pool::delta::PriceImpact,
     position::{CollateralDelta, Position, PositionExt},
     price::{Price, Prices},
@@ -18,6 +18,7 @@ use super::MarketAction;
 pub struct IncreasePosition<P: Position<DECIMALS>, const DECIMALS: u8> {
     position: P,
     params: IncreasePositionParams<P::Num>,
+    builder_fee_factor: Option<P::Num>,
 }
 
 /// Increase Position Params.
@@ -229,7 +230,14 @@ where
                 acceptable_price,
                 prices,
             },
+            builder_fee_factor: None,
         })
+    }
+
+    /// Set the builder fee factor.
+    pub fn with_builder_fee_factor(mut self, factor: Option<P::Num>) -> Self {
+        self.builder_fee_factor = factor;
+        self
     }
 
     fn initialize_position_if_empty(&mut self) -> crate::Result<()> {
@@ -370,12 +378,20 @@ where
 
         let mut collateral_delta_amount = self.params.collateral_increment_amount.to_signed()?;
 
-        let fees = self.position.position_fees(
+        let mut fees = self.position.position_fees(
             self.collateral_price(),
             &self.params.size_delta_usd,
             price_impact.balance_change,
             false,
         )?;
+
+        if let Some(factor) = &self.builder_fee_factor {
+            fees = fees.set_builder_fees(BuilderFees::try_new(
+                self.collateral_price(),
+                &self.params.size_delta_usd,
+                factor,
+            )?);
+        }
 
         collateral_delta_amount = collateral_delta_amount
             .checked_sub(&fees.total_cost_amount()?.to_signed()?)

--- a/crates/model/src/params/fee.rs
+++ b/crates/model/src/params/fee.rs
@@ -139,6 +139,7 @@ impl<T> FeeParams<T> {
             borrowing: Default::default(),
             funding: Default::default(),
             liquidation: Default::default(),
+            builder: Default::default(),
         })
     }
 }
@@ -673,6 +674,47 @@ impl<T> LiquidationFees<T> {
     }
 }
 
+/// Builder Fees.
+///
+/// Unlike other fees, the entire amount is paid to the builder, so there is
+/// no pool / receiver split.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor-lang",
+    derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)
+)]
+#[derive(Debug, Clone, Copy)]
+pub struct BuilderFees<T> {
+    fee_value: T,
+    fee_amount: T,
+}
+
+#[cfg(feature = "gmsol-utils")]
+impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for BuilderFees<T> {
+    const INIT_SPACE: usize = 2 * T::INIT_SPACE;
+}
+
+impl<T> BuilderFees<T> {
+    /// Get builder fee amount.
+    pub fn fee_amount(&self) -> &T {
+        &self.fee_amount
+    }
+
+    /// Get builder fee value.
+    pub fn fee_value(&self) -> &T {
+        &self.fee_value
+    }
+}
+
+impl<T: Zero> Default for BuilderFees<T> {
+    fn default() -> Self {
+        Self {
+            fee_value: Zero::zero(),
+            fee_amount: Zero::zero(),
+        }
+    }
+}
+
 /// Position Fees.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -686,6 +728,7 @@ pub struct PositionFees<T> {
     borrowing: BorrowingFees<T>,
     funding: FundingFees<T>,
     liquidation: Option<LiquidationFees<T>>,
+    builder: BuilderFees<T>,
 }
 
 #[cfg(feature = "gmsol-utils")]
@@ -695,7 +738,8 @@ impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for PositionFees<T> {
         + BorrowingFees::<T>::INIT_SPACE
         + FundingFees::<T>::INIT_SPACE
         + 1
-        + LiquidationFees::<T>::INIT_SPACE;
+        + LiquidationFees::<T>::INIT_SPACE
+        + BuilderFees::<T>::INIT_SPACE;
 }
 
 impl<T> PositionFees<T> {
@@ -766,6 +810,11 @@ impl<T> PositionFees<T> {
         self.liquidation.as_ref()
     }
 
+    /// Get builder fees.
+    pub fn builder_fees(&self) -> &BuilderFees<T> {
+        &self.builder
+    }
+
     /// Get total cost amount in collateral tokens.
     pub fn total_cost_amount(&self) -> crate::Result<T>
     where
@@ -814,6 +863,7 @@ impl<T> PositionFees<T> {
         self.order = Default::default();
         self.borrowing = BorrowingFees::default();
         self.liquidation = None;
+        self.builder = Default::default();
     }
 
     /// Set borrowing fees.
@@ -865,6 +915,7 @@ impl<T: Zero> Default for PositionFees<T> {
             borrowing: Default::default(),
             funding: Default::default(),
             liquidation: None,
+            builder: Default::default(),
         }
     }
 }

--- a/crates/model/src/params/fee.rs
+++ b/crates/model/src/params/fee.rs
@@ -695,6 +695,31 @@ impl<T: gmsol_utils::InitSpace> gmsol_utils::InitSpace for BuilderFees<T> {
 }
 
 impl<T> BuilderFees<T> {
+    /// Compute builder fees for the given size delta with the given factor.
+    pub(crate) fn try_new<const DECIMALS: u8>(
+        collateral_token_price: &Price<T>,
+        size_delta_usd: &T,
+        factor: &T,
+    ) -> crate::Result<Self>
+    where
+        T: FixedPointOps<DECIMALS>,
+    {
+        if collateral_token_price.has_zero() {
+            return Err(crate::Error::InvalidPrices);
+        }
+
+        let fee_value = utils::apply_factor(size_delta_usd, factor)
+            .ok_or(crate::Error::Computation("calculating builder fee value"))?;
+        let fee_amount = fee_value
+            .checked_div(collateral_token_price.pick_price(false))
+            .ok_or(crate::Error::Computation("calculating builder fee amount"))?;
+
+        Ok(Self {
+            fee_value,
+            fee_amount,
+        })
+    }
+
     /// Get builder fee amount.
     pub fn fee_amount(&self) -> &T {
         &self.fee_amount
@@ -842,6 +867,7 @@ impl<T> PositionFees<T> {
                     Some(acc)
                 }
             })
+            .and_then(|acc| acc.checked_add(self.builder.fee_amount()))
             .ok_or(crate::Error::Computation(
                 "overflow while calculating total cost excluding funding",
             ))
@@ -897,6 +923,12 @@ impl<T> PositionFees<T> {
     /// Set funding fees.
     pub fn set_funding_fees(mut self, fees: FundingFees<T>) -> Self {
         self.funding = fees;
+        self
+    }
+
+    /// Set builder fees.
+    pub fn set_builder_fees(mut self, fees: BuilderFees<T>) -> Self {
+        self.builder = fees;
         self
     }
 

--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -1013,6 +1013,294 @@
       "returns": "bool"
     },
     {
+      "name": "claim_builder_fees",
+      "docs": [
+        "Claim the settled builder fees from the claim vault.",
+        "",
+        "The entire balance of the claim vault is transferred to the given",
+        "destination token account. An empty claim vault is an explicit no-op.",
+        "",
+        "In the future, this instruction is expected to enforce access control",
+        "via the per-token access control account (e.g. a withdrawal timelock),",
+        "which is currently only required to exist.",
+        "",
+        "# Accounts",
+        "[*See the documentation for the accounts.*](ClaimBuilderFees)",
+        "",
+        "# Errors",
+        "- The [`owner`](ClaimBuilderFees::owner) must be a signer and the owner of the builder's",
+        "User Account.",
+        "- The [`store`](ClaimBuilderFees::store) must be an initialized store account.",
+        "- The [`builder_user`](ClaimBuilderFees::builder_user) must be an initialized User Account",
+        "owned by the given store.",
+        "- The [`controller`](ClaimBuilderFees::controller) must be the initialized per-token access",
+        "control account for the given token.",
+        "- The [`claim_vault`](ClaimBuilderFees::claim_vault) must be the ATA of the token owned by",
+        "the builder's User Account.",
+        "- The [`receiver_vault`](ClaimBuilderFees::receiver_vault) must be a token account of the",
+        "given token."
+      ],
+      "discriminator": [
+        207,
+        194,
+        126,
+        184,
+        118,
+        67,
+        225,
+        181
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The owner of the builder's User Account."
+          ],
+          "signer": true,
+          "relations": [
+            "builder_user"
+          ]
+        },
+        {
+          "name": "store",
+          "docs": [
+            "Store."
+          ],
+          "relations": [
+            "builder_user"
+          ]
+        },
+        {
+          "name": "builder_user",
+          "docs": [
+            "The builder's User Account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "store"
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "controller",
+          "docs": [
+            "The per-token access control account.",
+            "",
+            "Currently it is only required to exist: it is the hook for future",
+            "access control on builder fee withdrawal (e.g. a withdrawal timelock)."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  117,
+                  105,
+                  108,
+                  100,
+                  101,
+                  114,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  116,
+                  114,
+                  111,
+                  108,
+                  108,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "store"
+              },
+              {
+                "kind": "account",
+                "path": "token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token",
+          "docs": [
+            "The token to claim."
+          ]
+        },
+        {
+          "name": "claim_vault",
+          "docs": [
+            "The builder's claim vault: the associated token account of the token",
+            "owned by the builder's User Account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "builder_user"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "receiver_vault",
+          "docs": [
+            "The destination token account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "claim_fees_from_market",
       "docs": [
         "Claim fees from the given market.",
@@ -14960,6 +15248,119 @@
       ]
     },
     {
+      "name": "initialize_builder_fee_token_controller",
+      "docs": [
+        "Initialize the per-token access control account for builder fees.",
+        "",
+        "Its existence is required before a builder fee denominated in the given",
+        "token can be set on an order. The account currently carries no behavior:",
+        "it is a placeholder intended to support future access control on builder",
+        "fee withdrawal (e.g. a withdrawal timelock).",
+        "",
+        "# Accounts",
+        "[*See the documentation for the accounts.*](InitializeBuilderFeeTokenController)",
+        "",
+        "# Errors",
+        "- The [`authority`](InitializeBuilderFeeTokenController::authority) must be a signer and have",
+        "MARKET_KEEPER permissions in the store.",
+        "- The [`store`](InitializeBuilderFeeTokenController::store) must be an initialized store account.",
+        "- The [`controller`](InitializeBuilderFeeTokenController::controller) must be an uninitialized",
+        "account and its address must match the PDA derived from the expected seeds."
+      ],
+      "discriminator": [
+        185,
+        89,
+        57,
+        240,
+        216,
+        180,
+        23,
+        23
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "docs": [
+            "The caller."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "store",
+          "docs": [
+            "Store."
+          ]
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "The token mint to initialize the controller for."
+          ]
+        },
+        {
+          "name": "controller",
+          "docs": [
+            "The controller account to initialize."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  117,
+                  105,
+                  108,
+                  100,
+                  101,
+                  114,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  116,
+                  114,
+                  111,
+                  108,
+                  108,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "store"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "initialize_callback_authority",
       "docs": [
         "Initialize the [`CallbackAuthority`](crate::states::callback::CallbackAuthority) account."
@@ -19771,6 +20172,217 @@
       "args": []
     },
     {
+      "name": "settle_builder_fee",
+      "docs": [
+        "Settle the pending builder fee of the given order.",
+        "",
+        "This instruction is permissionless and idempotent: when the pending",
+        "builder fee amount is zero, it is an explicit no-op — no CPI is",
+        "performed and no state is updated. Otherwise, the fee is transferred",
+        "from the order's escrow into the builder's claim vault (the ATA owned",
+        "by the builder's User Account) and the pending amount is reset to zero.",
+        "",
+        "# Accounts",
+        "[*See the documentation for the accounts.*](SettleBuilderFee)",
+        "",
+        "# Errors",
+        "- The [`store`](SettleBuilderFee::store) must be an initialized store account.",
+        "- The [`order`](SettleBuilderFee::order) must be an initialized order account owned by",
+        "the given store.",
+        "- When the pending amount is non-zero:",
+        "- The [`builder_user`](SettleBuilderFee::builder_user) must be the builder's initialized",
+        "User Account recorded on the order.",
+        "- The [`collateral_token`](SettleBuilderFee::collateral_token) must be the collateral",
+        "token of the order.",
+        "- The [`escrow`](SettleBuilderFee::escrow) must be the order's escrow account for the",
+        "collateral token.",
+        "- The [`claim_vault`](SettleBuilderFee::claim_vault) must be the ATA of the collateral",
+        "token owned by the builder's User Account."
+      ],
+      "discriminator": [
+        209,
+        56,
+        167,
+        214,
+        184,
+        197,
+        10,
+        10
+      ],
+      "accounts": [
+        {
+          "name": "store",
+          "docs": [
+            "Store."
+          ],
+          "relations": [
+            "builder_user"
+          ]
+        },
+        {
+          "name": "order",
+          "docs": [
+            "The order whose builder fee is to be settled."
+          ],
+          "writable": true
+        },
+        {
+          "name": "builder_user",
+          "docs": [
+            "The builder's User Account."
+          ]
+        },
+        {
+          "name": "collateral_token",
+          "docs": [
+            "The token the builder fee is denominated in (the collateral token of",
+            "the order)."
+          ]
+        },
+        {
+          "name": "escrow",
+          "docs": [
+            "The order's escrow account for the collateral token."
+          ],
+          "writable": true
+        },
+        {
+          "name": "claim_vault",
+          "docs": [
+            "The builder's claim vault: the associated token account of the",
+            "collateral token owned by the builder's User Account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "builder_user"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_token"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "toggle_feature",
       "docs": [
         "Enable or disable a feature in this deployment.",
@@ -21928,6 +22540,19 @@
   ],
   "accounts": [
     {
+      "name": "BuilderFeeTokenController",
+      "discriminator": [
+        85,
+        146,
+        253,
+        108,
+        157,
+        178,
+        205,
+        146
+      ]
+    },
+    {
       "name": "CallbackAuthority",
       "discriminator": [
         21,
@@ -22226,6 +22851,32 @@
         216,
         237,
         151
+      ]
+    },
+    {
+      "name": "BuilderFeeClaimed",
+      "discriminator": [
+        173,
+        137,
+        231,
+        148,
+        184,
+        179,
+        14,
+        141
+      ]
+    },
+    {
+      "name": "BuilderFeeSettled",
+      "discriminator": [
+        92,
+        156,
+        185,
+        185,
+        199,
+        171,
+        24,
+        82
       ]
     },
     {
@@ -23181,6 +23832,11 @@
       "code": 6127,
       "name": "MarketClosed",
       "msg": "market is closed"
+    },
+    {
+      "code": 6128,
+      "name": "UnsettledBuilderFee",
+      "msg": "there is an unsettled builder fee"
     }
   ],
   "types": [
@@ -23550,6 +24206,224 @@
                   }
                 ]
               }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFeeClaimed",
+      "docs": [
+        "An event indicating that builder fees have been claimed."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ts",
+            "docs": [
+              "Timestamp."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slot",
+            "docs": [
+              "Slot."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "store",
+            "docs": [
+              "Store."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "builder",
+            "docs": [
+              "The builder's user account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token",
+            "docs": [
+              "The token claimed."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver",
+            "docs": [
+              "The destination token account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "The claimed amount."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFeeSettled",
+      "docs": [
+        "An event indicating that a builder fee has been settled."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ts",
+            "docs": [
+              "Timestamp."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slot",
+            "docs": [
+              "Slot."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "store",
+            "docs": [
+              "Store."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "order",
+            "docs": [
+              "Order."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "builder",
+            "docs": [
+              "The builder's user account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token",
+            "docs": [
+              "The token the fee is denominated in."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "The settled fee amount."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFeeTokenController",
+      "docs": [
+        "Per-token access control account for builder fees.",
+        "",
+        "One account exists per `(store, token_mint)` pair, and its existence is",
+        "required before a builder fee denominated in that token can be set on an",
+        "order.",
+        "",
+        "This account is currently a placeholder and carries no behavior: it is",
+        "intended to support future access control on builder fee withdrawal",
+        "(e.g. a withdrawal timelock)."
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          },
+          {
+            "name": "store",
+            "docs": [
+              "The store."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "docs": [
+              "The token mint this controller is for."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u8",
+                176
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFees",
+      "docs": [
+        "Builder Fees.",
+        "",
+        "Unlike other fees, the entire amount is paid to the builder, so there is",
+        "no pool / receiver split."
+      ],
+      "generics": [
+        {
+          "kind": "type",
+          "name": "T"
+        }
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_value",
+            "type": {
+              "generic": "T"
+            }
+          },
+          {
+            "name": "fee_amount",
+            "type": {
+              "generic": "T"
             }
           }
         ]
@@ -25530,11 +26404,15 @@
             "type": "u128"
           },
           {
+            "name": "max_builder_fee_factor",
+            "type": "u128"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u128",
-                64
+                63
               ]
             }
           }
@@ -28620,11 +29498,33 @@
             }
           },
           {
+            "name": "builder",
+            "docs": [
+              "The builder fee beneficiary (the builder's User Account address)."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "builder_fee_factor",
+            "docs": [
+              "The checkpointed builder fee factor."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "builder_fee_amount",
+            "docs": [
+              "The builder fee amount pending settlement, denominated in the",
+              "collateral token."
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                128
+                72
               ]
             }
           }
@@ -29946,6 +30846,22 @@
                     }
                   ]
                 }
+              }
+            }
+          },
+          {
+            "name": "builder",
+            "type": {
+              "defined": {
+                "name": "BuilderFees",
+                "generics": [
+                  {
+                    "kind": "type",
+                    "type": {
+                      "generic": "T"
+                    }
+                  }
+                ]
               }
             }
           }
@@ -32847,11 +33763,18 @@
             }
           },
           {
+            "name": "builder_fee_factor",
+            "docs": [
+              "The builder fee factor advertised by this user as a builder."
+            ],
+            "type": "u128"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                128
+                112
               ]
             }
           }

--- a/crates/sdk/src/client/mod.rs
+++ b/crates/sdk/src/client/mod.rs
@@ -501,6 +501,20 @@ impl<C: Clone + Deref<Target = impl Signer>> Client<C> {
         crate::pda::find_referral_code_address(store, code, self.store_program_id()).0
     }
 
+    /// Find PDA for builder fee token controller account.
+    pub fn find_builder_fee_token_controller_address(
+        &self,
+        store: &Pubkey,
+        token_mint: &Pubkey,
+    ) -> Pubkey {
+        crate::pda::find_builder_fee_token_controller_address(
+            store,
+            token_mint,
+            self.store_program_id(),
+        )
+        .0
+    }
+
     /// Find PDA for GLV token mint.
     pub fn find_glv_token_address(&self, store: &Pubkey, index: u16) -> Pubkey {
         crate::pda::find_glv_token_address(store, index, self.store_program_id()).0

--- a/crates/sdk/src/client/ops/builder_fee.rs
+++ b/crates/sdk/src/client/ops/builder_fee.rs
@@ -1,0 +1,157 @@
+use std::{future::Future, ops::Deref};
+
+use anchor_spl::associated_token::get_associated_token_address_with_program_id;
+use gmsol_programs::gmsol_store::client::{accounts, args};
+use gmsol_solana_utils::transaction_builder::TransactionBuilder;
+use gmsol_utils::pubkey::optional_address;
+use solana_sdk::{pubkey::Pubkey, signer::Signer, system_program};
+
+/// Operations for builder fees.
+pub trait BuilderFeeOps<C> {
+    /// Initialize the per-token access control account for builder fees.
+    fn initialize_builder_fee_token_controller(
+        &self,
+        store: &Pubkey,
+        token_mint: &Pubkey,
+    ) -> TransactionBuilder<C, Pubkey>;
+
+    /// Settle the builder fee of the given order.
+    fn settle_builder_fee(
+        &self,
+        store: &Pubkey,
+        order: &Pubkey,
+        hint: Option<SettleBuilderFeeHint>,
+    ) -> impl Future<Output = crate::Result<TransactionBuilder<C>>>;
+
+    /// Claim the settled builder fees of the given token to the given
+    /// destination token account.
+    ///
+    /// The payer must be the owner of the builder's User Account.
+    fn claim_builder_fees(
+        &self,
+        store: &Pubkey,
+        token: &Pubkey,
+        receiver_vault: &Pubkey,
+    ) -> TransactionBuilder<C>;
+}
+
+/// Hint for [`settle_builder_fee`](BuilderFeeOps::settle_builder_fee).
+#[derive(Debug, Clone, Copy)]
+pub struct SettleBuilderFeeHint {
+    /// The builder's User Account.
+    ///
+    /// When the order has no builder set, its builder fee amount is
+    /// necessarily zero and settlement is a no-op; any initialized User
+    /// Account of the store can be used.
+    pub builder: Pubkey,
+    /// The collateral token of the order.
+    pub collateral_token: Pubkey,
+    /// The order's escrow account for the collateral token.
+    pub escrow: Pubkey,
+}
+
+impl<C: Deref<Target = impl Signer> + Clone> BuilderFeeOps<C> for crate::Client<C> {
+    fn initialize_builder_fee_token_controller(
+        &self,
+        store: &Pubkey,
+        token_mint: &Pubkey,
+    ) -> TransactionBuilder<C, Pubkey> {
+        let controller = self.find_builder_fee_token_controller_address(store, token_mint);
+        self.store_transaction()
+            .anchor_accounts(accounts::InitializeBuilderFeeTokenController {
+                authority: self.payer(),
+                store: *store,
+                token_mint: *token_mint,
+                controller,
+                system_program: system_program::ID,
+            })
+            .anchor_args(args::InitializeBuilderFeeTokenController {})
+            .output(controller)
+    }
+
+    async fn settle_builder_fee(
+        &self,
+        store: &Pubkey,
+        order: &Pubkey,
+        hint: Option<SettleBuilderFeeHint>,
+    ) -> crate::Result<TransactionBuilder<C>> {
+        let hint = match hint {
+            Some(hint) => hint,
+            None => {
+                let order = self.order(order).await?;
+                let builder = match optional_address(&order.builder) {
+                    Some(builder) => *builder,
+                    // The order has no builder, so its builder fee amount is
+                    // necessarily zero and settlement is a no-op. The payer's
+                    // own User Account is used as a placeholder.
+                    None => self.find_user_address(store, &self.payer()),
+                };
+                let collateral_token = order.params.collateral_token;
+                let escrow = [&order.tokens.long_token, &order.tokens.short_token]
+                    .into_iter()
+                    .filter_map(|t| t.token_and_account())
+                    .find_map(|(token, account)| (token == collateral_token).then_some(account))
+                    .ok_or_else(|| {
+                        crate::Error::custom("no escrow account for the collateral token")
+                    })?;
+                SettleBuilderFeeHint {
+                    builder,
+                    collateral_token,
+                    escrow,
+                }
+            }
+        };
+
+        let claim_vault = get_associated_token_address_with_program_id(
+            &hint.builder,
+            &hint.collateral_token,
+            &anchor_spl::token::ID,
+        );
+
+        let rpc = self
+            .store_transaction()
+            .anchor_accounts(accounts::SettleBuilderFee {
+                store: *store,
+                order: *order,
+                builder_user: hint.builder,
+                collateral_token: hint.collateral_token,
+                escrow: hint.escrow,
+                claim_vault,
+                token_program: anchor_spl::token::ID,
+                event_authority: self.store_event_authority(),
+                program: *self.store_program_id(),
+            })
+            .anchor_args(args::SettleBuilderFee {});
+
+        Ok(rpc)
+    }
+
+    fn claim_builder_fees(
+        &self,
+        store: &Pubkey,
+        token: &Pubkey,
+        receiver_vault: &Pubkey,
+    ) -> TransactionBuilder<C> {
+        let owner = self.payer();
+        let builder_user = self.find_user_address(store, &owner);
+        let claim_vault = get_associated_token_address_with_program_id(
+            &builder_user,
+            token,
+            &anchor_spl::token::ID,
+        );
+        self.store_transaction()
+            .anchor_accounts(accounts::ClaimBuilderFees {
+                owner,
+                store: *store,
+                builder_user,
+                controller: self.find_builder_fee_token_controller_address(store, token),
+                token: *token,
+                claim_vault,
+                receiver_vault: *receiver_vault,
+                token_program: anchor_spl::token::ID,
+                event_authority: self.store_event_authority(),
+                program: *self.store_program_id(),
+            })
+            .anchor_args(args::ClaimBuilderFees {})
+    }
+}

--- a/crates/sdk/src/client/ops/mod.rs
+++ b/crates/sdk/src/client/ops/mod.rs
@@ -31,6 +31,9 @@ pub mod token_config;
 /// Operations for user account.
 pub mod user;
 
+/// Operations for builder fees.
+pub mod builder_fee;
+
 /// Operations for timelock.
 pub mod timelock;
 
@@ -58,6 +61,7 @@ pub mod virtual_inventory;
 pub mod liquidity_provider;
 
 pub use alt::AddressLookupTableOps;
+pub use builder_fee::BuilderFeeOps;
 pub use config::ConfigOps;
 pub use exchange::ExchangeOps;
 pub use glv::GlvOps;

--- a/crates/sdk/src/pda.rs
+++ b/crates/sdk/src/pda.rs
@@ -74,6 +74,9 @@ pub const USER_SEED: &[u8] = b"user";
 /// Seed for [`ReferralCodeV2`](store_accounts::ReferralCodeV2).
 pub const REFERRAL_CODE_SEED: &[u8] = b"referral_code";
 
+/// Seed for [`BuilderFeeTokenController`](store_accounts::BuilderFeeTokenController).
+pub const BUILDER_FEE_TOKEN_CONTROLLER_SEED: &[u8] = b"builder_fee_token_controller";
+
 /// Seed for GLV token mint.
 pub const GLV_TOKEN_SEED: &[u8] = b"glv_token";
 
@@ -330,6 +333,22 @@ pub fn find_user_address(
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[USER_SEED, store.as_ref(), owner.as_ref()],
+        store_program_id,
+    )
+}
+
+/// Find PDA for [`BuilderFeeTokenController`](store_accounts::BuilderFeeTokenController) account.
+pub fn find_builder_fee_token_controller_address(
+    store: &Pubkey,
+    token_mint: &Pubkey,
+    store_program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            BUILDER_FEE_TOKEN_CONTROLLER_SEED,
+            store.as_ref(),
+            token_mint.as_ref(),
+        ],
         store_program_id,
     )
 }

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -50,6 +50,8 @@ pub enum DomainDisabledFlag {
     GlvWithdrawal = 13,
     /// GLV shift.
     GlvShift = 14,
+    /// Builder fee.
+    BuilderFee = 15,
 }
 
 impl TryFrom<OrderKind> for DomainDisabledFlag {

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -146,6 +146,8 @@ pub enum FactorKey {
     OracleRefPriceDeviation,
     /// Order fee discount for referred user.
     OrderFeeDiscountForReferredUser,
+    /// Max builder fee factor.
+    MaxBuilderFeeFactor,
 }
 
 /// Address keys.

--- a/programs/store/src/events/builder_fee.rs
+++ b/programs/store/src/events/builder_fee.rs
@@ -51,3 +51,51 @@ impl InitSpace for BuilderFeeSettled {
 }
 
 impl Event for BuilderFeeSettled {}
+
+/// An event indicating that builder fees have been claimed.
+#[event]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone, InitSpace)]
+pub struct BuilderFeeClaimed {
+    /// Timestamp.
+    pub ts: i64,
+    /// Slot.
+    pub slot: u64,
+    /// Store.
+    pub store: Pubkey,
+    /// The builder's user account.
+    pub builder: Pubkey,
+    /// The token claimed.
+    pub token: Pubkey,
+    /// The destination token account.
+    pub receiver: Pubkey,
+    /// The claimed amount.
+    pub amount: u64,
+}
+
+impl BuilderFeeClaimed {
+    pub(crate) fn new(
+        store: &Pubkey,
+        builder: &Pubkey,
+        token: &Pubkey,
+        receiver: &Pubkey,
+        amount: u64,
+    ) -> Result<Self> {
+        let clock = Clock::get()?;
+        Ok(Self {
+            ts: clock.unix_timestamp,
+            slot: clock.slot,
+            store: *store,
+            builder: *builder,
+            token: *token,
+            receiver: *receiver,
+            amount,
+        })
+    }
+}
+
+impl InitSpace for BuilderFeeClaimed {
+    const INIT_SPACE: usize = <Self as Space>::INIT_SPACE;
+}
+
+impl Event for BuilderFeeClaimed {}

--- a/programs/store/src/events/builder_fee.rs
+++ b/programs/store/src/events/builder_fee.rs
@@ -1,0 +1,53 @@
+use anchor_lang::prelude::*;
+
+use gmsol_utils::InitSpace;
+
+use super::Event;
+
+/// An event indicating that a builder fee has been settled.
+#[event]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone, InitSpace)]
+pub struct BuilderFeeSettled {
+    /// Timestamp.
+    pub ts: i64,
+    /// Slot.
+    pub slot: u64,
+    /// Store.
+    pub store: Pubkey,
+    /// Order.
+    pub order: Pubkey,
+    /// The builder's user account.
+    pub builder: Pubkey,
+    /// The token the fee is denominated in.
+    pub token: Pubkey,
+    /// The settled fee amount.
+    pub amount: u64,
+}
+
+impl BuilderFeeSettled {
+    pub(crate) fn new(
+        store: &Pubkey,
+        order: &Pubkey,
+        builder: &Pubkey,
+        token: &Pubkey,
+        amount: u64,
+    ) -> Result<Self> {
+        let clock = Clock::get()?;
+        Ok(Self {
+            ts: clock.unix_timestamp,
+            slot: clock.slot,
+            store: *store,
+            order: *order,
+            builder: *builder,
+            token: *token,
+            amount,
+        })
+    }
+}
+
+impl InitSpace for BuilderFeeSettled {
+    const INIT_SPACE: usize = <Self as Space>::INIT_SPACE;
+}
+
+impl Event for BuilderFeeSettled {}

--- a/programs/store/src/events/mod.rs
+++ b/programs/store/src/events/mod.rs
@@ -25,6 +25,10 @@ mod market;
 /// GT events.
 mod gt;
 
+/// Builder fee events.
+mod builder_fee;
+
+pub use builder_fee::*;
 pub use deposit::*;
 pub use glv::*;
 pub use gt::*;

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -3,7 +3,7 @@ use anchor_spl::token::{transfer_checked, Token, TokenAccount, TransferChecked};
 use anchor_spl::token_interface::Mint;
 
 use crate::{
-    events::{BuilderFeeSettled, EventEmitter},
+    events::{BuilderFeeClaimed, BuilderFeeSettled, EventEmitter},
     states::{builder_fee::BuilderFeeTokenController, user::UserHeader, Order, Seed, Store},
     utils::internal,
     CoreError,
@@ -173,6 +173,99 @@ pub(crate) fn settle_builder_fee(ctx: Context<SettleBuilderFee>) -> Result<()> {
             &ctx.accounts.order.key(),
             &ctx.accounts.builder_user.key(),
             &ctx.accounts.collateral_token.key(),
+            amount,
+        )?,
+    )?;
+
+    Ok(())
+}
+
+/// The accounts definition for [`claim_builder_fees`](crate::gmsol_store::claim_builder_fees).
+#[event_cpi]
+#[derive(Accounts)]
+pub struct ClaimBuilderFees<'info> {
+    /// The owner of the builder's User Account.
+    pub owner: Signer<'info>,
+    /// Store.
+    pub store: AccountLoader<'info, Store>,
+    /// The builder's User Account.
+    #[account(
+        has_one = store,
+        has_one = owner,
+        constraint = builder_user.load()?.is_initialized() @ CoreError::InvalidUserAccount,
+        seeds = [UserHeader::SEED, store.key().as_ref(), owner.key().as_ref()],
+        bump = builder_user.load()?.bump,
+    )]
+    pub builder_user: AccountLoader<'info, UserHeader>,
+    /// The per-token access control account.
+    ///
+    /// Currently it is only required to exist: it is the hook for future
+    /// access control on builder fee withdrawal (e.g. a withdrawal timelock).
+    #[account(
+        seeds = [
+            BuilderFeeTokenController::SEED,
+            store.key().as_ref(),
+            token.key().as_ref(),
+        ],
+        bump = controller.load()?.bump,
+    )]
+    pub controller: AccountLoader<'info, BuilderFeeTokenController>,
+    /// The token to claim.
+    pub token: InterfaceAccount<'info, Mint>,
+    /// The builder's claim vault: the associated token account of the token
+    /// owned by the builder's User Account.
+    #[account(
+        mut,
+        associated_token::mint = token,
+        associated_token::authority = builder_user,
+    )]
+    pub claim_vault: Account<'info, TokenAccount>,
+    /// The destination token account.
+    #[account(mut, token::mint = token)]
+    pub receiver_vault: Account<'info, TokenAccount>,
+    /// Token program.
+    pub token_program: Program<'info, Token>,
+}
+
+/// Claim the settled builder fees from the claim vault.
+pub(crate) fn claim_builder_fees(ctx: Context<ClaimBuilderFees>) -> Result<()> {
+    let amount = ctx.accounts.claim_vault.amount;
+
+    // Nothing to claim is an explicit no-op.
+    if amount == 0 {
+        return Ok(());
+    }
+
+    let store = ctx.accounts.store.key();
+    let owner = ctx.accounts.owner.key();
+    let bump_bytes = [ctx.accounts.builder_user.load()?.bump];
+    let seeds: [&[u8]; 4] = [
+        UserHeader::SEED,
+        store.as_ref(),
+        owner.as_ref(),
+        &bump_bytes,
+    ];
+    transfer_checked(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            TransferChecked {
+                from: ctx.accounts.claim_vault.to_account_info(),
+                mint: ctx.accounts.token.to_account_info(),
+                to: ctx.accounts.receiver_vault.to_account_info(),
+                authority: ctx.accounts.builder_user.to_account_info(),
+            },
+        )
+        .with_signer(&[&seeds]),
+        amount,
+        ctx.accounts.token.decimals,
+    )?;
+
+    EventEmitter::new(&ctx.accounts.event_authority, ctx.bumps.event_authority).emit_cpi(
+        &BuilderFeeClaimed::new(
+            &store,
+            &ctx.accounts.builder_user.key(),
+            &ctx.accounts.token.key(),
+            &ctx.accounts.receiver_vault.key(),
             amount,
         )?,
     )?;

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -1,0 +1,62 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::Mint;
+
+use crate::{
+    states::{builder_fee::BuilderFeeTokenController, Seed, Store},
+    utils::internal,
+};
+
+use gmsol_utils::InitSpace;
+
+/// The accounts definition for
+/// [`initialize_builder_fee_token_controller`](crate::gmsol_store::initialize_builder_fee_token_controller).
+#[derive(Accounts)]
+pub struct InitializeBuilderFeeTokenController<'info> {
+    /// The caller.
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    /// Store.
+    pub store: AccountLoader<'info, Store>,
+    /// The token mint to initialize the controller for.
+    pub token_mint: InterfaceAccount<'info, Mint>,
+    /// The controller account to initialize.
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + BuilderFeeTokenController::INIT_SPACE,
+        seeds = [
+            BuilderFeeTokenController::SEED,
+            store.key().as_ref(),
+            token_mint.key().as_ref(),
+        ],
+        bump,
+    )]
+    pub controller: AccountLoader<'info, BuilderFeeTokenController>,
+    /// System program.
+    pub system_program: Program<'info, System>,
+}
+
+/// Initialize the per-token access control account for builder fees.
+///
+/// ## CHECK
+/// - Only MARKET_KEEPER can initialize the controller.
+pub(crate) fn unchecked_initialize_builder_fee_token_controller(
+    ctx: Context<InitializeBuilderFeeTokenController>,
+) -> Result<()> {
+    ctx.accounts.controller.load_init()?.init(
+        &ctx.accounts.store.key(),
+        &ctx.accounts.token_mint.key(),
+        ctx.bumps.controller,
+    );
+    Ok(())
+}
+
+impl<'info> internal::Authentication<'info> for InitializeBuilderFeeTokenController<'info> {
+    fn authority(&self) -> &Signer<'info> {
+        &self.authority
+    }
+
+    fn store(&self) -> &AccountLoader<'info, Store> {
+        &self.store
+    }
+}

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -1,9 +1,12 @@
 use anchor_lang::prelude::*;
+use anchor_spl::token::{transfer_checked, Token, TokenAccount, TransferChecked};
 use anchor_spl::token_interface::Mint;
 
 use crate::{
-    states::{builder_fee::BuilderFeeTokenController, Seed, Store},
+    events::{BuilderFeeSettled, EventEmitter},
+    states::{builder_fee::BuilderFeeTokenController, user::UserHeader, Order, Seed, Store},
     utils::internal,
+    CoreError,
 };
 
 use gmsol_utils::InitSpace;
@@ -59,4 +62,120 @@ impl<'info> internal::Authentication<'info> for InitializeBuilderFeeTokenControl
     fn store(&self) -> &AccountLoader<'info, Store> {
         &self.store
     }
+}
+
+/// The accounts definition for [`settle_builder_fee`](crate::gmsol_store::settle_builder_fee).
+#[event_cpi]
+#[derive(Accounts)]
+pub struct SettleBuilderFee<'info> {
+    /// Store.
+    pub store: AccountLoader<'info, Store>,
+    /// The order whose builder fee is to be settled.
+    #[account(
+        mut,
+        constraint = order.load()?.header.store == store.key() @ CoreError::StoreMismatched,
+    )]
+    pub order: AccountLoader<'info, Order>,
+    /// The builder's User Account.
+    #[account(
+        has_one = store,
+        constraint = builder_user.load()?.is_initialized() @ CoreError::InvalidUserAccount,
+    )]
+    pub builder_user: AccountLoader<'info, UserHeader>,
+    /// The token the builder fee is denominated in (the collateral token of
+    /// the order).
+    pub collateral_token: InterfaceAccount<'info, Mint>,
+    /// The order's escrow account for the collateral token.
+    #[account(
+        mut,
+        token::mint = collateral_token,
+        token::authority = order,
+    )]
+    pub escrow: Account<'info, TokenAccount>,
+    /// The builder's claim vault: the associated token account of the
+    /// collateral token owned by the builder's User Account.
+    #[account(
+        mut,
+        associated_token::mint = collateral_token,
+        associated_token::authority = builder_user,
+    )]
+    pub claim_vault: Account<'info, TokenAccount>,
+    /// Token program.
+    pub token_program: Program<'info, Token>,
+}
+
+/// Settle the builder fee of the given order.
+pub(crate) fn settle_builder_fee(ctx: Context<SettleBuilderFee>) -> Result<()> {
+    let amount = ctx.accounts.order.load()?.builder_fee_amount();
+
+    // An amount of zero is an explicit no-op.
+    if amount == 0 {
+        return Ok(());
+    }
+
+    {
+        let order = ctx.accounts.order.load()?;
+
+        // A non-zero amount implies that the builder must have been set.
+        let builder = order.builder().ok_or_else(|| error!(CoreError::Internal))?;
+        require_keys_eq!(
+            *builder,
+            ctx.accounts.builder_user.key(),
+            CoreError::InvalidUserAccount
+        );
+
+        let collateral_token = order.params.collateral_token;
+        require_keys_eq!(
+            ctx.accounts.collateral_token.key(),
+            collateral_token,
+            CoreError::TokenMintMismatched
+        );
+
+        let long_token = order.tokens.long_token();
+        let short_token = order.tokens.short_token();
+        let expected_escrow = if long_token.token() == Some(collateral_token) {
+            long_token.account()
+        } else if short_token.token() == Some(collateral_token) {
+            short_token.account()
+        } else {
+            None
+        }
+        .ok_or_else(|| error!(CoreError::TokenAccountNotProvided))?;
+        require_keys_eq!(
+            ctx.accounts.escrow.key(),
+            expected_escrow,
+            CoreError::TokenAccountNotProvided
+        );
+    }
+
+    let signer = ctx.accounts.order.load()?.signer();
+    let seeds = signer.as_seeds();
+    transfer_checked(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            TransferChecked {
+                from: ctx.accounts.escrow.to_account_info(),
+                mint: ctx.accounts.collateral_token.to_account_info(),
+                to: ctx.accounts.claim_vault.to_account_info(),
+                authority: ctx.accounts.order.to_account_info(),
+            },
+        )
+        .with_signer(&[&seeds]),
+        amount,
+        ctx.accounts.collateral_token.decimals,
+    )?;
+
+    ctx.accounts.order.load_mut()?.builder_fee_amount = 0;
+
+    EventEmitter::new(&ctx.accounts.event_authority, ctx.bumps.event_authority).emit_cpi(
+        &BuilderFeeSettled::new(
+            &ctx.accounts.store.key(),
+            &ctx.accounts.order.key(),
+            &ctx.accounts.builder_user.key(),
+            &ctx.accounts.collateral_token.key(),
+            amount,
+        )?,
+    )?;
+
+    Ok(())
 }

--- a/programs/store/src/instructions/exchange/order.rs
+++ b/programs/store/src/instructions/exchange/order.rs
@@ -679,6 +679,11 @@ impl<'info> internal::Close<'info, Order> for CloseOrderV2<'info> {
     #[inline(never)]
     fn validate(&self) -> Result<()> {
         let order = self.order.load()?;
+        require_eq!(
+            order.builder_fee_amount(),
+            0,
+            CoreError::UnsettledBuilderFee
+        );
         if order.header.action_state()?.is_pending() {
             self.store
                 .load()?

--- a/programs/store/src/instructions/mod.rs
+++ b/programs/store/src/instructions/mod.rs
@@ -43,6 +43,10 @@ pub mod callback;
 /// Instructions for virtual inventories.
 pub mod virtual_inventory;
 
+/// Instructions for builder fees.
+pub mod builder_fee;
+
+pub use builder_fee::*;
 pub use callback::*;
 pub use config::*;
 pub use exchange::*;

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -127,6 +127,8 @@
 //!
 //! #### Instructions for token accounts
 //! - [`initialize_market_vault`]: Initialize the market vault for the given token.
+//! - [`initialize_builder_fee_token_controller`]: Initialize the per-token access control
+//!   account for builder fees.
 //! - [`use_claimable_account`]: Prepare a claimable account to receive tokens during the order execution.
 //! - [`close_empty_claimable_account`]: Close a empty claimable account.
 //! - [`prepare_associated_token_account`](gmsol_store::prepare_associated_token_account): Prepare an ATA.
@@ -1824,6 +1826,29 @@ pub mod gmsol_store {
     #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
     pub fn initialize_market_vault(ctx: Context<InitializeMarketVault>) -> Result<()> {
         instructions::unchecked_initialize_market_vault(ctx)
+    }
+
+    /// Initialize the per-token access control account for builder fees.
+    ///
+    /// Its existence is required before a builder fee denominated in the given
+    /// token can be set on an order. The account currently carries no behavior:
+    /// it is a placeholder intended to support future access control on builder
+    /// fee withdrawal (e.g. a withdrawal timelock).
+    ///
+    /// # Accounts
+    /// [*See the documentation for the accounts.*](InitializeBuilderFeeTokenController)
+    ///
+    /// # Errors
+    /// - The [`authority`](InitializeBuilderFeeTokenController::authority) must be a signer and have
+    ///   MARKET_KEEPER permissions in the store.
+    /// - The [`store`](InitializeBuilderFeeTokenController::store) must be an initialized store account.
+    /// - The [`controller`](InitializeBuilderFeeTokenController::controller) must be an uninitialized
+    ///   account and its address must match the PDA derived from the expected seeds.
+    #[access_control(internal::Authenticate::only_market_keeper(&ctx))]
+    pub fn initialize_builder_fee_token_controller(
+        ctx: Context<InitializeBuilderFeeTokenController>,
+    ) -> Result<()> {
+        instructions::unchecked_initialize_builder_fee_token_controller(ctx)
     }
 
     /// Prepare a claimable account to receive tokens during order execution.

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -4386,6 +4386,12 @@ pub enum CoreError {
     /// Market is closed.
     #[msg("market is closed")]
     MarketClosed,
+    // ===========================================
+    //             Builder Fee Errors
+    // ===========================================
+    /// Unsettled builder fee.
+    #[msg("there is an unsettled builder fee")]
+    UnsettledBuilderFee,
 }
 
 #[cfg(not(feature = "no-entrypoint"))]

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -159,6 +159,7 @@
 //! - [`execute_increase_or_swap_order_v2`]: Execute an order by keepers.
 //! - [`execute_decrease_order_v2`]: Execute a decrease order by keepers.
 //! - [`close_order_v2`]: Close an order, either by the owner or by keepers.
+//! - [`settle_builder_fee`](gmsol_store::settle_builder_fee): Settle the pending builder fee of an order.
 //! - [`cancel_order_if_no_position`]: Cancel an order if the position does not exist.
 //! - [`liquidate`]: Perform a liquidation by keepers.
 //! - [`auto_deleverage`]: Perform an ADL by keepers.
@@ -1849,6 +1850,34 @@ pub mod gmsol_store {
         ctx: Context<InitializeBuilderFeeTokenController>,
     ) -> Result<()> {
         instructions::unchecked_initialize_builder_fee_token_controller(ctx)
+    }
+
+    /// Settle the pending builder fee of the given order.
+    ///
+    /// This instruction is permissionless and idempotent: when the pending
+    /// builder fee amount is zero, it is an explicit no-op — no CPI is
+    /// performed and no state is updated. Otherwise, the fee is transferred
+    /// from the order's escrow into the builder's claim vault (the ATA owned
+    /// by the builder's User Account) and the pending amount is reset to zero.
+    ///
+    /// # Accounts
+    /// [*See the documentation for the accounts.*](SettleBuilderFee)
+    ///
+    /// # Errors
+    /// - The [`store`](SettleBuilderFee::store) must be an initialized store account.
+    /// - The [`order`](SettleBuilderFee::order) must be an initialized order account owned by
+    ///   the given store.
+    /// - When the pending amount is non-zero:
+    ///   - The [`builder_user`](SettleBuilderFee::builder_user) must be the builder's initialized
+    ///     User Account recorded on the order.
+    ///   - The [`collateral_token`](SettleBuilderFee::collateral_token) must be the collateral
+    ///     token of the order.
+    ///   - The [`escrow`](SettleBuilderFee::escrow) must be the order's escrow account for the
+    ///     collateral token.
+    ///   - The [`claim_vault`](SettleBuilderFee::claim_vault) must be the ATA of the collateral
+    ///     token owned by the builder's User Account.
+    pub fn settle_builder_fee(ctx: Context<SettleBuilderFee>) -> Result<()> {
+        instructions::settle_builder_fee(ctx)
     }
 
     /// Prepare a claimable account to receive tokens during order execution.

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -160,6 +160,7 @@
 //! - [`execute_decrease_order_v2`]: Execute a decrease order by keepers.
 //! - [`close_order_v2`]: Close an order, either by the owner or by keepers.
 //! - [`settle_builder_fee`](gmsol_store::settle_builder_fee): Settle the pending builder fee of an order.
+//! - [`claim_builder_fees`](gmsol_store::claim_builder_fees): Claim the settled builder fees from the claim vault.
 //! - [`cancel_order_if_no_position`]: Cancel an order if the position does not exist.
 //! - [`liquidate`]: Perform a liquidation by keepers.
 //! - [`auto_deleverage`]: Perform an ADL by keepers.
@@ -1878,6 +1879,34 @@ pub mod gmsol_store {
     ///     token owned by the builder's User Account.
     pub fn settle_builder_fee(ctx: Context<SettleBuilderFee>) -> Result<()> {
         instructions::settle_builder_fee(ctx)
+    }
+
+    /// Claim the settled builder fees from the claim vault.
+    ///
+    /// The entire balance of the claim vault is transferred to the given
+    /// destination token account. An empty claim vault is an explicit no-op.
+    ///
+    /// In the future, this instruction is expected to enforce access control
+    /// via the per-token access control account (e.g. a withdrawal timelock),
+    /// which is currently only required to exist.
+    ///
+    /// # Accounts
+    /// [*See the documentation for the accounts.*](ClaimBuilderFees)
+    ///
+    /// # Errors
+    /// - The [`owner`](ClaimBuilderFees::owner) must be a signer and the owner of the builder's
+    ///   User Account.
+    /// - The [`store`](ClaimBuilderFees::store) must be an initialized store account.
+    /// - The [`builder_user`](ClaimBuilderFees::builder_user) must be an initialized User Account
+    ///   owned by the given store.
+    /// - The [`controller`](ClaimBuilderFees::controller) must be the initialized per-token access
+    ///   control account for the given token.
+    /// - The [`claim_vault`](ClaimBuilderFees::claim_vault) must be the ATA of the token owned by
+    ///   the builder's User Account.
+    /// - The [`receiver_vault`](ClaimBuilderFees::receiver_vault) must be a token account of the
+    ///   given token.
+    pub fn claim_builder_fees(ctx: Context<ClaimBuilderFees>) -> Result<()> {
+        instructions::claim_builder_fees(ctx)
     }
 
     /// Prepare a claimable account to receive tokens during order execution.

--- a/programs/store/src/states/builder_fee.rs
+++ b/programs/store/src/states/builder_fee.rs
@@ -1,0 +1,58 @@
+use anchor_lang::prelude::*;
+
+use super::Seed;
+
+/// Per-token access control account for builder fees.
+///
+/// One account exists per `(store, token_mint)` pair, and its existence is
+/// required before a builder fee denominated in that token can be set on an
+/// order.
+///
+/// This account is currently a placeholder and carries no behavior: it is
+/// intended to support future access control on builder fee withdrawal
+/// (e.g. a withdrawal timelock).
+#[account(zero_copy)]
+#[cfg_attr(feature = "debug", derive(derive_more::Debug))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BuilderFeeTokenController {
+    version: u8,
+    /// Bump seed.
+    pub(crate) bump: u8,
+    #[cfg_attr(feature = "debug", debug(skip))]
+    padding_0: [u8; 14],
+    /// The store.
+    pub(crate) store: Pubkey,
+    /// The token mint this controller is for.
+    pub(crate) token_mint: Pubkey,
+    #[cfg_attr(feature = "debug", debug(skip))]
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
+    reserved: [u8; 176],
+}
+
+static_assertions::const_assert_eq!(std::mem::size_of::<BuilderFeeTokenController>(), 256);
+
+impl BuilderFeeTokenController {
+    pub(crate) fn init(&mut self, store: &Pubkey, token_mint: &Pubkey, bump: u8) {
+        self.bump = bump;
+        self.store = *store;
+        self.token_mint = *token_mint;
+    }
+
+    /// Get the store.
+    pub fn store(&self) -> &Pubkey {
+        &self.store
+    }
+
+    /// Get the token mint this controller is for.
+    pub fn token_mint(&self) -> &Pubkey {
+        &self.token_mint
+    }
+}
+
+impl Seed for BuilderFeeTokenController {
+    const SEED: &'static [u8] = b"builder_fee_token_controller";
+}
+
+impl gmsol_utils::InitSpace for BuilderFeeTokenController {
+    const INIT_SPACE: usize = std::mem::size_of::<Self>();
+}

--- a/programs/store/src/states/mod.rs
+++ b/programs/store/src/states/mod.rs
@@ -46,6 +46,9 @@ pub mod gt;
 /// Definitions related to callback.
 pub mod callback;
 
+/// Definitions related to builder fees.
+pub mod builder_fee;
+
 /// Permission stores and related definitions.
 pub mod permissions;
 

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -325,9 +325,38 @@ pub struct Order {
     pub(crate) gt_reward: u64,
     #[cfg_attr(feature = "debug", debug(skip))]
     padding_1: [u8; 8],
+    /// The builder fee beneficiary (the builder's User Account address).
+    pub(crate) builder: Pubkey,
+    /// The checkpointed builder fee factor.
+    pub(crate) builder_fee_factor: u128,
+    /// The builder fee amount pending settlement, denominated in the
+    /// collateral token.
+    pub(crate) builder_fee_amount: u64,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 128],
+    reserved: [u8; 72],
+}
+
+// The builder fee fields are carved out of previously reserved bytes: the
+// total size and the offsets of all fields must remain unchanged.
+static_assertions::const_assert_eq!(std::mem::size_of::<Order>(), 2464);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, builder), 2336);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, builder_fee_factor), 2368);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, builder_fee_amount), 2384);
+static_assertions::const_assert_eq!(std::mem::offset_of!(Order, reserved), 2392);
+
+impl Order {
+    pub fn builder(&self) -> Option<&Pubkey> {
+        crate::utils::pubkey::optional_address(&self.builder)
+    }
+
+    pub fn builder_fee_factor(&self) -> u128 {
+        self.builder_fee_factor
+    }
+
+    pub fn builder_fee_amount(&self) -> u64 {
+        self.builder_fee_amount
+    }
 }
 
 impl Seed for Order {

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -619,8 +619,9 @@ impl Amounts {
 pub struct Factors {
     pub(crate) oracle_ref_price_deviation: Factor,
     pub(crate) order_fee_discount_for_referred_user: Factor,
+    pub(crate) max_builder_fee_factor: Factor,
     #[cfg_attr(feature = "debug", debug(skip))]
-    reserved: [Factor; 64],
+    reserved: [Factor; 63],
 }
 
 impl Factors {
@@ -635,6 +636,7 @@ impl Factors {
             FactorKey::OrderFeeDiscountForReferredUser => {
                 &self.order_fee_discount_for_referred_user
             }
+            FactorKey::MaxBuilderFeeFactor => &self.max_builder_fee_factor,
             _ => return None,
         };
         Some(value)
@@ -647,6 +649,7 @@ impl Factors {
             FactorKey::OrderFeeDiscountForReferredUser => {
                 &mut self.order_fee_discount_for_referred_user
             }
+            FactorKey::MaxBuilderFeeFactor => &mut self.max_builder_fee_factor,
             _ => return None,
         };
         Some(value)

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -397,6 +397,30 @@ impl Store {
         }
     }
 
+    /// Is the builder fee feature enabled for the given action.
+    /// [`toggle_feature`](crate::gmsol_store::toggle_feature).
+    pub fn is_builder_fee_feature_enabled(&self, action: ActionDisabledFlag) -> bool {
+        matches!(
+            self.get_feature_disabled(DomainDisabledFlag::BuilderFee, action),
+            Some(false)
+        )
+    }
+
+    /// Validate whether the builder fee feature is enabled for the given
+    /// action. See [`is_builder_fee_feature_enabled`](Self::is_builder_fee_feature_enabled)
+    /// for the default behavior.
+    pub fn validate_builder_fee_feature_enabled(&self, action: ActionDisabledFlag) -> Result<()> {
+        if self.is_builder_fee_feature_enabled(action) {
+            Ok(())
+        } else {
+            msg!(
+                "Feature `{}` is not enabled (builder fee features are disabled by default)",
+                display_feature(DomainDisabledFlag::BuilderFee, action)
+            );
+            err!(CoreError::FeatureDisabled)
+        }
+    }
+
     /// Set features disabled.
     pub(crate) fn set_feature_disabled(
         &mut self,

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -31,9 +31,24 @@ pub struct UserHeader {
     pub(crate) referral: Referral,
     /// GT State.
     pub(crate) gt: UserGtState,
+    /// The builder fee factor advertised by this user as a builder.
+    pub(crate) builder_fee_factor: u128,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 128],
+    reserved: [u8; 112],
+}
+
+// The builder fee factor is carved out of previously reserved bytes: the
+// total size and the offsets of all fields must remain unchanged.
+static_assertions::const_assert_eq!(std::mem::size_of::<UserHeader>(), 512);
+static_assertions::const_assert_eq!(std::mem::offset_of!(UserHeader, builder_fee_factor), 384);
+static_assertions::const_assert_eq!(std::mem::offset_of!(UserHeader, reserved), 400);
+
+impl UserHeader {
+    /// Get the builder fee factor advertised by this user as a builder.
+    pub fn builder_fee_factor(&self) -> u128 {
+        self.builder_fee_factor
+    }
 }
 
 gmsol_utils::flags!(UserFlag, MAX_USER_FLAGS, u8);

--- a/tests/anchor_test/builder_fee.rs
+++ b/tests/anchor_test/builder_fee.rs
@@ -1,0 +1,155 @@
+use anchor_spl::associated_token::spl_associated_token_account::get_associated_token_address;
+use anchor_spl::token::ID as TOKEN_PROGRAM_ID;
+use gmsol_sdk::{
+    client::ops::{BuilderFeeOps, ExchangeOps, TokenAccountOps, UserOps},
+    constants::MARKET_USD_UNIT,
+};
+use gmsol_store::CoreError;
+
+use crate::anchor_test::setup::{current_deployment, Deployment};
+
+#[tokio::test]
+async fn settle_builder_fee_no_op() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("settle_builder_fee_no_op");
+    let _enter = span.enter();
+
+    let client = deployment.user_client(Deployment::DEFAULT_USER)?;
+    let store = &deployment.store;
+
+    let market_token = deployment
+        .market_token("fBTC", "fBTC", "USDG")
+        .expect("must exist");
+
+    let collateral_amount = 100 * 100_000_000;
+    deployment
+        .mint_or_transfer_to_user("USDG", Deployment::DEFAULT_USER, collateral_amount)
+        .await?;
+
+    // The settler's User Account is used as the placeholder builder account
+    // for orders without a builder.
+    let signature = client.prepare_user(store)?.send_without_preflight().await?;
+    tracing::info!(%signature, "prepared user account");
+
+    let size = 100 * MARKET_USD_UNIT;
+    let (rpc, order) = client
+        .market_increase(store, market_token, false, collateral_amount, true, size)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created an increase position order without a builder");
+
+    // Settling an order without a builder fee is an explicit no-op.
+    let signature = client
+        .settle_builder_fee(store, &order, None)
+        .await?
+        .send()
+        .await?;
+    tracing::info!(%order, %signature, "settled the builder fee (no-op)");
+
+    let account = client.order(&order).await?;
+    assert_eq!(account.builder_fee_amount, 0);
+
+    // An order with no unsettled builder fee can be closed.
+    let signature = client.close_order(&order)?.build().await?.send().await?;
+    tracing::info!(%order, %signature, "order cancelled");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_builder_fees() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("claim_builder_fees");
+    let _enter = span.enter();
+
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let builder = deployment.user_client(Deployment::USER_1)?;
+    let store = &deployment.store;
+    let usdg = deployment.token("USDG").expect("must exist").address;
+
+    let signature = builder
+        .prepare_user(store)?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "prepared the builder's user account");
+    let builder_user = builder.find_user_address(store, &builder.payer());
+
+    // Fund the claim vault directly, standing in for settled builder fees
+    // (charging a real fee requires order execution, which cannot record a
+    // builder fee until the execution-side changes land).
+    let claim_amount = 5_000_000;
+    deployment
+        .mint_or_transfer_to("USDG", &builder_user, claim_amount)
+        .await?;
+
+    let signature = builder
+        .prepare_associated_token_account(&usdg, &TOKEN_PROGRAM_ID, None)
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "prepared the receiver vault");
+    let receiver_vault = get_associated_token_address(&builder.payer(), &usdg);
+
+    // The claim requires the per-token controller to have been initialized.
+    builder
+        .claim_builder_fees(store, &usdg, &receiver_vault)
+        .send()
+        .await
+        .expect_err("should throw an error when the controller is not initialized");
+
+    // Only MARKET_KEEPER can initialize the controller.
+    let err = builder
+        .initialize_builder_fee_token_controller(store, &usdg)
+        .send()
+        .await
+        .expect_err("should throw an error when the authority is not a MARKET_KEEPER");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(CoreError::PermissionDenied.into())
+    );
+
+    let signature = keeper
+        .initialize_builder_fee_token_controller(store, &usdg)
+        .send()
+        .await?;
+    tracing::info!(%signature, "initialized the builder fee token controller");
+
+    let receiver_before = deployment
+        .get_ata_amount(&usdg, &builder.payer())
+        .await?
+        .unwrap_or(0);
+
+    let signature = builder
+        .claim_builder_fees(store, &usdg, &receiver_vault)
+        .send()
+        .await?;
+    tracing::info!(%signature, "claimed the builder fees");
+
+    let claim_vault_amount = deployment
+        .get_ata_amount(&usdg, &builder_user)
+        .await?
+        .expect("claim vault must exist");
+    assert_eq!(claim_vault_amount, 0);
+    let receiver_after = deployment
+        .get_ata_amount(&usdg, &builder.payer())
+        .await?
+        .expect("receiver vault must exist");
+    assert_eq!(receiver_after, receiver_before + claim_amount);
+
+    // Claiming with an empty claim vault is an explicit no-op.
+    let signature = builder
+        .claim_builder_fees(store, &usdg, &receiver_vault)
+        .send()
+        .await?;
+    tracing::info!(%signature, "claimed the builder fees again (no-op)");
+
+    let receiver_amount = deployment
+        .get_ata_amount(&usdg, &builder.payer())
+        .await?
+        .expect("receiver vault must exist");
+    assert_eq!(receiver_amount, receiver_after);
+
+    Ok(())
+}

--- a/tests/anchor_test/mod.rs
+++ b/tests/anchor_test/mod.rs
@@ -13,6 +13,8 @@ mod swap;
 
 mod user;
 
+mod builder_fee;
+
 mod shift;
 
 mod market;


### PR DESCRIPTION
Settlement layer of **ADR-1 (Order Builder Fee)**, PR 3 of the stack (on top of the state/config carve-outs from PR 2). This PR builds the rails that move a recorded builder fee from an order's escrow to the builder's wallet — plus the guard that keeps orders from being closed around them. It is still **inert in production**: nothing charges a builder fee yet (that's the execution PR), so `builder_fee_amount` is always zero today and every new code path here reduces to its no-op branch until the rest of the stack lands.

The full asset path introduced here: order escrow → (permissionless `settle_builder_fee`) → builder's claim vault → (owner-only `claim_builder_fees`) → any token account the builder chooses.

## What this adds

- **Close guard**: `CloseOrderV2` now requires `builder_fee_amount == 0` (new appended `CoreError::UnsettledBuilderFee`), so an order with an unsettled fee cannot be reaped — the escrow holding the fee outlives the trade until someone settles. `CloseOrderV2` is the only order-closing path, so this single precondition covers all closes.
- **`settle_builder_fee` (permissionless)**: transfers exactly the recorded `builder_fee_amount` from the order's collateral-token escrow to the builder's claim vault (the ATA owned by the builder's **User Account PDA**), signed with the order's own signer seeds — the same authority the close flow uses. Zeroes the amount and emits `BuilderFeeSettled`. A zero amount is an **explicit no-op** (early return before any account-identity checks), which makes settlement idempotent and lets keepers settle unconditionally.
- **`claim_builder_fees` (owner-only)**: sweeps the full claim-vault balance to a destination token account of the owner's choosing, signed by the User Account PDA itself. Empty vault is an explicit no-op. Emits `BuilderFeeClaimed`.
- **`initialize_builder_fee_token_controller`** wiring: `claim_builder_fees` *requires* the per-token controller account (from PR 2) to exist, even though it has no behavior yet.
- **SDK**: `BuilderFeeOps` (init-controller / settle / claim instruction builders), controller PDA finder, and the regenerated store IDL.
- **Anchor tests**: the settle no-op flow on a real order (create → settle → assert zero → close) and the full claim matrix (fails without controller; controller init is MARKET_KEEPER-gated; claim sweeps exactly the funded amount and empties the vault; second claim is a clean no-op).

## Why permissionless settle is safe

Settlement takes no authority because every account it touches is pinned by state the builder/user already committed to: the builder identity must equal the order's recorded `builder`, the mint must equal the order's recorded collateral token, the escrow must be the order's own recorded escrow account, and the destination is derived (ATA of the builder's User Account for that mint). The amount is exactly the recorded `builder_fee_amount`, and it is zeroed in the same instruction. A griefer can therefore only do the builder a favor: move the exact fee to the builder's own vault. Combined with the close guard, there is no path that strands or redirects a recorded fee.



The claim vault is owned by the User Account PDA precisely so the program can gate withdrawals: `claim_builder_fees` re-derives the User PDA from (store, owner) and requires `owner` as signer, then the PDA signs the transfer. Requiring the controller account today is deliberate — when withdrawal access control (e.g. a timelock) lands, it becomes a pure logic change with no accounts-layout break. It also cannot strand funds: `set_builder_fee` (next PR) will refuse tokens whose controller doesn't exist, so any token with claimable fees necessarily has one.

## IDL / compatibility note

The regenerated IDL rides with the SDK commit (the builders compile against its generated types). Its diff is purely additive for instructions/accounts/events/errors; the only modified existing types are `Factors`, `Order`, `PositionFees`, `UserHeader` — the shape changes from PRs 1–2, which is why decoders must ship in the same release as the rest of the stack.

