### PR TITLE
feat(store): initialize increase orders' final output token at creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- sdk(sdk): Added `CreateOrderBuilder::prepare_final_output_token_escrow`, opting an increase order into providing its final output token escrow at creation. The escrow is what a builder fee would be paid out of, so an increase order created without it cannot be given one. Off by default, leaving the previous behavior unchanged.
 - sdk(solana-utils): Added `Bundle::send_all_with_opts_detailed`, returning one `Result` per transaction with stable bundle indices.
 - sdk(solana-utils): Added `Error::SendAborted` for unsent transactions after an early bundle abort.
 - sdk(solana-utils): Made `compress_send_results` public so callers can map detailed results to the legacy signature list.
 
 ### Changed
 
+- programs(store): An increase order now initializes its final output token at creation when the escrow is provided, and its final output token must equal the position's collateral token. Creating one with a different final output token used to succeed and silently ignore the value; it now reverts. Existing orders with an uninitialized final output token keep executing unchanged.
 - sdk(solana-utils): Kept the two-argument `Bundle::send_all_with_opts` as a deprecated compatibility wrapper around the detailed API. It still returns the compressed success-signature list, and when multiple transactions fail it returns the **last** real send error (matching prior overwrite semantics; `SendAborted` placeholders are ignored).
 
 ## [0.10.0] - 2026-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- programs(store): Creating an increase order now requires its final output token to be the position's collateral token, and executing one whose final output token was recorded at creation revalidates the same thing. Creating an order with a different final output token used to succeed and silently ignore the value; it now reverts with `TokenMintMismatched`. Existing orders with an uninitialized final output token are unaffected and keep executing.
+
 ### Added
 
 - sdk(sdk): Added `CreateOrderBuilder::prepare_final_output_token_escrow`, opting an increase order into providing its final output token escrow at creation. The escrow is what a builder fee would be paid out of, so an increase order created without it cannot be given one. Off by default, leaving the previous behavior unchanged.
@@ -16,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- programs(store): An increase order now initializes its final output token at creation when the escrow is provided, and its final output token must equal the position's collateral token. Creating one with a different final output token used to succeed and silently ignore the value; it now reverts. Existing orders with an uninitialized final output token keep executing unchanged.
+- programs(store): An increase order now records its final output token at creation when the escrow is provided, which is what makes it eligible for a builder fee later.
 - sdk(solana-utils): Kept the two-argument `Bundle::send_all_with_opts` as a deprecated compatibility wrapper around the detailed API. It still returns the compressed success-signature list, and when multiple transactions fail it returns the **last** real send error (matching prior overwrite semantics; `SendAborted` placeholders are ignored).
 
 ## [0.10.0] - 2026-08-12

--- a/crates/sdk/src/client/ops/exchange/order.rs
+++ b/crates/sdk/src/client/ops/exchange/order.rs
@@ -121,6 +121,7 @@ pub struct CreateOrderBuilder<'a, C> {
     receiver: Pubkey,
     callback: Option<Callback>,
     alts: HashMap<Pubkey, Vec<Pubkey>>,
+    prepare_final_output_token_escrow: bool,
 }
 
 /// Create Order Hint.
@@ -160,6 +161,7 @@ where
             receiver: client.payer(),
             callback: None,
             alts: Default::default(),
+            prepare_final_output_token_escrow: false,
         }
     }
 
@@ -254,6 +256,19 @@ where
     /// Defaults to should unwrap.
     pub fn should_unwrap_native_token(&mut self, should_unwrap: bool) -> &mut Self {
         self.should_unwrap_native_token = should_unwrap;
+        self
+    }
+
+    /// Prepare and pass the final output token escrow for **increase** orders.
+    ///
+    /// Increase orders are not required to provide it, and by default this builder does not, which
+    /// leaves the order's final output token uninitialized. Opt in when the order may later be
+    /// given a builder fee: the fee is charged in the final output token and paid out of that
+    /// escrow, so `set_builder_fee` requires the escrow to be present on the order.
+    ///
+    /// Has no effect on swap and decrease orders, which always provide it.
+    pub fn prepare_final_output_token_escrow(&mut self, prepare: bool) -> &mut Self {
+        self.prepare_final_output_token_escrow = prepare;
         self
     }
 
@@ -492,13 +507,16 @@ where
             let ata = get_associated_token_address(&receiver, token);
             (escrow, ata)
         });
-        let final_output_token_accounts = if is_swap || is_decrease {
-            let escrow = get_associated_token_address(&order, &final_output_token);
-            let ata = get_associated_token_address(&receiver, &final_output_token);
-            Some((escrow, ata))
-        } else {
-            None
-        };
+        // Swap and decrease orders always need it; increase orders only when the caller opts in,
+        // which is what makes the order eligible for a builder fee later.
+        let final_output_token_accounts =
+            if is_swap || is_decrease || self.prepare_final_output_token_escrow {
+                let escrow = get_associated_token_address(&order, &final_output_token);
+                let ata = get_associated_token_address(&receiver, &final_output_token);
+                Some((escrow, ata))
+            } else {
+                None
+            };
         let position = self.position().await?;
         let user = self.client.find_user_address(&self.store, owner);
 
@@ -564,6 +582,12 @@ where
                     &token_program_id,
                     Some(&receiver),
                 );
+
+                // Opting into the final output token escrow requires no additional preparation
+                // instruction: for an increase order the final output token is the collateral
+                // token, i.e. the long or short token, so its escrow is one of the two prepared
+                // above. The opt-in only changes which accounts are passed, via
+                // `final_output_token_accounts`.
 
                 let prepare_position = self
                     .client

--- a/programs/store/src/instructions/exchange/order.rs
+++ b/programs/store/src/instructions/exchange/order.rs
@@ -405,6 +405,22 @@ impl<'info> internal::Create<'info, Order> for CreateOrderV2<'info> {
                     .execute()?;
             }
             OrderKind::MarketIncrease | OrderKind::LimitIncrease => {
+                // The final output token is where a builder fee would be charged, so for an
+                // increase order it must be the position's collateral token. The check lives here
+                // rather than in the operation because the escrow is optional: without it the ops
+                // layer never sees the requested mint, while this account is always provided, so
+                // this is the only place that covers every increase-creation path.
+                let collateral_token = if params.is_collateral_long {
+                    self.market.load()?.meta().long_token_mint
+                } else {
+                    self.market.load()?.meta().short_token_mint
+                };
+                require_keys_eq!(
+                    self.final_output_token.key(),
+                    collateral_token,
+                    CoreError::TokenMintMismatched
+                );
+
                 let initial_collateral = self
                     .initial_collateral_token_escrow
                     .as_ref()
@@ -426,8 +442,7 @@ impl<'info> internal::Create<'info, Order> for CreateOrderV2<'info> {
                     .initial_collateral_token(initial_collateral.as_ref())
                     .long_token(long_token.as_ref())
                     .short_token(short_token.as_ref())
-                    .final_output_token(&self.final_output_token)
-                    .final_output_token_escrow(self.final_output_token_escrow.as_deref())
+                    .final_output_token(self.final_output_token_escrow.as_deref())
                     .build()
                     .execute()?;
             }

--- a/programs/store/src/instructions/exchange/order.rs
+++ b/programs/store/src/instructions/exchange/order.rs
@@ -259,7 +259,11 @@ pub struct CreateOrderV2<'info> {
     )]
     pub initial_collateral_token_escrow: Option<Box<Account<'info, TokenAccount>>>,
     /// Final output token escrow account.
-    /// Only required by decrease and swap orders.
+    ///
+    /// Required by decrease and swap orders. Optional for increase orders: when provided, it is
+    /// recorded on the order and becomes the account a builder fee would be paid out of, and when
+    /// omitted the order's final output token is left uninitialized, so no builder fee can be set
+    /// on it later.
     #[account(
         mut,
         associated_token::mint = final_output_token,
@@ -422,6 +426,8 @@ impl<'info> internal::Create<'info, Order> for CreateOrderV2<'info> {
                     .initial_collateral_token(initial_collateral.as_ref())
                     .long_token(long_token.as_ref())
                     .short_token(short_token.as_ref())
+                    .final_output_token(&self.final_output_token)
+                    .final_output_token_escrow(self.final_output_token_escrow.as_deref())
                     .build()
                     .execute()?;
             }

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -149,7 +149,7 @@ impl<'a, 'info> CreateOrderOperation<'a, 'info> {
     ) -> CreateIncreaseOrderOperationBuilder<
         'a,
         'info,
-        ((CreateOrderOperation<'a, 'info>,), (), (), (), ()),
+        ((CreateOrderOperation<'a, 'info>,), (), (), (), (), (), ()),
     > {
         CreateIncreaseOrderOperation::builder().common(self)
     }
@@ -356,6 +356,20 @@ pub(crate) struct CreateIncreaseOrderOperation<'a, 'info> {
     initial_collateral_token: &'a Account<'info, TokenAccount>,
     long_token: &'a Account<'info, TokenAccount>,
     short_token: &'a Account<'info, TokenAccount>,
+    /// The final output token mint, always provided by the instruction.
+    ///
+    /// It is validated to be the collateral token in
+    /// [`init_increase`](OrderActionParams::init_increase).
+    final_output_token: &'a Account<'info, Mint>,
+    /// The escrow for the final output token.
+    ///
+    /// Optional for increase orders: clients that do not intend to use a builder fee can keep
+    /// omitting it, and the order's final output token is then left uninitialized, exactly as
+    /// before this account was read at all. When it is provided, both halves of
+    /// [`OrderTokenAccounts::final_output_token`] are initialized from it. The account is
+    /// constrained to be the ATA of `final_output_token` owned by the order, so no further
+    /// validation of the escrow itself is needed here.
+    final_output_token_escrow: Option<&'a Account<'info, TokenAccount>>,
 }
 
 impl CreateIncreaseOrderOperation<'_, '_> {
@@ -376,11 +390,15 @@ impl CreateIncreaseOrderOperation<'_, '_> {
                     .init(self.initial_collateral_token);
                 tokens.long_token.init(self.long_token);
                 tokens.short_token.init(self.short_token);
+                if let Some(escrow) = self.final_output_token_escrow {
+                    tokens.final_output_token.init(escrow);
+                }
                 params.init_increase(
                     create.is_long,
                     create.kind,
                     self.position.key(),
                     collateral_token,
+                    self.final_output_token.key(),
                     create.initial_collateral_delta_amount,
                     create.size_delta_value,
                     create.trigger_price,
@@ -1499,6 +1517,26 @@ fn execute_increase_position(
     event: &mut TradeData,
     order: &mut Order,
 ) -> Result<u128> {
+    // The builder fee is charged in the order's final output token, so for an increase order that
+    // token, and therefore the escrow it is paid out of, must belong to the position's collateral
+    // token. Orders created before the final output token was initialized at creation time carry
+    // `None` here and are skipped, otherwise every one of them would stop executing.
+    //
+    // The escrow itself needs no check: the account passed to the execute instruction is
+    // constrained to equal the one stored on the order, and to be the ATA of the passed final
+    // output token mint. Since an ATA address determines its mint, a mismatching mint cannot get
+    // this far.
+    //
+    // Once the builder fee lands, `set_builder_fee` is what requires the escrow to be present, so
+    // that is what makes this validation run for every fee-bearing order.
+    if let Some(final_output_token) = order.tokens.final_output_token.token() {
+        require_keys_eq!(
+            final_output_token,
+            *position.collateral_token(),
+            CoreError::TokenMintMismatched
+        );
+    }
+
     let params = &order.params;
 
     // Perform swap.

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -149,7 +149,7 @@ impl<'a, 'info> CreateOrderOperation<'a, 'info> {
     ) -> CreateIncreaseOrderOperationBuilder<
         'a,
         'info,
-        ((CreateOrderOperation<'a, 'info>,), (), (), (), (), (), ()),
+        ((CreateOrderOperation<'a, 'info>,), (), (), (), (), ()),
     > {
         CreateIncreaseOrderOperation::builder().common(self)
     }
@@ -356,20 +356,14 @@ pub(crate) struct CreateIncreaseOrderOperation<'a, 'info> {
     initial_collateral_token: &'a Account<'info, TokenAccount>,
     long_token: &'a Account<'info, TokenAccount>,
     short_token: &'a Account<'info, TokenAccount>,
-    /// The final output token mint, always provided by the instruction.
-    ///
-    /// It is validated to be the collateral token in
-    /// [`init_increase`](OrderActionParams::init_increase).
-    final_output_token: &'a Account<'info, Mint>,
     /// The escrow for the final output token.
     ///
     /// Optional for increase orders: clients that do not intend to use a builder fee can keep
     /// omitting it, and the order's final output token is then left uninitialized, exactly as
     /// before this account was read at all. When it is provided, both halves of
-    /// [`OrderTokenAccounts::final_output_token`] are initialized from it. The account is
-    /// constrained to be the ATA of `final_output_token` owned by the order, so no further
-    /// validation of the escrow itself is needed here.
-    final_output_token_escrow: Option<&'a Account<'info, TokenAccount>>,
+    /// [`OrderTokenAccounts::final_output_token`] are initialized from it, after its mint has
+    /// been validated to be the collateral token.
+    final_output_token: Option<&'a Account<'info, TokenAccount>>,
 }
 
 impl CreateIncreaseOrderOperation<'_, '_> {
@@ -390,7 +384,17 @@ impl CreateIncreaseOrderOperation<'_, '_> {
                     .init(self.initial_collateral_token);
                 tokens.long_token.init(self.long_token);
                 tokens.short_token.init(self.short_token);
-                if let Some(escrow) = self.final_output_token_escrow {
+                if let Some(escrow) = self.final_output_token {
+                    // The builder fee is charged in the order's final output token, so for an
+                    // increase order that token has to be the position's collateral token. The
+                    // instruction layer enforces the same thing unconditionally; this is the
+                    // second line of defense, and the only one that can run here, since without
+                    // the escrow the ops layer never learns which mint was requested.
+                    require_keys_eq!(
+                        escrow.mint,
+                        collateral_token,
+                        CoreError::TokenMintMismatched
+                    );
                     tokens.final_output_token.init(escrow);
                 }
                 params.init_increase(
@@ -398,7 +402,6 @@ impl CreateIncreaseOrderOperation<'_, '_> {
                     create.kind,
                     self.position.key(),
                     collateral_token,
-                    self.final_output_token.key(),
                     create.initial_collateral_delta_amount,
                     create.size_delta_value,
                     create.trigger_price,

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -751,6 +751,7 @@ impl OrderActionParams {
         kind: OrderKind,
         position: Pubkey,
         collateral_token: Pubkey,
+        final_output_token: Pubkey,
         initial_collateral_delta_amount: u64,
         size_delta_value: u128,
         trigger_price: Option<u128>,
@@ -758,6 +759,15 @@ impl OrderActionParams {
         min_output: Option<u128>,
         valid_from_ts: Option<i64>,
     ) -> Result<()> {
+        // The builder fee is charged in the order's final output token, so for an increase order
+        // that token has to be the position's collateral token. This is the choke point every
+        // increase-order creation path goes through, so validating here covers all of them.
+        require_keys_eq!(
+            final_output_token,
+            collateral_token,
+            CoreError::TokenMintMismatched
+        );
+
         self.kind = kind.into();
         self.side = if is_long {
             OrderSide::Long

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -751,7 +751,6 @@ impl OrderActionParams {
         kind: OrderKind,
         position: Pubkey,
         collateral_token: Pubkey,
-        final_output_token: Pubkey,
         initial_collateral_delta_amount: u64,
         size_delta_value: u128,
         trigger_price: Option<u128>,
@@ -759,15 +758,6 @@ impl OrderActionParams {
         min_output: Option<u128>,
         valid_from_ts: Option<i64>,
     ) -> Result<()> {
-        // The builder fee is charged in the order's final output token, so for an increase order
-        // that token has to be the position's collateral token. This is the choke point every
-        // increase-order creation path goes through, so validating here covers all of them.
-        require_keys_eq!(
-            final_output_token,
-            collateral_token,
-            CoreError::TokenMintMismatched
-        );
-
         self.kind = kind.into();
         self.side = if is_long {
             OrderSide::Long

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -906,9 +906,10 @@ async fn increase_order_with_escrow_initializes_final_output_token() -> eyre::Re
 /// revert, leaving no order account behind. The SDK always passes the collateral token for increase
 /// orders, so the mismatch is produced by rewriting that one account on the built instruction.
 ///
-/// The order is deliberately built **without** the escrow: when the escrow is provided, Anchor's
-/// own `associated_token::mint = final_output_token` constraint rejects a rewritten mint before the
-/// creation-time validation is reached, so this path is the only one that exercises it.
+/// The order is deliberately built **without** the escrow, which is also the case only the
+/// instruction-layer check can catch: with no escrow the operation never learns which mint was
+/// requested. When the escrow is provided, Anchor's own `associated_token::mint =
+/// final_output_token` constraint rejects a rewritten mint before either validation is reached.
 #[tokio::test]
 async fn increase_order_with_mismatched_final_output_token_should_fail() -> eyre::Result<()> {
     let deployment = current_deployment().await?;

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -1,10 +1,13 @@
 use std::time::Duration;
 
+use anchor_spl::associated_token::get_associated_token_address;
+use eyre::OptionExt;
 use gmsol_programs::gmsol_store::types::{DecreasePositionSwapType, UpdateOrderParams};
 use gmsol_sdk::{
     client::ops::{ExchangeOps, MarketOps},
     constants::MARKET_USD_UNIT,
 };
+use gmsol_store::CoreError;
 use gmsol_utils::market::MarketConfigKey;
 use tracing::Instrument;
 
@@ -760,6 +763,235 @@ async fn update_order() -> eyre::Result<()> {
     let signature = client.close_order(&order)?.build().await?.send().await?;
 
     tracing::info!(%order, %signature, "cancelled a limit order");
+
+    Ok(())
+}
+
+/// An increase order created **without** the optional final output token escrow keeps behaving as
+/// it did before: the final output token stays uninitialized, while the long and short token slots
+/// are filled. This is the backward-compatibility case, and the one every client that does not
+/// intend to set a builder fee keeps hitting.
+#[tokio::test]
+async fn increase_order_without_escrow_leaves_final_output_token_uninitialized() -> eyre::Result<()>
+{
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("increase_order_without_escrow");
+    let _enter = span.enter();
+
+    let client = deployment.user_client(Deployment::DEFAULT_USER)?;
+    let store = &deployment.store;
+    let fbtc = deployment.token("fBTC").expect("must exist");
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    let collateral_amount = 100_000;
+    deployment
+        .mint_or_transfer_to_user("fBTC", Deployment::DEFAULT_USER, collateral_amount)
+        .await?;
+
+    let size = 5_000 * MARKET_USD_UNIT;
+    let price = 400_000 * MARKET_USD_UNIT / 10u128.pow(fbtc.config.decimals as u32);
+    let (rpc, order) = client
+        .limit_increase(
+            store,
+            market_token,
+            false,
+            size,
+            price,
+            true,
+            collateral_amount,
+        )
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created a limit increase order");
+
+    let created = client.order(&order).await?;
+    let final_output_token = created.tokens.final_output_token.token_and_account();
+    let long_token = created.tokens.long_token.token_and_account();
+
+    tracing::info!(?final_output_token, ?long_token, "order token slots");
+    assert!(
+        final_output_token.is_none(),
+        "an increase order created without the escrow must leave the final output token uninitialized, got {final_output_token:?}"
+    );
+    assert!(
+        long_token.is_some(),
+        "the long token slot must be initialized at creation"
+    );
+
+    let signature = client.close_order(&order)?.build().await?.send().await?;
+    tracing::info!(%order, %signature, "cancelled the order");
+
+    Ok(())
+}
+
+/// An increase order created **with** the optional final output token escrow records both halves of
+/// the final output token: the mint is the position's collateral token, and the account is that
+/// token's escrow under the order. This is the shape a builder fee needs, since the fee is charged
+/// in the final output token and paid out of that escrow.
+#[tokio::test]
+async fn increase_order_with_escrow_initializes_final_output_token() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("increase_order_with_escrow");
+    let _enter = span.enter();
+
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let client = deployment.user_client(Deployment::DEFAULT_USER)?;
+    let store = &deployment.store;
+    let oracle = &deployment.oracle();
+    let fbtc = deployment.token("fBTC").expect("must exist");
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    // Deliberately small: this test shares the market with the other order tests and executes for
+    // real, so it keeps its footprint on open interest and pool balances negligible.
+    let collateral_amount = 10_000;
+    deployment
+        .mint_or_transfer_to_user("fBTC", Deployment::DEFAULT_USER, collateral_amount * 2)
+        .await?;
+
+    let size = 100 * MARKET_USD_UNIT;
+    let (rpc, order) = client
+        .market_increase(store, market_token, true, collateral_amount, true, size)
+        .prepare_final_output_token_escrow(true)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created an increase order with the escrow");
+
+    let created = client.order(&order).await?;
+    let (token, account) = created
+        .tokens
+        .final_output_token
+        .token_and_account()
+        .ok_or_eyre("final output token must be initialized when the escrow is provided")?;
+
+    assert_eq!(
+        token, fbtc.address,
+        "the final output token must be the collateral token"
+    );
+    assert_eq!(
+        account,
+        get_associated_token_address(&order, &token),
+        "the final output token account must be the order's escrow for that token"
+    );
+
+    // Executing it is what exercises the execution-time validation: with the slot initialized, the
+    // check that the final output token is the collateral token actually runs, instead of being
+    // skipped as it is for orders created without the escrow.
+    let mut builder = keeper.execute_order(store, oracle, &order, false)?;
+    deployment
+        .execute_with_pyth(
+            builder
+                .add_alt(deployment.common_alt().clone())
+                .add_alt(deployment.market_alt().clone()),
+            None,
+            true,
+            true,
+        )
+        .await?;
+    tracing::info!(%order, "executed the increase order carrying the escrow");
+
+    Ok(())
+}
+
+/// Creating an increase order whose final output token is not the position's collateral token must
+/// revert, leaving no order account behind. The SDK always passes the collateral token for increase
+/// orders, so the mismatch is produced by rewriting that one account on the built instruction.
+///
+/// The order is deliberately built **without** the escrow: when the escrow is provided, Anchor's
+/// own `associated_token::mint = final_output_token` constraint rejects a rewritten mint before the
+/// creation-time validation is reached, so this path is the only one that exercises it.
+#[tokio::test]
+async fn increase_order_with_mismatched_final_output_token_should_fail() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("increase_order_with_mismatched_final_output_token");
+    let _enter = span.enter();
+
+    let client = deployment.user_client(Deployment::DEFAULT_USER)?;
+    let store = &deployment.store;
+    let fbtc = deployment.token("fBTC").expect("must exist");
+    let usdg = deployment.token("USDG").expect("must exist");
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    let collateral_amount = 100_000;
+    deployment
+        .mint_or_transfer_to_user("fBTC", Deployment::DEFAULT_USER, collateral_amount)
+        .await?;
+
+    let size = 5_000 * MARKET_USD_UNIT;
+    let price = 400_000 * MARKET_USD_UNIT / 10u128.pow(fbtc.config.decimals as u32);
+    let (rpc, order) = client
+        .limit_increase(
+            store,
+            market_token,
+            false,
+            size,
+            price,
+            true,
+            collateral_amount,
+        )
+        .build_with_address()
+        .await?;
+
+    // The collateral is the long token (fBTC), so pointing the final output token at the short
+    // token (USDG) is exactly the case the creation-time validation must reject. Only that one
+    // account may be rewritten: fBTC is also the initial collateral token and the long token, and
+    // it appears again in the escrow-preparation instructions, so a blanket search-and-replace
+    // would trip a different check first.
+    const FINAL_OUTPUT_TOKEN_INDEX: usize = 8;
+    // Without the compute budget instructions: they are re-added when the rewritten instructions
+    // are sent, and Solana rejects a transaction that carries the same one twice.
+    let mut instructions = rpc.instructions_with_options(true, None, None);
+    let create_order = instructions
+        .iter_mut()
+        .filter(|ix| ix.program_id == gmsol_store::ID)
+        .max_by_key(|ix| ix.accounts.len())
+        .ok_or_eyre("the create-order instruction must be present")?;
+    let account = create_order
+        .accounts
+        .get_mut(FINAL_OUTPUT_TOKEN_INDEX)
+        .ok_or_eyre("the create-order instruction must carry the final output token")?;
+    assert_eq!(
+        account.pubkey, fbtc.address,
+        "account {FINAL_OUTPUT_TOKEN_INDEX} is expected to be the final output token; the account \
+         order of `CreateOrderV2` must have changed"
+    );
+    account.pubkey = usdg.address;
+
+    let err = client
+        .store_transaction()
+        .pre_instructions(instructions, true)
+        .send()
+        .await
+        .expect_err("the final output token must equal the collateral token");
+    let err = gmsol_sdk::Error::from(err);
+    assert_eq!(
+        err.anchor_error_code(),
+        Some(CoreError::TokenMintMismatched.into()),
+        "unexpected error: {err:?}"
+    );
+
+    let err = client
+        .order(&order)
+        .await
+        .err()
+        .ok_or_eyre("no order account may exist after the creation reverted")?;
+    assert!(
+        matches!(err, gmsol_sdk::Error::NotFound),
+        "expected the order account to be absent, got {err:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

An increase order can now initialize its final output token at creation. The escrow stays **optional**
for increase orders, exactly as before: when it is passed, both halves of the order's final output token
slot are recorded and the mint is validated to be the position's collateral token; when it is omitted,
the slot stays uninitialized and nothing changes.

This is what makes an increase order eligible for a builder fee later. The fee is charged in the final
output token and paid out of that escrow (ADR-0001), so an order created without the escrow can never be
given one. Requiring the escrow to be present is deliberately not done here; it belongs to the
owner-signed `set_builder_fee` instruction.

## What's here

- `create_order_v2` validates `final_output_token == collateral_token` for increase orders before it
  builds the operation. That account is always provided, so the check covers every increase-creation path,
  and it keeps `init_increase` free of a token concern that means nothing at that level. It reuses
  `CoreError::TokenMintMismatched`, the same error the neighbouring long/short token checks raise, instead
  of adding a new error variant.
- `CreateIncreaseOrderOperation` takes the optional escrow as its source of truth. When it is provided, its
  mint is validated against the collateral token and `tokens.final_output_token` is initialized from it;
  when it is omitted the slot stays uninitialized. This is the second of the two layers, and the only check
  that can run there, since without the escrow the operation never learns which mint was requested.
- `execute_increase_position` validates that the stored final output token equals the position's collateral
  token, **only when that slot is set**. Orders created before this change carry `None` and are skipped,
  otherwise every one of them would stop executing.
- Doc comments: `final_output_token_escrow` is now documented as optional for increase orders rather than
  "only required by decrease and swap orders", and both validation sites carry a comment explaining what a
  builder fee will require of them.
- SDK: `CreateOrderBuilder::prepare_final_output_token_escrow`, off by default (see "For review").

## Behavior change

One, and it is the intended one: creating an increase order whose final output token differs from the
collateral token used to succeed and silently ignore the value. It now reverts with `TokenMintMismatched`
and no order is created. Everything else is additive.

Failure semantics at execution time, since the ACs do not spell them out: an error raised inside
`perform_execution` is turned into a cancellation unless the keeper passes `throw_on_execution_error`, so a
mismatch on an already-created order cancels that order and the keeper's transaction still succeeds. This
matches ADR-0001's "the execution-side rejection cancels the order rather than reverting".

## Breaking-change verification

Checked every surface the optional-escrow shape touches. **Verdict: non-breaking on all of them, no client
or keeper release coordination needed.**

| # | Surface | Finding |
|---|---|---|
| 1 | Create, old client (passes `None`) | Identical to today: the slot stays uninitialized. Grandfathered by design; such orders simply cannot receive a builder fee later. |
| 2 | Create, new client + old program | Safe in either deploy order: `final_output_token_escrow` is already `Option` in `CreateOrderV2` with only ATA constraints, and today's program validates then ignores it on increase. |
| 3 | Create, `Some` + new program | The ATA constraints already force `escrow == ATA(order, final_output_token)`; this PR adds the mint check and the init. Since the mint must equal the collateral token, the address coincides with the collateral-side escrow, so the stored bytes match the shape decrease orders already produce today. |
| 4 | Execute, on-chain | The constraint is `Option` equality, stored vs passed. Old orders (`None`) need `None`: unchanged. New orders (`Some`) need `Some`: see #5. |
| 5 | Execute, keeper side | The SDK's increase/swap branch maps `final_output_token_and_account` read from the stored order as a plain `Option`, with no order-kind gating and no `ok_or`, so even an old keeper binary auto-includes the mint, escrow and vault for new orders. The `ok_or("missing final output token")` path exists only in the decrease branch, where the hint is always `Some`. |
| 6 | Execute, runtime | No builder fee exists yet, so `TransferOut.final_output_token` stays 0 for increase: the accounts are present but untouched. |
| 7 | Close, on-chain | Constraint is again stored vs passed. `transfer_to_atas` keeps a `seen` set and skips an escrow it has already handled, so the duplicated final == collateral-side escrow is transferred and closed exactly once by explicit design. The payout target is the receiver's ATA of the same mint either way. |
| 8 | Close, SDK side | Same plain-`Option` hint mapping as #5, no kind gating: old binaries adapt on their own. |
| 9 | `update_order_v2` | Touches params only, cannot corrupt the initialized token slots. |
| 10 | IDL / ABI | No account-list or argument changes; the account is already optional in the IDL, only doc comments move. Passing the escrow costs about one byte on the wire, since it is the same pubkey as the long/short escrow and message-level account dedup applies. |
| 11 | Order-kind inference | Grepped `programs/` and `crates/` for presence-based inference on the final output token: nothing treats "has a final output token" as "is a decrease or swap order". |

One caveat worth stating as a client contract: the above holds for clients that assemble accounts from the
order's stored token hints, which is what the SDK does on every v2 path. A third-party integrator that
hardcodes `None` for the increase final-output accounts instead of reading the hints would fail the
stored-vs-passed constraint on new orders.

## Tests

Three cases in `tests/anchor_test/order.rs`:

1. Without the escrow, the final output token slot stays uninitialized while the long and short slots are
   filled. This is the backward-compatibility case and the default every client hits today.
2. With the escrow, both halves are set to the collateral token and its order-owned ATA, and the order is
   then executed for real, so the new execution-time check runs on a live path rather than being asserted
   about.
3. A mismatching final output token reverts with `TokenMintMismatched` and leaves no order account.

The third one has a wrinkle: with the escrow present a wrong mint is unreachable, because the
`associated_token::mint = final_output_token` constraint on the escrow rejects it before either
validation runs. The test therefore builds the instruction without the escrow, which is both the only
path where the mint is unconstrained and the only case the instruction-layer check alone can catch. The
upside is that with the escrow present, two independent layers enforce the same invariant.

## For review

- The SDK opt-in is not covered by the ACs. Today the SDK prepares the final-output escrow only for swap
  and decrease orders, so no client could create an increase order carrying it, and therefore none could ever
  be given a builder fee. I added the minimal opt-in here, off by default, because the tests need it anyway.
  Happy to pull it out if you would rather it landed with the fee work.
- This rests on one assumption: the builder fee is charged in the final output token for increase as well as
  decrease. The creation-time mint validation is what would need revisiting if that direction changes.
- `builders/order/create.rs` has the same integration gap and is deliberately not touched here. Nothing is
  broken there today, since `receive_token` is `None` for increase orders and the mint therefore already
  resolves to the collateral token; what is missing is the opt-in to pass the escrow. Follow-up PR right
  after this one.

## Out of scope

- Requiring the escrow to be present. That check belongs to `set_builder_fee`.
- Any fee computation, accrual or routing.
- Swap and decrease paths: untouched, in both creation and execution.
