### PR TITLE
feat: land builder fee computing and routing behind a zero factor

### DIFF
--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -22672,6 +22672,19 @@
       ]
     },
     {
+      "name": "BuilderFeeCharged",
+      "discriminator": [
+        128,
+        242,
+        205,
+        122,
+        163,
+        166,
+        209,
+        114
+      ]
+    },
+    {
       "name": "BuilderFeeFactorSet",
       "discriminator": [
         4,
@@ -23665,6 +23678,21 @@
       "code": 6130,
       "name": "UnsettledBuilderFee",
       "msg": "order has an unsettled builder fee"
+    },
+    {
+      "code": 6131,
+      "name": "BuilderFeeExceedsCollateral",
+      "msg": "builder fee exceeds the collateral increment"
+    },
+    {
+      "code": 6132,
+      "name": "BuilderFeeFinalOutputTokenMismatch",
+      "msg": "builder fee requires the final output token to equal the collateral token"
+    },
+    {
+      "code": 6133,
+      "name": "BuilderFeeSwapTypeNotAllowed",
+      "msg": "this decrease position swap type is not allowed together with a builder fee"
     }
   ],
   "types": [
@@ -24035,6 +24063,72 @@
                 ]
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFeeCharged",
+      "docs": [
+        "An event indicating that a builder fee has been charged.",
+        "",
+        "Only emitted when the order's builder fee factor is non-zero. Emitted",
+        "even when `paid_amount` is `0` (e.g. fully clamped away by a",
+        "shortfall), so indexers can distinguish \"no builder attached\" from",
+        "\"builder attached but nothing was collectible\" by whether this event",
+        "is present at all."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ts",
+            "docs": [
+              "Timestamp."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slot",
+            "docs": [
+              "Slot."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "store",
+            "docs": [
+              "Store."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "market_token",
+            "docs": [
+              "Market token."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token",
+            "docs": [
+              "The token the builder fee is denominated and paid in."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "payable_amount",
+            "docs": [
+              "The computed builder fee amount, before shortfall clamping."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "paid_amount",
+            "docs": [
+              "The amount actually charged, after shortfall clamping."
+            ],
+            "type": "u128"
           }
         ]
       }

--- a/programs/store/src/events/order.rs
+++ b/programs/store/src/events/order.rs
@@ -217,6 +217,60 @@ impl InitSpace for InsufficientFundingFeePayment {
 
 impl Event for InsufficientFundingFeePayment {}
 
+/// An event indicating that a builder fee has been charged.
+///
+/// Only emitted when the order's builder fee factor is non-zero. Emitted
+/// even when `paid_amount` is `0` (e.g. fully clamped away by a
+/// shortfall), so indexers can distinguish "no builder attached" from
+/// "builder attached but nothing was collectible" by whether this event
+/// is present at all.
+#[event]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone, InitSpace)]
+pub struct BuilderFeeCharged {
+    /// Timestamp.
+    pub ts: i64,
+    /// Slot.
+    pub slot: u64,
+    /// Store.
+    pub store: Pubkey,
+    /// Market token.
+    pub market_token: Pubkey,
+    /// The token the builder fee is denominated and paid in.
+    pub token: Pubkey,
+    /// The computed builder fee amount, before shortfall clamping.
+    pub payable_amount: u128,
+    /// The amount actually charged, after shortfall clamping.
+    pub paid_amount: u128,
+}
+
+impl BuilderFeeCharged {
+    pub(crate) fn new(
+        store: &Pubkey,
+        market_token: &Pubkey,
+        token: &Pubkey,
+        payable_amount: u128,
+        paid_amount: u128,
+    ) -> Result<Self> {
+        let clock = Clock::get()?;
+        Ok(Self {
+            ts: clock.unix_timestamp,
+            slot: clock.slot,
+            store: *store,
+            market_token: *market_token,
+            token: *token,
+            payable_amount,
+            paid_amount,
+        })
+    }
+}
+
+impl InitSpace for BuilderFeeCharged {
+    const INIT_SPACE: usize = <Self as Space>::INIT_SPACE;
+}
+
+impl Event for BuilderFeeCharged {}
+
 /// Order parameters for event.
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -4438,6 +4438,12 @@ pub enum CoreError {
     /// order instead of charging a partial fee.
     #[msg("builder fee exceeds the collateral increment")]
     BuilderFeeExceedsCollateral,
+    /// A non-zero builder fee is being charged on an increase order that
+    /// has no final output token. Initializing it is optional for
+    /// increase orders, and the builder fee is charged in it, so an order
+    /// that never opted in cannot pay one.
+    #[msg("builder fee requires the final output token to equal the collateral token")]
+    BuilderFeeFinalOutputTokenMismatch,
     // NOTE: New variants must be appended here to keep existing error codes stable.
 }
 

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -4444,6 +4444,14 @@ pub enum CoreError {
     /// that never opted in cannot pay one.
     #[msg("builder fee requires the final output token to equal the collateral token")]
     BuilderFeeFinalOutputTokenMismatch,
+    /// A decrease order with a non-zero builder fee used
+    /// `DecreasePositionSwapType::CollateralToPnlToken`. That swap type
+    /// deterministically moves the entire collateral-token output into the
+    /// pnl token before the receive-token swap runs, leaving the final
+    /// output token bucket at zero every time, which would make the
+    /// builder fee trivially and reliably bypassable.
+    #[msg("this decrease position swap type is not allowed together with a builder fee")]
+    BuilderFeeSwapTypeNotAllowed,
     // NOTE: New variants must be appended here to keep existing error codes stable.
 }
 

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -4432,6 +4432,12 @@ pub enum CoreError {
     /// fee; settle it first via `settle_builder_fee`.
     #[msg("order has an unsettled builder fee")]
     UnsettledBuilderFee,
+    /// An increase order's collateral increment cannot fully cover the
+    /// builder fee. Unlike decrease, increase has no equivalent of
+    /// "complete anyway at a loss" to fall back on, so this cancels the
+    /// order instead of charging a partial fee.
+    #[msg("builder fee exceeds the collateral increment")]
+    BuilderFeeExceedsCollateral,
     // NOTE: New variants must be appended here to keep existing error codes stable.
 }
 

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1544,6 +1544,39 @@ fn execute_swap(
     Ok(())
 }
 
+/// Charges the builder fee against an increase order's collateral
+/// increment, in the collateral token, after the pay token has already
+/// been swapped into it. Returns the reduced collateral increment
+/// together with the fee actually charged.
+///
+/// Unlike the decrease path, underpayment here is not tolerated: an
+/// increase order has no equivalent of "complete the close anyway, at a
+/// loss" to fall back on, so if the collateral increment can't fully
+/// cover the fee, this returns an error instead of charging a partial
+/// amount. The caller propagates this as a soft failure (the order is
+/// cancelled), not a transaction revert.
+fn charge_builder_fee_on_collateral_increment(
+    collateral_increment_amount: u64,
+    size_delta_usd: u128,
+    builder_fee_factor: u128,
+    collateral_price: &Price<u128>,
+) -> Result<(u64, u64)> {
+    let payable_amount =
+        compute_builder_fee_amount(size_delta_usd, builder_fee_factor, collateral_price)?;
+    let payable_amount_u64 =
+        u64::try_from(payable_amount).map_err(|_| error!(CoreError::TokenAmountOverflow))?;
+    require_gte!(
+        collateral_increment_amount,
+        payable_amount_u64,
+        CoreError::BuilderFeeExceedsCollateral
+    );
+    // The assertion above guarantees the subtraction succeeds.
+    let collateral_increment_after_fee = collateral_increment_amount
+        .checked_sub(payable_amount_u64)
+        .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
+    Ok((collateral_increment_after_fee, payable_amount_u64))
+}
+
 #[inline(never)]
 fn execute_increase_position(
     oracle: &Oracle,
@@ -2136,5 +2169,77 @@ mod tests {
     #[test]
     fn builder_fee_within_available_is_unchanged() {
         assert_eq!(clamp_builder_fee_amount(10, 100), 10);
+    }
+
+    #[test]
+    fn zero_builder_fee_factor_leaves_collateral_increment_unchanged() {
+        let (collateral_increment_after_fee, fee) = charge_builder_fee_on_collateral_increment(
+            1_000,
+            100_000 * constants::MARKET_USD_UNIT,
+            0,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+        )
+        .unwrap();
+        assert_eq!(fee, 0);
+        assert_eq!(collateral_increment_after_fee, 1_000);
+    }
+
+    #[test]
+    fn charges_expected_builder_fee_on_collateral_increment() {
+        // $100,000 size, 5 bps factor => $50 fee value, at $2/unit => 25 units.
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000;
+        let (collateral_increment_after_fee, fee) = charge_builder_fee_on_collateral_increment(
+            1_000,
+            size_delta_usd,
+            factor,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+        )
+        .unwrap();
+        assert_eq!(fee, 25);
+        assert_eq!(collateral_increment_after_fee, 975);
+    }
+
+    #[test]
+    fn exact_builder_fee_consumes_the_whole_collateral_increment() {
+        // Fee equals the entire collateral increment: allowed, leaves 0.
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000;
+        let (collateral_increment_after_fee, fee) = charge_builder_fee_on_collateral_increment(
+            25,
+            size_delta_usd,
+            factor,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+        )
+        .unwrap();
+        assert_eq!(fee, 25);
+        assert_eq!(collateral_increment_after_fee, 0);
+    }
+
+    #[test]
+    fn builder_fee_underpayment_errors_instead_of_clamping() {
+        // Same fee value as above (25 units), but the swap only produced 10 units.
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000;
+        let err = charge_builder_fee_on_collateral_increment(
+            10,
+            size_delta_usd,
+            factor,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+        )
+        .unwrap_err();
+        assert_eq!(err, error!(CoreError::BuilderFeeExceedsCollateral));
     }
 }

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1740,6 +1740,60 @@ fn execute_increase_position(
     Ok(paid_order_fee_value)
 }
 
+/// Folds an estimate of the builder fee, denominated in the collateral
+/// token, into a decrease order's collateral withdrawal amount, so it can
+/// still be paid even when the position is closed at a loss. Returns the
+/// withdrawal amount including the estimate.
+///
+/// This is only an estimate used to size how much extra collateral to
+/// pull out of the position; the amount actually charged is computed
+/// afterwards, in the final output token, once it's known how much of
+/// that token the withdrawal (and any subsequent swap) actually produced.
+///
+/// Also rejects [`DecreasePositionSwapType::CollateralToPnlToken`]
+/// whenever a builder fee factor is set. This is different from ordinary
+/// underpayment: `NoSwap` can *sometimes* leave less in the final output
+/// token bucket than the fee needs (when the pnl token differs from the
+/// final output token), which is tolerated the same way any other
+/// decrease-side shortfall is. `CollateralToPnlToken`, however,
+/// deterministically moves the *entire* collateral-token output into the
+/// pnl token before the receive-token swap even runs (see
+/// `DecreasePosition::swap_collateral_token_to_pnl_token`), so the final
+/// output token bucket would be zero on every single order that chooses
+/// it. That's not variance, it's a guaranteed way to pay no fee at all,
+/// so it isn't allowed.
+///
+/// The rejection is keyed off the factor rather than off the estimate
+/// computed here. The estimate can round down to zero for a small
+/// requested size delta, while the fee actually charged is computed on
+/// the *executed* size delta, which a decrease may enlarge into a full
+/// close. Gating on a non-zero estimate would therefore admit exactly
+/// the orders that go on to incur a fee they can then bypass.
+fn estimate_builder_fee_for_collateral_withdrawal(
+    collateral_withdrawal_amount: u128,
+    size_delta_usd: u128,
+    builder_fee_factor: u128,
+    collateral_price: &Price<u128>,
+    decrease_position_swap_type: DecreasePositionSwapType,
+) -> Result<u128> {
+    if builder_fee_factor == 0 {
+        return Ok(collateral_withdrawal_amount);
+    }
+
+    require_neq!(
+        decrease_position_swap_type,
+        DecreasePositionSwapType::CollateralToPnlToken,
+        CoreError::BuilderFeeSwapTypeNotAllowed
+    );
+
+    let fee_estimate =
+        compute_builder_fee_amount(size_delta_usd, builder_fee_factor, collateral_price)?;
+
+    collateral_withdrawal_amount
+        .checked_add(fee_estimate)
+        .ok_or_else(|| error!(CoreError::TokenAmountOverflow))
+}
+
 #[allow(clippy::too_many_arguments)]
 #[inline(never)]
 fn execute_decrease_position(
@@ -2302,5 +2356,114 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, error!(CoreError::BuilderFeeExceedsCollateral));
+    }
+
+    #[test]
+    fn zero_builder_fee_factor_leaves_withdrawal_amount_unchanged() {
+        let withdrawal_amount = estimate_builder_fee_for_collateral_withdrawal(
+            1_000,
+            100_000 * constants::MARKET_USD_UNIT,
+            0,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+            DecreasePositionSwapType::NoSwap,
+        )
+        .unwrap();
+        assert_eq!(withdrawal_amount, 1_000);
+    }
+
+    #[test]
+    fn tops_up_withdrawal_amount_by_builder_fee_estimate() {
+        // $100,000 size, 5 bps factor => $50 fee value, at $2/unit => 25 units.
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000;
+        let withdrawal_amount = estimate_builder_fee_for_collateral_withdrawal(
+            1_000,
+            size_delta_usd,
+            factor,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+            DecreasePositionSwapType::PnlTokenToCollateralToken,
+        )
+        .unwrap();
+        // The withdrawal amount grows by the estimate; it is not subtracted.
+        assert_eq!(withdrawal_amount, 1_025);
+    }
+
+    #[test]
+    fn no_swap_is_allowed_with_a_non_zero_builder_fee() {
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000;
+        let result = estimate_builder_fee_for_collateral_withdrawal(
+            1_000,
+            size_delta_usd,
+            factor,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+            DecreasePositionSwapType::NoSwap,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn collateral_to_pnl_token_is_rejected_with_a_non_zero_builder_fee() {
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000;
+        let result = estimate_builder_fee_for_collateral_withdrawal(
+            1_000,
+            size_delta_usd,
+            factor,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+            DecreasePositionSwapType::CollateralToPnlToken,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn collateral_to_pnl_token_is_rejected_when_the_fee_estimate_rounds_to_zero() {
+        // A dust size delta, whose fee value truncates to zero, while the
+        // factor is still set: the executed size delta may be enlarged
+        // into a full close and incur a real fee, so the swap type must
+        // already have been rejected by then.
+        let size_delta_usd = 1_000;
+        let factor = constants::MARKET_USD_UNIT / 2_000;
+        let result = estimate_builder_fee_for_collateral_withdrawal(
+            1_000,
+            size_delta_usd,
+            factor,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+            DecreasePositionSwapType::CollateralToPnlToken,
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            error!(CoreError::BuilderFeeSwapTypeNotAllowed)
+        );
+    }
+
+    #[test]
+    fn collateral_to_pnl_token_is_allowed_when_builder_fee_is_zero() {
+        let result = estimate_builder_fee_for_collateral_withdrawal(
+            1_000,
+            100_000 * constants::MARKET_USD_UNIT,
+            0,
+            &price(
+                2 * constants::MARKET_USD_UNIT,
+                2 * constants::MARKET_USD_UNIT,
+            ),
+            DecreasePositionSwapType::CollateralToPnlToken,
+        );
+        assert!(result.is_ok());
     }
 }

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -4,7 +4,7 @@ use gmsol_callback::interface::ActionKind;
 use gmsol_model::{
     action::decrease_position::{DecreasePositionFlags, DecreasePositionSwapType},
     num::Unsigned,
-    price::Prices,
+    price::{Price, Prices},
     BaseMarket, BaseMarketExt, MarketAction, PnlFactorKind, Position as _, PositionMut,
     PositionMutExt, PositionState, PositionStateExt,
 };
@@ -12,6 +12,7 @@ use gmsol_utils::action::ActionCallbackKind;
 use typed_builder::TypedBuilder;
 
 use crate::{
+    constants,
     events::{EventEmitter, OrderUpdated, PositionDecreased, PositionIncreased, TradeData},
     states::{
         callback::CallbackAuthority,
@@ -1468,6 +1469,39 @@ impl ValidateOracleTime for ExecuteOrderOperation<'_, '_> {
 }
 
 #[inline(never)]
+/// Computes a builder fee amount, denominated in the token of `price`,
+/// from `size_delta_usd` and the builder's fee `factor`.
+///
+/// The amount is rounded up so the fee is never under-collected. Returns
+/// `0` without touching `price` if `factor` is zero, so callers don't need
+/// a meaningful price when no builder fee applies.
+fn compute_builder_fee_amount(
+    size_delta_usd: u128,
+    factor: u128,
+    price: &Price<u128>,
+) -> Result<u128> {
+    if factor == 0 {
+        return Ok(0);
+    }
+
+    let fee_value = gmsol_model::utils::apply_factor::<_, { constants::MARKET_DECIMALS }>(
+        &size_delta_usd,
+        &factor,
+    )
+    .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
+
+    fee_value
+        .checked_round_up_div(price.pick_price(false))
+        .ok_or_else(|| error!(CoreError::TokenAmountOverflow))
+}
+
+/// Clamps a computed builder fee down to at most `available`, so a
+/// builder fee never turns an otherwise-fillable order into a hard
+/// failure.
+fn clamp_builder_fee_amount(fee_amount: u128, available: u128) -> u128 {
+    fee_amount.min(available)
+}
+
 fn execute_swap(
     should_throw_error: &mut bool,
     oracle: &Oracle,
@@ -2048,5 +2082,59 @@ impl PositionCutOperation<'_, '_> {
             .build()
             .execute()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn price(min: u128, max: u128) -> Price<u128> {
+        Price { min, max }
+    }
+
+    #[test]
+    fn zero_builder_fee_factor_yields_zero_fee_without_needing_a_price() {
+        let fee = compute_builder_fee_amount(1_000_000, 0, &price(0, 0)).unwrap();
+        assert_eq!(fee, 0);
+    }
+
+    #[test]
+    fn computes_expected_builder_fee_amount() {
+        // $100,000 size, 5 bps factor => $50 fee value, at $2/unit => 25 units.
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000; // 5 bps
+        let unit_price = 2 * constants::MARKET_USD_UNIT;
+        let fee =
+            compute_builder_fee_amount(size_delta_usd, factor, &price(unit_price, unit_price))
+                .unwrap();
+        assert_eq!(fee, 25);
+    }
+
+    #[test]
+    fn builder_fee_amount_rounds_up_on_remainder() {
+        let size_delta_usd = 100_000 * constants::MARKET_USD_UNIT;
+        let factor = constants::MARKET_USD_UNIT / 2_000; // 5 bps => $50 fee value
+        let unit_price = 3 * constants::MARKET_USD_UNIT;
+        let fee =
+            compute_builder_fee_amount(size_delta_usd, factor, &price(unit_price, unit_price))
+                .unwrap();
+        // 50 / 3 = 16.67, rounded up.
+        assert_eq!(fee, 17);
+    }
+
+    #[test]
+    fn builder_fee_shortfall_clamps_to_available() {
+        assert_eq!(clamp_builder_fee_amount(1_000, 100), 100);
+    }
+
+    #[test]
+    fn builder_fee_clamps_to_zero_when_nothing_is_available() {
+        assert_eq!(clamp_builder_fee_amount(1_000, 0), 0);
+    }
+
+    #[test]
+    fn builder_fee_within_available_is_unchanged() {
+        assert_eq!(clamp_builder_fee_amount(10, 100), 10);
     }
 }

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1578,18 +1578,18 @@ fn charge_builder_fee_on_collateral_increment(
 ) -> Result<(u64, u64)> {
     let payable_amount =
         compute_builder_fee_amount(size_delta_usd, builder_fee_factor, collateral_price)?;
-    let payable_amount_u64 =
+    let payable_amount =
         u64::try_from(payable_amount).map_err(|_| error!(CoreError::TokenAmountOverflow))?;
     require_gte!(
         collateral_increment_amount,
-        payable_amount_u64,
+        payable_amount,
         CoreError::BuilderFeeExceedsCollateral
     );
     // The assertion above guarantees the subtraction succeeds.
     let collateral_increment_after_fee = collateral_increment_amount
-        .checked_sub(payable_amount_u64)
+        .checked_sub(payable_amount)
         .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
-    Ok((collateral_increment_after_fee, payable_amount_u64))
+    Ok((collateral_increment_after_fee, payable_amount))
 }
 
 #[inline(never)]
@@ -1961,16 +1961,31 @@ fn execute_decrease_position(
         )?;
 
         // Builder fee is charged in the final output token, after the
-        // receive-token swap above. Deducting it here, before validating
-        // and transferring out the amounts below, means the order's own
-        // slippage validation and `transfer_out` both naturally see the
-        // post-fee amount: the fee is simply netted out of what would
-        // otherwise be transferred out, so no separate accounting or
-        // balance-validation adjustment is needed. Underpayment is
-        // tolerated (charges whatever is available): unlike increase, this
-        // can't fall back to cancelling the order, since a decrease order
-        // may be closing an insolvent position.
-        let output_amount = if builder_fee_factor != 0 {
+        // receive-token swap above. It is only *recorded* here, never
+        // netted out of `output_amount`: the full output amount is routed
+        // into the final-output-token bucket as usual, so the fee value
+        // physically lands in the order's escrow alongside the user's
+        // payout, and settlement is what later moves the recorded amount
+        // on to the builder. That matches the increase path, which
+        // likewise transfers the fee into the escrow rather than leaving
+        // it behind in the market vault, and it preserves the invariant
+        // settlement relies on: the escrow always covers the recorded
+        // amount. The collateral withdrawal was already topped up by an
+        // estimate of the fee above, so the fee is funded even when the
+        // position closes at a loss.
+        //
+        // Underpayment is tolerated (records whatever the output amount
+        // covers) rather than erroring: unlike increase, this can't fall
+        // back to cancelling the order, since a decrease order may be
+        // closing an insolvent position.
+        //
+        // A consequence of recording rather than netting: the amount
+        // checked against the order's `min_output` below is the gross
+        // payout, before the builder fee is settled out of the escrow.
+        // Builders using `min_output` for slippage control must therefore
+        // account for their own fee, since it is part of the output that
+        // bound is checked against.
+        if builder_fee_factor != 0 {
             let final_output_token_price = oracle.get_primary_price(&final_output_token, false)?;
             // The executed size delta, not the requested one: a decrease may
             // be enlarged into a full close, and in that case the whole
@@ -1984,12 +1999,6 @@ fn execute_decrease_position(
                 &final_output_token_price,
             )?;
             let paid_amount = clamp_builder_fee_amount(payable_amount, output_amount.into());
-            // `paid_amount` is clamped to `output_amount`, so both the
-            // conversion and the subtraction below cannot fail.
-            let output_amount = u64::try_from(paid_amount)
-                .ok()
-                .and_then(|paid| output_amount.checked_sub(paid))
-                .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
 
             // TODO(builder-fee): accumulate `paid_amount` into
             // `order.builder_fee_amount` once that field exists.
@@ -2000,11 +2009,7 @@ fn execute_decrease_position(
                 payable_amount,
                 paid_amount,
             )?)?;
-
-            output_amount
-        } else {
-            output_amount
-        };
+        }
 
         order.validate_decrease_output_amounts(
             oracle,

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -5,15 +5,18 @@ use gmsol_model::{
     action::decrease_position::{DecreasePositionFlags, DecreasePositionSwapType},
     num::Unsigned,
     price::{Price, Prices},
-    BaseMarket, BaseMarketExt, MarketAction, PnlFactorKind, Position as _, PositionMut,
-    PositionMutExt, PositionState, PositionStateExt,
+    BaseMarket, BaseMarketExt, MarketAction, PnlFactorKind, Position as _, PositionExt,
+    PositionMut, PositionMutExt, PositionState, PositionStateExt,
 };
 use gmsol_utils::action::ActionCallbackKind;
 use typed_builder::TypedBuilder;
 
 use crate::{
     constants,
-    events::{EventEmitter, OrderUpdated, PositionDecreased, PositionIncreased, TradeData},
+    events::{
+        BuilderFeeCharged, EventEmitter, OrderUpdated, PositionDecreased, PositionIncreased,
+        TradeData,
+    },
     states::{
         callback::CallbackAuthority,
         common::{
@@ -1106,6 +1109,9 @@ impl ExecuteOrderOperation<'_, '_> {
                             &mut transfer_out,
                             &mut *event_loader.load_mut()?,
                             &mut *self.order.load_mut()?,
+                            // TODO(builder-fee): read the snapshot factor from
+                            // the order once it is captured at order creation.
+                            0,
                         )?;
                         (false, paid_fee_value)
                     }
@@ -1586,6 +1592,7 @@ fn execute_increase_position(
     transfer_out: &mut TransferOut,
     event: &mut TradeData,
     order: &mut Order,
+    builder_fee_factor: u128,
 ) -> Result<u128> {
     // The builder fee is charged in the order's final output token, so for an increase order that
     // token, and therefore the escrow it is paid out of, must belong to the position's collateral
@@ -1633,6 +1640,60 @@ fn execute_increase_position(
     // Here, `min_output` refers to the minimum amount of collateral tokens expected
     // after the swap.
     order.validate_output_amount(collateral_increment_amount.into())?;
+
+    // Builder fee is charged in the collateral token, after the pay token
+    // has already been swapped into it, and is deducted from
+    // `collateral_increment_amount` before it is fed into
+    // `position.increase()` below. Because of that, the withheld amount
+    // never enters any market's balances (it is counted only into
+    // `TransferOut`'s final-output-token bucket), so
+    // `validate_market_balances` further down does not need to be
+    // adjusted to cover it.
+    let collateral_increment_amount = if builder_fee_factor != 0 {
+        // Initializing the final output token is optional for increase
+        // orders (see `CreateIncreaseOrderOperation`), so an order whose
+        // creator did not opt in carries `None` here and cannot pay a fee.
+        // The check at the top of this function already rejects a `Some`
+        // that disagrees with the collateral token, so this is the same
+        // condition stated positively, and it is what the fee branch
+        // actually depends on.
+        let final_output_token = order
+            .tokens
+            .final_output_token
+            .token()
+            .ok_or_else(|| error!(CoreError::BuilderFeeFinalOutputTokenMismatch))?;
+        require_keys_eq!(
+            final_output_token,
+            *position.collateral_token(),
+            CoreError::BuilderFeeFinalOutputTokenMismatch
+        );
+
+        let (collateral_increment_amount, payable_amount) =
+            charge_builder_fee_on_collateral_increment(
+                collateral_increment_amount,
+                params.size_delta_value,
+                builder_fee_factor,
+                position.collateral_price(&prices),
+            )?;
+
+        // TODO(builder-fee): accumulate `payable_amount` into
+        // `order.builder_fee_amount` once that field exists.
+        transfer_out.transfer_out(false, payable_amount)?;
+        position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
+            order.header().store(),
+            &position.market().market_meta().market_token_mint,
+            position.collateral_token(),
+            payable_amount.into(),
+            // Underpayment errors out above rather than charging a partial
+            // amount, so the paid amount always equals the payable amount
+            // here.
+            payable_amount.into(),
+        )?)?;
+
+        collateral_increment_amount
+    } else {
+        collateral_increment_amount
+    };
 
     // Increase position.
     let (long_amount, short_amount, paid_order_fee_value) = {

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1125,6 +1125,9 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut *self.order.load_mut()?,
                         true,
                         Some(SecondaryOrderType::Liquidation),
+                        // TODO(builder-fee): read the snapshot factor from
+                        // the order once it is captured at order creation.
+                        0,
                     )?,
                     OrderKind::AutoDeleveraging => execute_decrease_position(
                         self.oracle,
@@ -1136,6 +1139,9 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut *self.order.load_mut()?,
                         true,
                         Some(SecondaryOrderType::AutoDeleveraging),
+                        // TODO(builder-fee): read the snapshot factor from
+                        // the order once it is captured at order creation.
+                        0,
                     )?,
                     OrderKind::MarketDecrease
                     | OrderKind::LimitDecrease
@@ -1149,6 +1155,9 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut *self.order.load_mut()?,
                         false,
                         None,
+                        // TODO(builder-fee): read the snapshot factor from
+                        // the order once it is captured at order creation.
+                        0,
                     )?,
                     _ => unreachable!(),
                 };
@@ -1806,14 +1815,26 @@ fn execute_decrease_position(
     order: &mut Order,
     is_insolvent_close_allowed: bool,
     secondary_order_type: Option<SecondaryOrderType>,
+    builder_fee_factor: u128,
 ) -> Result<(RemovePosition, u128)> {
     // Decrease position.
     let report = {
         let params = &order.params;
         let decrease_position_swap_type = params.decrease_position_swap_type()?;
-        let collateral_withdrawal_amount = params.initial_collateral_delta_amount as u128;
         let size_delta_usd = params.size_delta_value;
         let acceptable_price = params.acceptable_price;
+        // Fold an estimate of the builder fee into the collateral
+        // withdrawal amount so it's still funded even if the position is
+        // closed at a loss. This is only an estimate for sizing the
+        // withdrawal; the amount actually charged is computed later, in
+        // the final output token, once the receive-token swap has run.
+        let collateral_withdrawal_amount = estimate_builder_fee_for_collateral_withdrawal(
+            u128::from(params.initial_collateral_delta_amount),
+            size_delta_usd,
+            builder_fee_factor,
+            position.collateral_price(&prices),
+            decrease_position_swap_type,
+        )?;
         let is_liquidation_order =
             matches!(secondary_order_type, Some(SecondaryOrderType::Liquidation));
         let is_adl_order = matches!(
@@ -1938,6 +1959,53 @@ fn execute_decrease_position(
             token_ins,
             (output_amount, secondary_output_amount),
         )?;
+
+        // Builder fee is charged in the final output token, after the
+        // receive-token swap above. Deducting it here, before validating
+        // and transferring out the amounts below, means the order's own
+        // slippage validation and `transfer_out` both naturally see the
+        // post-fee amount: the fee is simply netted out of what would
+        // otherwise be transferred out, so no separate accounting or
+        // balance-validation adjustment is needed. Underpayment is
+        // tolerated (charges whatever is available): unlike increase, this
+        // can't fall back to cancelling the order, since a decrease order
+        // may be closing an insolvent position.
+        let output_amount = if builder_fee_factor != 0 {
+            let final_output_token_price = oracle.get_primary_price(&final_output_token, false)?;
+            // The executed size delta, not the requested one: a decrease may
+            // be enlarged into a full close, and in that case the whole
+            // collateral is withdrawn, so the fee computed from the executed
+            // size is still the maximum the withdrawal can support. The
+            // slightly smaller estimate used to size the withdrawal above is
+            // therefore not a constraint here.
+            let payable_amount = compute_builder_fee_amount(
+                *report.size_delta_usd(),
+                builder_fee_factor,
+                &final_output_token_price,
+            )?;
+            let paid_amount = clamp_builder_fee_amount(payable_amount, output_amount.into());
+            // `paid_amount` is clamped to `output_amount`, so both the
+            // conversion and the subtraction below cannot fail.
+            let output_amount = u64::try_from(paid_amount)
+                .ok()
+                .and_then(|paid| output_amount.checked_sub(paid))
+                .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
+
+            // TODO(builder-fee): accumulate `paid_amount` into
+            // `order.builder_fee_amount` once that field exists.
+            position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
+                order.header().store(),
+                &position.market().market_meta().market_token_mint,
+                &final_output_token,
+                payable_amount,
+                paid_amount,
+            )?)?;
+
+            output_amount
+        } else {
+            output_amount
+        };
+
         order.validate_decrease_output_amounts(
             oracle,
             &final_output_token,

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1685,9 +1685,11 @@ fn execute_increase_position(
                 position.collateral_price(&prices),
             )?;
 
-        // TODO(builder-fee): accumulate `payable_amount` into
-        // `order.builder_fee_amount` once that field exists.
+        // Recorded on the order and routed into the final output token
+        // escrow: the two go together, since settlement pays the recorded
+        // amount out of that escrow.
         transfer_out.transfer_out(false, payable_amount)?;
+        order.record_builder_fee(payable_amount)?;
         position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
             order.header().store(),
             &position.market().market_meta().market_token_mint,
@@ -1703,6 +1705,9 @@ fn execute_increase_position(
     } else {
         collateral_increment_amount
     };
+
+    // Re-borrowed because recording the fee above took `order` mutably.
+    let params = &order.params;
 
     // Increase position.
     let (long_amount, short_amount, paid_order_fee_value) = {
@@ -2000,8 +2005,12 @@ fn execute_decrease_position(
             )?;
             let paid_amount = clamp_builder_fee_amount(payable_amount, output_amount.into());
 
-            // TODO(builder-fee): accumulate `paid_amount` into
-            // `order.builder_fee_amount` once that field exists.
+            // `paid_amount` is clamped to `output_amount`, a `u64`, so the
+            // conversion cannot fail.
+            let recorded_amount =
+                u64::try_from(paid_amount).map_err(|_| error!(CoreError::TokenAmountOverflow))?;
+            order.record_builder_fee(recorded_amount)?;
+
             position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
                 order.header().store(),
                 &position.market().market_meta().market_token_mint,

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -554,6 +554,24 @@ impl Order {
         self.builder_fee_amount
     }
 
+    /// Record a builder fee amount charged during execution, adding it to
+    /// the amount pending settlement.
+    ///
+    /// Accumulates rather than overwrites: the field is the total charged
+    /// so far, and `settle_builder_fee` is what zeroes it once the amount
+    /// has been paid out to the builder.
+    ///
+    /// CHECK: the caller must have routed the same amount into the order's
+    /// final output token escrow, since settlement pays the recorded
+    /// amount out of that escrow.
+    pub(crate) fn record_builder_fee(&mut self, amount: u64) -> Result<()> {
+        self.builder_fee_amount = self
+            .builder_fee_amount
+            .checked_add(amount)
+            .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
+        Ok(())
+    }
+
     /// Process GT.
     /// CHECK: the order must have been successfully executed.
     #[inline(never)]
@@ -1002,5 +1020,25 @@ mod tests {
         assert_eq!(order.builder(), None);
         assert_eq!(order.builder_fee_factor(), 0);
         assert_eq!(order.builder_fee_amount(), 0);
+    }
+
+    #[test]
+    fn recorded_builder_fee_amounts_accumulate() {
+        let mut order: Order = bytemuck::Zeroable::zeroed();
+        order.record_builder_fee(25).unwrap();
+        order.record_builder_fee(17).unwrap();
+        // The field is the total charged so far, so a second charge adds
+        // to the first rather than replacing it.
+        assert_eq!(order.builder_fee_amount(), 42);
+    }
+
+    #[test]
+    fn recording_a_builder_fee_rejects_overflow() {
+        let mut order: Order = bytemuck::Zeroable::zeroed();
+        order.record_builder_fee(u64::MAX).unwrap();
+        let err = order.record_builder_fee(1).unwrap_err();
+        assert_eq!(err, error!(CoreError::TokenAmountOverflow));
+        // The rejected charge leaves the recorded amount untouched.
+        assert_eq!(order.builder_fee_amount(), u64::MAX);
     }
 }


### PR DESCRIPTION
CON-34 Land builder fee computation and routing behind a zero factor

## Summary

This is the productionized implementation of builder fee computation for the increase and decrease execution paths, per ADR-0001 and the follow-up issue that supersedes PoC #401. The fee is charged from collateral at execution time, denominated in each order's final output token (the collateral token for increase, the post-swap receive token for decrease). Everything ships inert. Every real call site still hardcodes a builder fee factor of 0, so production behavior is unchanged until a later activation issue replaces that constant with the order's snapshotted factor.

## What's implemented

- `compute_builder_fee_amount` / `clamp_builder_fee_amount`. Pure USD-value to token-amount conversion (`apply_factor` against `size_delta_usd`, rounded up against the min price) and shortfall clamping.
- Increase orders now initialize `tokens.final_output_token` at creation, required to equal the collateral token. This field was previously left unset for increase orders even though the account was already threaded through `create_order_v2`. `final_output_token_escrow` is now a required account for increase-order creation, so the Rust SDK's order-creation builder was updated to supply it.
- `charge_builder_fee_on_collateral_increment`. Computes and charges the fee in the collateral token, after the pay token has been swapped into it. Underpayment is not tolerated here. A shortfall returns `CoreError::BuilderFeeExceedsCollateral`, cancelling the order rather than charging a partial amount.
- `execute_increase_position` wiring. Validates `final_output_token == collateral_token` (a backward-compatibility guard, `CoreError::BuilderFeeFinalOutputTokenMismatch`, for orders created before the field was initialized), charges the fee post-swap, routes it through `transfer_out`'s final-output-token bucket, and emits `BuilderFeeCharged`.
- `estimate_builder_fee_for_collateral_withdrawal`. Folds a fee estimate into a decrease order's collateral withdrawal amount, so it stays fundable even when the position closes at a loss. Rejects `DecreasePositionSwapType::CollateralToPnlToken` whenever the fee is non-zero, via `CoreError::BuilderFeeSwapTypeNotAllowed`.
- `execute_decrease_position` wiring. The actual charge happens after the receive-token swap, against the final output token (which may differ from the collateral token), computed fresh against that token's price. Underpayment is tolerated here, charging whatever is available. Emits `BuilderFeeCharged`.
- `BuilderFeeCharged` CPI event. Records both the payable (pre-clamp) and paid (post-clamp) amounts. Not emitted when the factor is 0. Emitted even when the paid amount is 0, as long as the factor is non-zero, so indexers can tell "no builder attached" apart from "builder attached, nothing collectible."

## Why the fee token changed from the PoC

PoC #401 charged the increase fee in the pay token before the swap, and the decrease fee in the collateral token before the receive-token swap. Review settled on a different, cheaper design instead. Charge both in the order's final output token, after any swap.

For increase, the final output token is now required to equal the collateral token, so the fee computation reuses the collateral price that's already loaded for the instruction instead of fetching a separate price for an arbitrary pay token.

For decrease, the final output token can legitimately differ from the collateral token. This is what keeps the design compatible with a future cross-collateral feature, where the collateral token might not be the long or short token at all. The `CollateralToPnlToken` rejection is still required, but for a different reason than before. That swap type deterministically routes the entire collateral-token output into the pnl token before the receive-token swap even runs, so the final output token bucket would be empty on every single order that picks it. That's not ordinary underpayment variance, which decrease already tolerates via `NoSwap`. It's a guaranteed way to pay no fee at all.

## Acceptance criteria

- [x] Builder fee charged from the final output token on both paths, counted into the final output token output.
- [x] Accrual into `order.builder_fee_amount` is out of scope. TODO comments mark both accrual sites.
- [x] Fee computed as `apply_factor(size_delta_usd, factor)`, converted using the min price, rounded up.
- [x] Decrease underpayment is not restricted. Charges whatever is available and completes.
- [x] Increase underpayment cancels the order.
- [x] Increase deduction happens after the swap and before `position.increase()`, so the fee never enters any market's balances. Commented at the deduction site.
- [x] Decrease deduction happens after the swap, naturally netted out of the market's balances. Commented at the deduction site.
- [x] `CollateralToPnlToken` rejected on decrease when the factor is non-zero.
- [x] `BuilderFeeCharged` records both amounts, gated on the factor rather than the paid amount, emitted via `event_emitter`.
- [x] Every real call site hardcodes factor 0. No existing instruction's behavior changes.

## Out of scope

- Account and schema changes (`Order.builder_fee_amount`, `UserHeader.builder_fee_factor`, `Store.max_builder_fee_factor`, the feature flag, `UserTokenController`). Covered by a separate, independent issue.
- The order-creation snapshot instruction that would populate a real, non-zero factor.
- Settlement, claim, and permissionless configuration.

## Testing

- `cargo test -p gmsol-store`. 22 passed, 0 failed.
- `cargo build` / `cargo check --workspace` / `cargo clippy --workspace --lib`. Clean, no new warnings.
- No behavioral change to any existing on-chain path. Verified by inspection that every real caller passes `builder_fee_factor = 0`, which short-circuits before touching any price or account.
