### PR TITLE
feat: expose market-status flags in SDK/CLI

### DIFF
--- a/crates/cli/src/commands/market.rs
+++ b/crates/cli/src/commands/market.rs
@@ -28,7 +28,7 @@ use gmsol_sdk::{
     },
     serde::{
         serde_market::{SerdeMarket, SerdeMarketConfig, SerdeMarketConfigBuffer},
-        serde_token_map::SerdeTokenConfig,
+        serde_token_map::{SerdeMarketStatusFlags, SerdeTokenConfig},
         StringPubkey,
     },
     solana_utils::{
@@ -424,7 +424,7 @@ impl super::Command for Market {
 
                 if let Some(token) = token {
                     let config = token_map.get(token).ok_or_eyre("token not found")?;
-                    let serialized = SerdeTokenConfig::try_from(config)?;
+                    let serialized = TokenConfigDisplay::new(SerdeTokenConfig::try_from(config)?);
                     println!(
                         "{}",
                         output.display_keyed_account(
@@ -443,13 +443,16 @@ impl super::Command for Market {
                                     "feeds.chainlink_data_streams.timestamp_adjustment",
                                     "Chainlink TS Adj",
                                 ),
+                                ("market_status.chainlink_data_streams", "Chainlink Status",),
                                 ("feeds.pyth.feed_id", "Pyth Feed"),
                                 ("feeds.pyth.timestamp_adjustment", "Pyth TS Adj",),
+                                ("market_status.pyth", "Pyth Status"),
                                 ("feeds.switchboard.feed_id", "Switchboard Feed"),
                                 (
                                     "feeds.switchboard.timestamp_adjustment",
                                     "Switchboard TS Adj",
                                 ),
+                                ("market_status.switchboard", "Switchboard Status",),
                             ])
                         )?
                     );
@@ -1690,6 +1693,59 @@ struct TokenMetadata {
     uri: String,
     #[serde(default)]
     init: bool,
+}
+
+/// [`SerdeTokenConfig`] augmented with a joined, human-readable summary of
+/// each feed's market-status flags, for CLI display only.
+#[derive(serde::Serialize)]
+struct TokenConfigDisplay {
+    #[serde(flatten)]
+    config: SerdeTokenConfig,
+    market_status: IndexMap<PriceProviderKind, String>,
+}
+
+impl TokenConfigDisplay {
+    fn new(config: SerdeTokenConfig) -> Self {
+        let market_status = config
+            .feeds
+            .iter()
+            .map(|(kind, feed)| (*kind, market_status_summary(&feed.market_status)))
+            .collect();
+        Self {
+            config,
+            market_status,
+        }
+    }
+}
+
+/// Join the set `allow_*` flags into a comma-separated summary, e.g.
+/// `"allow_unknown, halt_regular_hours"`, or `"-"` if none are set.
+fn market_status_summary(flags: &SerdeMarketStatusFlags) -> String {
+    let mut names = Vec::new();
+    if flags.allow_unknown {
+        names.push("allow_unknown");
+    }
+    if flags.allow_pre_market {
+        names.push("allow_pre_market");
+    }
+    if flags.halt_regular_hours {
+        names.push("halt_regular_hours");
+    }
+    if flags.allow_post_market {
+        names.push("allow_post_market");
+    }
+    if flags.allow_overnight {
+        names.push("allow_overnight");
+    }
+    if flags.allow_closed {
+        names.push("allow_closed");
+    }
+
+    if names.is_empty() {
+        "-".to_string()
+    } else {
+        names.join(", ")
+    }
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/crates/cli/src/commands/market.rs
+++ b/crates/cli/src/commands/market.rs
@@ -443,16 +443,19 @@ impl super::Command for Market {
                                     "feeds.chainlink_data_streams.timestamp_adjustment",
                                     "Chainlink TS Adj",
                                 ),
-                                ("market_status.chainlink_data_streams", "Chainlink Status",),
+                                (
+                                    "market_status_summary.chainlink_data_streams",
+                                    "Chainlink Status",
+                                ),
                                 ("feeds.pyth.feed_id", "Pyth Feed"),
                                 ("feeds.pyth.timestamp_adjustment", "Pyth TS Adj",),
-                                ("market_status.pyth", "Pyth Status"),
+                                ("market_status_summary.pyth", "Pyth Status"),
                                 ("feeds.switchboard.feed_id", "Switchboard Feed"),
                                 (
                                     "feeds.switchboard.timestamp_adjustment",
                                     "Switchboard TS Adj",
                                 ),
-                                ("market_status.switchboard", "Switchboard Status",),
+                                ("market_status_summary.switchboard", "Switchboard Status",),
                             ])
                         )?
                     );
@@ -1701,19 +1704,19 @@ struct TokenMetadata {
 struct TokenConfigDisplay {
     #[serde(flatten)]
     config: SerdeTokenConfig,
-    market_status: IndexMap<PriceProviderKind, String>,
+    market_status_summary: IndexMap<PriceProviderKind, String>,
 }
 
 impl TokenConfigDisplay {
     fn new(config: SerdeTokenConfig) -> Self {
-        let market_status = config
+        let market_status_summary = config
             .feeds
             .iter()
             .map(|(kind, feed)| (*kind, market_status_summary(&feed.market_status)))
             .collect();
         Self {
             config,
-            market_status,
+            market_status_summary,
         }
     }
 }
@@ -1778,5 +1781,116 @@ impl SerdeVirtualInventory {
             short_decimals: vi.short_amount_decimals,
             for_swaps,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gmsol_sdk::serde::serde_token_map::{Encoding, SerdeFeedConfig};
+
+    #[allow(clippy::too_many_arguments)]
+    fn flags(
+        allow_unknown: bool,
+        allow_pre_market: bool,
+        halt_regular_hours: bool,
+        allow_post_market: bool,
+        allow_overnight: bool,
+        allow_closed: bool,
+    ) -> SerdeMarketStatusFlags {
+        SerdeMarketStatusFlags {
+            allow_unknown,
+            allow_pre_market,
+            halt_regular_hours,
+            allow_post_market,
+            allow_overnight,
+            allow_closed,
+        }
+    }
+
+    #[test]
+    fn market_status_summary_none_set() {
+        let flags = flags(false, false, false, false, false, false);
+        assert_eq!(market_status_summary(&flags), "-");
+    }
+
+    #[test]
+    fn market_status_summary_joins_set_flags_in_declaration_order() {
+        let flags = flags(true, false, true, false, false, false);
+        assert_eq!(
+            market_status_summary(&flags),
+            "allow_unknown, halt_regular_hours"
+        );
+    }
+
+    #[test]
+    fn market_status_summary_all_set() {
+        let flags = flags(true, true, true, true, true, true);
+        assert_eq!(
+            market_status_summary(&flags),
+            "allow_unknown, allow_pre_market, halt_regular_hours, allow_post_market, allow_overnight, allow_closed"
+        );
+    }
+
+    fn feed_config(
+        feed_id: &str,
+        feed_id_encoding: Encoding,
+        market_status: SerdeMarketStatusFlags,
+    ) -> SerdeFeedConfig {
+        SerdeFeedConfig {
+            feed_id: feed_id.to_string(),
+            feed_id_encoding,
+            timestamp_adjustment: 5,
+            max_deviation_factor: None,
+            market_status,
+        }
+    }
+
+    #[test]
+    fn token_config_display_summarizes_each_provider() {
+        let mut feeds = IndexMap::new();
+        feeds.insert(
+            PriceProviderKind::Pyth,
+            feed_config(
+                "0xabc123",
+                Encoding::Hex,
+                flags(false, true, true, false, false, false),
+            ),
+        );
+        feeds.insert(
+            PriceProviderKind::Switchboard,
+            feed_config(
+                "3M3KHmARtcRUmMBHwsvhCM3xB4gyPWjXfrPUFm2ELk9K",
+                Encoding::Base58,
+                flags(false, false, false, false, false, false),
+            ),
+        );
+
+        let config = SerdeTokenConfig {
+            name: "fBTC".to_string(),
+            is_enabled: true,
+            is_synthetic: false,
+            token_decimals: 8,
+            price_precision: 4,
+            expected_provider: PriceProviderKind::Pyth,
+            feeds,
+            heartbeat_duration: 60,
+        };
+
+        let display = TokenConfigDisplay::new(config);
+        assert_eq!(
+            display
+                .market_status_summary
+                .get(&PriceProviderKind::Pyth)
+                .unwrap(),
+            "allow_pre_market, halt_regular_hours"
+        );
+        assert_eq!(
+            display
+                .market_status_summary
+                .get(&PriceProviderKind::Switchboard)
+                .unwrap(),
+            "-"
+        );
     }
 }

--- a/crates/sdk/src/serde/serde_token_map.rs
+++ b/crates/sdk/src/serde/serde_token_map.rs
@@ -1,5 +1,6 @@
 use gmsol_utils::{
     oracle::PriceProviderKind,
+    price::{MarketStatusFlag, MarketStatusFlagContainer},
     token_config::{FeedConfig, TokenConfig},
 };
 use indexmap::IndexMap;
@@ -78,24 +79,30 @@ pub struct SerdeFeedConfig {
     /// Max deviation factor.
     #[cfg_attr(serde, serde(default))]
     pub max_deviation_factor: Option<Value>,
+    /// Market status flags
+    #[cfg_attr(serde, serde(default))]
+    pub market_status: SerdeMarketStatusFlags,
 }
 
 impl SerdeFeedConfig {
     /// Create from [`FeedConfig`].
     pub fn from_feed_config(kind: PriceProviderKind, config: &FeedConfig) -> Self {
         let max_deviation_factor = config.max_deviation_factor().map(Value::from_u128);
+        let market_status = SerdeMarketStatusFlags::from_container(config.market_status_flags());
         match kind {
             PriceProviderKind::Pyth | PriceProviderKind::ChainlinkDataStreams => Self {
                 feed_id_encoding: Encoding::Hex,
                 feed_id: format!("0x{}", hex::encode(config.feed())),
                 timestamp_adjustment: config.timestamp_adjustment(),
                 max_deviation_factor,
+                market_status,
             },
             _ => Self {
                 feed_id_encoding: Encoding::Base58,
                 feed_id: config.feed().to_string(),
                 timestamp_adjustment: config.timestamp_adjustment(),
                 max_deviation_factor,
+                market_status,
             },
         }
     }
@@ -105,6 +112,30 @@ impl SerdeFeedConfig {
         match self.feed_id_encoding {
             Encoding::Hex => format!("0x{}", self.feed_id),
             Encoding::Base58 => self.feed_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(serde, derive(serde::Serialize, serde::Deserialize))]
+pub struct SerdeMarketStatusFlags {
+    pub allow_unknown: bool,
+    pub allow_pre_market: bool,
+    pub halt_regular_hours: bool,
+    pub allow_post_market: bool,
+    pub allow_overnight: bool,
+    pub allow_closed: bool,
+}
+
+impl SerdeMarketStatusFlags {
+    pub fn from_container(container: MarketStatusFlagContainer) -> Self {
+        Self {
+            allow_unknown: container.get_flag(MarketStatusFlag::AllowUnknown),
+            allow_pre_market: container.get_flag(MarketStatusFlag::AllowPreMarket),
+            halt_regular_hours: container.get_flag(MarketStatusFlag::HaltRegularHours),
+            allow_post_market: container.get_flag(MarketStatusFlag::AllowPostMarket),
+            allow_overnight: container.get_flag(MarketStatusFlag::AllowOvernight),
+            allow_closed: container.get_flag(MarketStatusFlag::AllowClosed),
         }
     }
 }


### PR DESCRIPTION
v0.10.0 added a per-feed market-status policy (`MarketStatusFlag` / `FeedConfig::market_status_flags`, a `u8` bitmap resolving how each `MarketStatus` reading resolves to open/closed) with a MARKET_KEEPER-gated setter, but no read-side visibility: the raw bitmap had no serde support, and neither the SDK's token-map view nor the CLI surfaced it. Users could set the policy but not see it. This PR closes that gap.

## What this adds

- **`MarketStatusFlag` is now serializable and iterable** (`crates/utils/src/price/market_status.rs`): `serde` (snake_case, matching the existing `clap::ValueEnum` naming so CLI input and JSON output agree), `strum::Display` (snake_case), and `strum::EnumIter` behind the existing `enum-iter` feature — the same gating pattern already used for `PriceProviderKind`.
- **`SerdeFeedConfig` gains `market_status_flags: u8`** (`crates/sdk/src/serde/serde_token_map.rs`), populated from `FeedConfig::market_status_flags().into_value()` in both match arms of `from_feed_config`. `#[serde(default)]` so existing serialized token-map dumps without the field still deserialize.
- **CLI decodes the bitmap for display** (`crates/cli/src/commands/market.rs`): `TokenConfigDisplay` wraps `SerdeTokenConfig` (via `#[serde(flatten)]`) and adds a per-provider `market_status: IndexMap<PriceProviderKind, String>` of decoded flag names, e.g. `"allow_pre_market, halt_regular_hours"`, rendered as `"-"` when no flags are set. Wired into the existing `market_status.<provider>` keys in the account-display output alongside the feed/timestamp-adjustment columns.

## Design decision: raw bitmap in the SDK, decoding only in the CLI (review focus)

`SerdeFeedConfig` deliberately exposes the **raw `u8`**, not a decoded flag list. `MarketStatusFlag` is `#[non_exhaustive]` and append-only over a live bitmap (each variant's position is a persisted bit), so a future flag added on-chain would be silently dropped by any SDK-level decode step running an older build — exactly the kind of round-trip data loss the SDK's serde views elsewhere avoid (see `max_deviation_factor`'s own `#[serde(default)]` precedent). Keeping the SDK layer as the raw, lossless value pushes decoding to the CLI's display-only `TokenConfigDisplay`, which explicitly reports bits it doesn't recognize as `"unknown (bit N)"` rather than dropping them — so an out-of-date CLI degrades legibly instead of hiding information.

## Tests

- `market_status.rs`: `Display`/serde snake_case naming per variant; JSON round-trip; `EnumIter` yields all variants in declaration order.
- `serde_token_map.rs`: bitmap round-trips through JSON for zero, a single flag, combined flags, and an unknown high bit (constructed directly via the container, bypassing the enum, to simulate a future flag this build doesn't recognize); `from_feed_config` surfaces the flags identically in both provider match arms, and defaults to zero when unset.
- `commands/market.rs`: `decode_market_status_flags` unit tests (zero, single flag, combined flags, unknown-bit-only, known+unknown mixed) and one end-to-end test that `TokenConfigDisplay` decodes per-provider flags from a constructed `SerdeTokenConfig`.

## Compatibility

Additive and backward compatible: new field is `#[serde(default)]` on the SDK struct, and the CLI change only adds output columns. No account layout or instruction changes.
