### PR TITLE
feat: add builder fee state and config carve-outs

### DIFF
--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -25537,11 +25537,20 @@
             "type": "u128"
           },
           {
+            "name": "max_builder_fee_factor",
+            "docs": [
+              "Max builder fee factor. Reads as `0` on existing stores until a",
+              "CONFIG_KEEPER explicitly raises it via `insert_factor`, so no",
+              "non-zero builder fee factor can be configured by default."
+            ],
+            "type": "u128"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u128",
-                64
+                63
               ]
             }
           }
@@ -28627,11 +28636,33 @@
             }
           },
           {
+            "name": "builder",
+            "docs": [
+              "The builder attached to this order, at order creation time. The",
+              "default (zero) [`Pubkey`] means no builder is attached."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "builder_fee_factor",
+            "docs": [
+              "The builder's fee factor, snapshotted at order creation time."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "builder_fee_amount",
+            "docs": [
+              "The builder fee amount charged so far, pending settlement."
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                128
+                72
               ]
             }
           }
@@ -32854,11 +32885,19 @@
             }
           },
           {
+            "name": "builder_fee_factor",
+            "docs": [
+              "This user's builder fee factor, as a builder. `0` means the user",
+              "has not advertised a rate."
+            ],
+            "type": "u128"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                128
+                112
               ]
             }
           }
@@ -33506,6 +33545,21 @@
       ],
       "type": "bytes",
       "value": "[109, 97, 114, 107, 101, 116, 95, 118, 97, 117, 108, 116]"
+    },
+    {
+      "name": "USER_TOKEN_CONTROLLER_SEED",
+      "docs": [
+        "The seed of the (per-user, per-token) user token controller PDA.",
+        "",
+        "This PDA has no backing account and no init instruction yet; today its",
+        "only purpose is to fix the derivation scheme, `[SEED, user_account,",
+        "token_mint]`, so future claim/set-builder-fee instructions can reserve",
+        "the account slot ahead of the controller having any data or behavior.",
+        "A future \"controller account exists\" check degenerates to \"the passed",
+        "account matches this PDA derivation\"."
+      ],
+      "type": "bytes",
+      "value": "[117, 115, 101, 114, 95, 116, 111, 107, 101, 110, 95, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114]"
     },
     {
       "name": "VIRTUAL_INVENTORY_FOR_POSITIONS_SEED",

--- a/crates/sdk/src/pda.rs
+++ b/crates/sdk/src/pda.rs
@@ -17,7 +17,8 @@ use gmsol_programs::gmsol_timelock::accounts as timelock_accounts;
 use gmsol_programs::gmsol_liquidity_provider::accounts as liquidity_provider_accounts;
 
 pub use gmsol_programs::gmsol_store::constants::{
-    VIRTUAL_INVENTORY_FOR_POSITIONS_SEED, VIRTUAL_INVENTORY_FOR_SWAPS_SEED,
+    USER_TOKEN_CONTROLLER_SEED, VIRTUAL_INVENTORY_FOR_POSITIONS_SEED,
+    VIRTUAL_INVENTORY_FOR_SWAPS_SEED,
 };
 
 /// Nonce bytes.
@@ -73,11 +74,6 @@ pub const USER_SEED: &[u8] = b"user";
 
 /// Seed for [`ReferralCodeV2`](store_accounts::ReferralCodeV2).
 pub const REFERRAL_CODE_SEED: &[u8] = b"referral_code";
-
-/// Seed for the (per-user, per-token) user token controller PDA.
-///
-/// This PDA has no backing account yet; only its derivation is fixed.
-pub const USER_TOKEN_CONTROLLER_SEED: &[u8] = b"user_token_controller";
 
 /// Seed for GLV token mint.
 pub const GLV_TOKEN_SEED: &[u8] = b"glv_token";

--- a/crates/sdk/src/pda.rs
+++ b/crates/sdk/src/pda.rs
@@ -74,6 +74,11 @@ pub const USER_SEED: &[u8] = b"user";
 /// Seed for [`ReferralCodeV2`](store_accounts::ReferralCodeV2).
 pub const REFERRAL_CODE_SEED: &[u8] = b"referral_code";
 
+/// Seed for the (per-user, per-token) user token controller PDA.
+///
+/// This PDA has no backing account yet; only its derivation is fixed.
+pub const USER_TOKEN_CONTROLLER_SEED: &[u8] = b"user_token_controller";
+
 /// Seed for GLV token mint.
 pub const GLV_TOKEN_SEED: &[u8] = b"glv_token";
 
@@ -342,6 +347,31 @@ pub fn find_referral_code_address(
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[REFERRAL_CODE_SEED, store.as_ref(), &code],
+        store_program_id,
+    )
+}
+
+/// Find PDA for the (per-user, per-token) user token controller.
+///
+/// `user_account` is the [`User`](store_accounts::UserHeader) account's
+/// own PDA (see [`find_user_address`]), not the user's wallet address; it
+/// is already store-scoped, so no separate store seed is needed here. This
+/// mirrors the derivation keys of the claim ATA the controller will guard
+/// (`(user_account, token_mint)`), and matches the identity convention
+/// where a builder is identified by its User Account.
+///
+/// This PDA has no backing account yet; only its derivation is fixed.
+pub fn find_user_token_controller_address(
+    user_account: &Pubkey,
+    token_mint: &Pubkey,
+    store_program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            USER_TOKEN_CONTROLLER_SEED,
+            user_account.as_ref(),
+            token_mint.as_ref(),
+        ],
         store_program_id,
     )
 }

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -50,6 +50,10 @@ pub enum DomainDisabledFlag {
     GlvWithdrawal = 13,
     /// GLV shift.
     GlvShift = 14,
+    /// Builder fee.
+    ///
+    /// An unset flag means the builder fee mechanism is enabled.
+    BuilderFee = 15,
 }
 
 impl TryFrom<OrderKind> for DomainDisabledFlag {
@@ -146,6 +150,8 @@ pub enum FactorKey {
     OracleRefPriceDeviation,
     /// Order fee discount for referred user.
     OrderFeeDiscountForReferredUser,
+    /// Max builder fee factor.
+    MaxBuilderFeeFactor,
 }
 
 /// Address keys.

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -325,9 +325,16 @@ pub struct Order {
     pub(crate) gt_reward: u64,
     #[cfg_attr(feature = "debug", debug(skip))]
     padding_1: [u8; 8],
+    /// The builder attached to this order, at order creation time. The
+    /// default (zero) [`Pubkey`] means no builder is attached.
+    pub(crate) builder: Pubkey,
+    /// The builder's fee factor, snapshotted when the builder fee is set.
+    pub(crate) builder_fee_factor: u128,
+    /// The builder fee amount charged so far, pending settlement.
+    pub(crate) builder_fee_amount: u64,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 128],
+    reserved: [u8; 72],
 }
 
 impl Seed for Order {
@@ -532,6 +539,21 @@ impl Order {
     /// Get token accounts.
     pub fn tokens(&self) -> &OrderTokenAccounts {
         &self.tokens
+    }
+
+    /// Get the builder attached to this order, if any.
+    pub fn builder(&self) -> Option<&Pubkey> {
+        optional_address(&self.builder)
+    }
+
+    /// Get the builder's fee factor, snapshotted when the builder fee is set.
+    pub fn builder_fee_factor(&self) -> u128 {
+        self.builder_fee_factor
+    }
+
+    /// Get the builder fee amount charged so far, pending settlement.
+    pub fn builder_fee_amount(&self) -> u64 {
+        self.builder_fee_amount
     }
 
     /// Process GT.
@@ -941,5 +963,42 @@ impl OrderActionParams {
     pub(crate) fn set_should_keep_position_account(&mut self, keep: bool) -> bool {
         self.flags
             .set_flag(OrderFlag::ShouldKeepPositionAccount, keep)
+    }
+}
+
+#[cfg(test)]
+mod builder_fee_layout_tests {
+    use super::*;
+
+    // Captured from the layout before the builder fee fields were carved
+    // out of `reserved`. These must never change.
+    const OLD_SIZE: usize = 2464;
+    const GT_REWARD_OFFSET: usize = 2320;
+    const PADDING_1_OFFSET: usize = 2328;
+    const OLD_RESERVED_OFFSET: usize = 2336;
+
+    #[test]
+    fn existing_fields_keep_their_offsets_and_size_is_unchanged() {
+        assert_eq!(std::mem::size_of::<Order>(), OLD_SIZE);
+        assert_eq!(std::mem::offset_of!(Order, gt_reward), GT_REWARD_OFFSET);
+        assert_eq!(std::mem::offset_of!(Order, padding_1), PADDING_1_OFFSET);
+    }
+
+    #[test]
+    fn builder_fee_fields_are_carved_from_the_old_reserved_region_with_correct_alignment() {
+        assert_eq!(std::mem::offset_of!(Order, builder), OLD_RESERVED_OFFSET);
+        let builder_fee_factor_offset = std::mem::offset_of!(Order, builder_fee_factor);
+        assert_eq!(builder_fee_factor_offset, OLD_RESERVED_OFFSET + 32);
+        // u128 requires 16-byte alignment.
+        assert_eq!(builder_fee_factor_offset % 16, 0);
+        assert_eq!(
+            std::mem::offset_of!(Order, builder_fee_amount),
+            OLD_RESERVED_OFFSET + 32 + 16
+        );
+        // No new fields introduced beyond what the old reserved region
+        // covered.
+        assert!(
+            std::mem::offset_of!(Order, reserved) + std::mem::size_of::<[u8; 72]>() <= OLD_SIZE
+        );
     }
 }

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -1001,4 +1001,16 @@ mod builder_fee_layout_tests {
             std::mem::offset_of!(Order, reserved) + std::mem::size_of::<[u8; 72]>() <= OLD_SIZE
         );
     }
+
+    #[test]
+    fn existing_zeroed_accounts_read_as_no_builder_fee() {
+        // Every existing on-chain `Order` account has zero bytes
+        // throughout what used to be its `reserved` region, so
+        // reinterpreting one under the new layout must read the new
+        // fields as "no builder fee attached", not fail to deserialize.
+        let order: Order = bytemuck::Zeroable::zeroed();
+        assert_eq!(order.builder(), None);
+        assert_eq!(order.builder_fee_factor(), 0);
+        assert_eq!(order.builder_fee_amount(), 0);
+    }
 }

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -323,18 +323,16 @@ pub struct Order {
     /// Order params.
     pub(crate) params: OrderActionParams,
     pub(crate) gt_reward: u64,
-    #[cfg_attr(feature = "debug", debug(skip))]
-    padding_1: [u8; 8],
+    /// The builder fee amount charged so far, pending settlement.
+    pub(crate) builder_fee_amount: u64,
     /// The builder attached to this order, at order creation time. The
     /// default (zero) [`Pubkey`] means no builder is attached.
     pub(crate) builder: Pubkey,
     /// The builder's fee factor, snapshotted when the builder fee is set.
     pub(crate) builder_fee_factor: u128,
-    /// The builder fee amount charged so far, pending settlement.
-    pub(crate) builder_fee_amount: u64,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 72],
+    reserved: [u8; 80],
 }
 
 impl Seed for Order {
@@ -967,39 +965,31 @@ impl OrderActionParams {
 }
 
 #[cfg(test)]
-mod builder_fee_layout_tests {
+mod tests {
     use super::*;
 
-    // Captured from the layout before the builder fee fields were carved
-    // out of `reserved`. These must never change.
-    const OLD_SIZE: usize = 2464;
+    // The `Order` account's byte layout. These must never change.
+    const EXPECTED_ORDER_ACCOUNT_SIZE: usize = 2464;
     const GT_REWARD_OFFSET: usize = 2320;
-    const PADDING_1_OFFSET: usize = 2328;
-    const OLD_RESERVED_OFFSET: usize = 2336;
+    const BUILDER_FEE_AMOUNT_OFFSET: usize = 2328;
+    const BUILDER_OFFSET: usize = 2336;
+    const BUILDER_FEE_FACTOR_OFFSET: usize = 2368;
 
     #[test]
-    fn existing_fields_keep_their_offsets_and_size_is_unchanged() {
-        assert_eq!(std::mem::size_of::<Order>(), OLD_SIZE);
+    fn order_account_layout() {
+        assert_eq!(std::mem::size_of::<Order>(), EXPECTED_ORDER_ACCOUNT_SIZE);
         assert_eq!(std::mem::offset_of!(Order, gt_reward), GT_REWARD_OFFSET);
-        assert_eq!(std::mem::offset_of!(Order, padding_1), PADDING_1_OFFSET);
-    }
-
-    #[test]
-    fn builder_fee_fields_are_carved_from_the_old_reserved_region_with_correct_alignment() {
-        assert_eq!(std::mem::offset_of!(Order, builder), OLD_RESERVED_OFFSET);
-        let builder_fee_factor_offset = std::mem::offset_of!(Order, builder_fee_factor);
-        assert_eq!(builder_fee_factor_offset, OLD_RESERVED_OFFSET + 32);
-        // u128 requires 16-byte alignment.
-        assert_eq!(builder_fee_factor_offset % 16, 0);
         assert_eq!(
             std::mem::offset_of!(Order, builder_fee_amount),
-            OLD_RESERVED_OFFSET + 32 + 16
+            BUILDER_FEE_AMOUNT_OFFSET
         );
-        // No new fields introduced beyond what the old reserved region
-        // covered.
-        assert!(
-            std::mem::offset_of!(Order, reserved) + std::mem::size_of::<[u8; 72]>() <= OLD_SIZE
+        assert_eq!(std::mem::offset_of!(Order, builder), BUILDER_OFFSET);
+        assert_eq!(
+            std::mem::offset_of!(Order, builder_fee_factor),
+            BUILDER_FEE_FACTOR_OFFSET
         );
+        // u128 requires 16-byte alignment.
+        assert_eq!(BUILDER_FEE_FACTOR_OFFSET % 16, 0);
     }
 
     #[test]

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -659,55 +659,6 @@ impl Factors {
     }
 }
 
-#[cfg(test)]
-mod factors_layout_tests {
-    use super::*;
-
-    // Captured from the layout before `max_builder_fee_factor` was carved
-    // out of `reserved`. These must never change.
-    const OLD_SIZE: usize = 1056;
-    const ORACLE_REF_PRICE_DEVIATION_OFFSET: usize = 0;
-    const ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET: usize = 16;
-
-    #[test]
-    fn existing_fields_keep_their_offsets_and_size_is_unchanged() {
-        assert_eq!(std::mem::size_of::<Factors>(), OLD_SIZE);
-        assert_eq!(
-            std::mem::offset_of!(Factors, oracle_ref_price_deviation),
-            ORACLE_REF_PRICE_DEVIATION_OFFSET
-        );
-        assert_eq!(
-            std::mem::offset_of!(Factors, order_fee_discount_for_referred_user),
-            ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET
-        );
-    }
-
-    #[test]
-    fn max_builder_fee_factor_is_carved_from_the_old_reserved_region() {
-        // The old `reserved: [Factor; 64]` started right after
-        // `order_fee_discount_for_referred_user`, at offset 32.
-        let old_reserved_offset = ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET + 16;
-        assert_eq!(
-            std::mem::offset_of!(Factors, max_builder_fee_factor),
-            old_reserved_offset
-        );
-        // No new fields introduced beyond what the old reserved region
-        // covered.
-        assert!(
-            std::mem::offset_of!(Factors, reserved) + std::mem::size_of::<[Factor; 63]>()
-                <= OLD_SIZE
-        );
-    }
-
-    #[test]
-    fn existing_zeroed_stores_read_max_builder_fee_factor_as_zero() {
-        // Every existing on-chain `Store` account has zero bytes
-        // throughout what used to be `Factors::reserved`.
-        let factors: Factors = bytemuck::Zeroable::zeroed();
-        assert_eq!(factors.get(&FactorKey::MaxBuilderFeeFactor), Some(&0u128));
-    }
-}
-
 /// Addresses.
 #[zero_copy]
 #[cfg_attr(feature = "debug", derive(derive_more::Debug))]
@@ -738,5 +689,44 @@ impl Addresses {
             _ => return None,
         };
         Some(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The `Factors` account's byte layout. These must never change.
+    const EXPECTED_FACTORS_ACCOUNT_SIZE: usize = 1056;
+    const ORACLE_REF_PRICE_DEVIATION_OFFSET: usize = 0;
+    const ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET: usize = 16;
+    const MAX_BUILDER_FEE_FACTOR_OFFSET: usize = 32;
+
+    #[test]
+    fn factors_account_layout() {
+        assert_eq!(
+            std::mem::size_of::<Factors>(),
+            EXPECTED_FACTORS_ACCOUNT_SIZE
+        );
+        assert_eq!(
+            std::mem::offset_of!(Factors, oracle_ref_price_deviation),
+            ORACLE_REF_PRICE_DEVIATION_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(Factors, order_fee_discount_for_referred_user),
+            ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(Factors, max_builder_fee_factor),
+            MAX_BUILDER_FEE_FACTOR_OFFSET
+        );
+    }
+
+    #[test]
+    fn existing_zeroed_stores_read_max_builder_fee_factor_as_zero() {
+        // Every existing on-chain `Store` account has zero bytes
+        // throughout what used to be `Factors::reserved`.
+        let factors: Factors = bytemuck::Zeroable::zeroed();
+        assert_eq!(factors.get(&FactorKey::MaxBuilderFeeFactor), Some(&0u128));
     }
 }

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -698,6 +698,14 @@ mod factors_layout_tests {
                 <= OLD_SIZE
         );
     }
+
+    #[test]
+    fn existing_zeroed_stores_read_max_builder_fee_factor_as_zero() {
+        // Every existing on-chain `Store` account has zero bytes
+        // throughout what used to be `Factors::reserved`.
+        let factors: Factors = bytemuck::Zeroable::zeroed();
+        assert_eq!(factors.get(&FactorKey::MaxBuilderFeeFactor), Some(&0u128));
+    }
 }
 
 /// Addresses.

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -619,8 +619,12 @@ impl Amounts {
 pub struct Factors {
     pub(crate) oracle_ref_price_deviation: Factor,
     pub(crate) order_fee_discount_for_referred_user: Factor,
+    /// Max builder fee factor. Reads as `0` on existing stores until a
+    /// CONFIG_KEEPER explicitly raises it via `insert_factor`, so no
+    /// non-zero builder fee factor can be configured by default.
+    pub(crate) max_builder_fee_factor: Factor,
     #[cfg_attr(feature = "debug", debug(skip))]
-    reserved: [Factor; 64],
+    reserved: [Factor; 63],
 }
 
 impl Factors {
@@ -635,6 +639,7 @@ impl Factors {
             FactorKey::OrderFeeDiscountForReferredUser => {
                 &self.order_fee_discount_for_referred_user
             }
+            FactorKey::MaxBuilderFeeFactor => &self.max_builder_fee_factor,
             _ => return None,
         };
         Some(value)
@@ -647,9 +652,51 @@ impl Factors {
             FactorKey::OrderFeeDiscountForReferredUser => {
                 &mut self.order_fee_discount_for_referred_user
             }
+            FactorKey::MaxBuilderFeeFactor => &mut self.max_builder_fee_factor,
             _ => return None,
         };
         Some(value)
+    }
+}
+
+#[cfg(test)]
+mod factors_layout_tests {
+    use super::*;
+
+    // Captured from the layout before `max_builder_fee_factor` was carved
+    // out of `reserved`. These must never change.
+    const OLD_SIZE: usize = 1056;
+    const ORACLE_REF_PRICE_DEVIATION_OFFSET: usize = 0;
+    const ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET: usize = 16;
+
+    #[test]
+    fn existing_fields_keep_their_offsets_and_size_is_unchanged() {
+        assert_eq!(std::mem::size_of::<Factors>(), OLD_SIZE);
+        assert_eq!(
+            std::mem::offset_of!(Factors, oracle_ref_price_deviation),
+            ORACLE_REF_PRICE_DEVIATION_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(Factors, order_fee_discount_for_referred_user),
+            ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET
+        );
+    }
+
+    #[test]
+    fn max_builder_fee_factor_is_carved_from_the_old_reserved_region() {
+        // The old `reserved: [Factor; 64]` started right after
+        // `order_fee_discount_for_referred_user`, at offset 32.
+        let old_reserved_offset = ORDER_FEE_DISCOUNT_FOR_REFERRED_USER_OFFSET + 16;
+        assert_eq!(
+            std::mem::offset_of!(Factors, max_builder_fee_factor),
+            old_reserved_offset
+        );
+        // No new fields introduced beyond what the old reserved region
+        // covered.
+        assert!(
+            std::mem::offset_of!(Factors, reserved) + std::mem::size_of::<[Factor; 63]>()
+                <= OLD_SIZE
+        );
     }
 }
 

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -361,33 +361,27 @@ impl UserGtState {
 }
 
 #[cfg(test)]
-mod builder_fee_layout_tests {
+mod tests {
     use super::*;
 
-    // Captured from the layout before `builder_fee_factor` was carved out
-    // of `reserved`. These must never change.
-    const OLD_SIZE: usize = 512;
+    // The `UserHeader` account's byte layout. These must never change.
+    const EXPECTED_USER_HEADER_ACCOUNT_SIZE: usize = 512;
     const GT_OFFSET: usize = 224;
-    const OLD_RESERVED_OFFSET: usize = 384;
+    const BUILDER_FEE_FACTOR_OFFSET: usize = 384;
 
     #[test]
-    fn existing_fields_keep_their_offsets_and_size_is_unchanged() {
-        assert_eq!(std::mem::size_of::<UserHeader>(), OLD_SIZE);
-        assert_eq!(std::mem::offset_of!(UserHeader, gt), GT_OFFSET);
-    }
-
-    #[test]
-    fn builder_fee_factor_is_carved_from_the_old_reserved_region_with_correct_alignment() {
-        let offset = std::mem::offset_of!(UserHeader, builder_fee_factor);
-        assert_eq!(offset, OLD_RESERVED_OFFSET);
-        // u128 requires 16-byte alignment.
-        assert_eq!(offset % 16, 0);
-        // No new fields introduced beyond what the old reserved region
-        // covered.
-        assert!(
-            std::mem::offset_of!(UserHeader, reserved) + std::mem::size_of::<[u8; 112]>()
-                <= OLD_SIZE
+    fn user_header_account_layout() {
+        assert_eq!(
+            std::mem::size_of::<UserHeader>(),
+            EXPECTED_USER_HEADER_ACCOUNT_SIZE
         );
+        assert_eq!(std::mem::offset_of!(UserHeader, gt), GT_OFFSET);
+        assert_eq!(
+            std::mem::offset_of!(UserHeader, builder_fee_factor),
+            BUILDER_FEE_FACTOR_OFFSET
+        );
+        // u128 requires 16-byte alignment.
+        assert_eq!(BUILDER_FEE_FACTOR_OFFSET % 16, 0);
     }
 
     #[test]

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -31,9 +31,12 @@ pub struct UserHeader {
     pub(crate) referral: Referral,
     /// GT State.
     pub(crate) gt: UserGtState,
+    /// This user's builder fee factor, as a builder. `0` means the user
+    /// has not advertised a rate.
+    pub(crate) builder_fee_factor: u128,
     #[cfg_attr(feature = "debug", debug(skip))]
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    reserved: [u8; 128],
+    reserved: [u8; 112],
 }
 
 gmsol_utils::flags!(UserFlag, MAX_USER_FLAGS, u8);
@@ -148,6 +151,11 @@ impl UserHeader {
     /// Get GT state.
     pub fn gt(&self) -> &UserGtState {
         &self.gt
+    }
+
+    /// Get this user's builder fee factor, as a builder.
+    pub fn builder_fee_factor(&self) -> u128 {
+        self.builder_fee_factor
     }
 }
 
@@ -338,5 +346,36 @@ impl UserGtState {
     /// Get GT balance.
     pub fn amount(&self) -> u64 {
         self.amount
+    }
+}
+
+#[cfg(test)]
+mod builder_fee_layout_tests {
+    use super::*;
+
+    // Captured from the layout before `builder_fee_factor` was carved out
+    // of `reserved`. These must never change.
+    const OLD_SIZE: usize = 512;
+    const GT_OFFSET: usize = 224;
+    const OLD_RESERVED_OFFSET: usize = 384;
+
+    #[test]
+    fn existing_fields_keep_their_offsets_and_size_is_unchanged() {
+        assert_eq!(std::mem::size_of::<UserHeader>(), OLD_SIZE);
+        assert_eq!(std::mem::offset_of!(UserHeader, gt), GT_OFFSET);
+    }
+
+    #[test]
+    fn builder_fee_factor_is_carved_from_the_old_reserved_region_with_correct_alignment() {
+        let offset = std::mem::offset_of!(UserHeader, builder_fee_factor);
+        assert_eq!(offset, OLD_RESERVED_OFFSET);
+        // u128 requires 16-byte alignment.
+        assert_eq!(offset % 16, 0);
+        // No new fields introduced beyond what the old reserved region
+        // covered.
+        assert!(
+            std::mem::offset_of!(UserHeader, reserved) + std::mem::size_of::<[u8; 112]>()
+                <= OLD_SIZE
+        );
     }
 }

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -163,6 +163,17 @@ impl Seed for UserHeader {
     const SEED: &'static [u8] = b"user";
 }
 
+/// The seed of the (per-user, per-token) user token controller PDA.
+///
+/// This PDA has no backing account and no init instruction yet; today its
+/// only purpose is to fix the derivation scheme, `[SEED, user_account,
+/// token_mint]`, so future claim/set-builder-fee instructions can reserve
+/// the account slot ahead of the controller having any data or behavior.
+/// A future "controller account exists" check degenerates to "the passed
+/// account matches this PDA derivation".
+#[constant]
+pub const USER_TOKEN_CONTROLLER_SEED: &[u8] = b"user_token_controller";
+
 /// Referral Code Bytes.
 pub type ReferralCodeBytes = [u8; 8];
 

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -389,4 +389,12 @@ mod builder_fee_layout_tests {
                 <= OLD_SIZE
         );
     }
+
+    #[test]
+    fn existing_zeroed_accounts_read_as_no_builder_fee_factor() {
+        // Every existing on-chain `UserHeader` account has zero bytes
+        // throughout what used to be its `reserved` region.
+        let user: UserHeader = bytemuck::Zeroable::zeroed();
+        assert_eq!(user.builder_fee_factor(), 0);
+    }
 }


### PR DESCRIPTION
## CON-35

## Summary

Carves the builder fee state fields into `Order`, `UserHeader`, and the store config, adds the builder fee feature flag and factor cap config keys, and defines the `UserTokenController` PDA derivation, per ADR-0001. Everything here is passive. No instruction reads or writes any of these fields yet, so this can merge ahead of and in parallel with the settlement, configuration, and activation tracks.

Every field addition is carved out of an existing `reserved` region. Account sizes and every pre-existing field's offset are unchanged, verified with `core::mem::offset_of!` assertions rather than just claimed, so live accounts need no migration.


## What's implemented

- `Order` gains `builder: Pubkey`, `builder_fee_factor: u128`, and `builder_fee_amount: u64`, carved from `reserved: [u8; 128]` down to `[u8; 72]`. Field order was chosen so the `u128` lands on a 16-byte-aligned offset with zero compiler-inserted padding, matched exactly by a test that checks the real offsets. Read-only getters `builder()`, `builder_fee_factor()`, `builder_fee_amount()`. Nothing writes them yet.
- `UserHeader` gains `builder_fee_factor: u128`, carved from `reserved: [u8; 128]` down to `[u8; 112]`, with a read-only getter. This is the builder's advertised rate, distinct from the snapshot copy on `Order`.
- `Store::Factors` gains `max_builder_fee_factor: Factor`, carved from `reserved: [Factor; 64]` down to `[Factor; 63]`, wired into the existing `get`/`get_mut` match arms. No `init()` default, so it reads as `0` on every existing store. `insert_factor` already dispatches generically by string key, so no instruction-level change was needed to make it settable.
- `FactorKey::MaxBuilderFeeFactor` and `DomainDisabledFlag::BuilderFee` appended in `crates/utils/src/config.rs`. `DisabledFeatures` turned out to already be a generic `(domain, action)` map rather than a hardcoded match, so the flag needed no extra wiring beyond the enum variant itself.
- `UserTokenController` PDA derivation, `[SEED, user_account, token_mint]`, defined as a program-side seed constant (`programs/store/src/states/user.rs`) and an SDK helper (`find_user_token_controller_address` in `crates/sdk/src/pda.rs`). No account struct, no init instruction. The per-user component is the User Account PDA rather than a raw wallet address, since it's already store-scoped and matches the identity convention the rest of ADR-0001 uses.

## Testing

- `cargo test -p gmsol-store`. 16 passed, 0 failed, up from 9 pre-existing.
- For each touched struct (`Order`, `UserHeader`, `Factors`), a layout test pair. One asserts pre-existing fields keep their exact offsets and the struct's total size is unchanged. One asserts the new fields sit inside what used to be the `reserved` region, at correctly aligned offsets.
- A separate test per struct constructs a zeroed instance via `bytemuck::Zeroable::zeroed()`, standing in for a real pre-upgrade on-chain account (Solana account data is zero-initialized, and nothing ever wrote into these `reserved` regions), and asserts the new getters read back as the "no builder fee" defaults. This exercises the acceptance criteria directly rather than only arguing it from the offset math.
- `cargo build` / `cargo check --workspace` / `cargo clippy -p gmsol-store -p gmsol-sdk -p gmsol-utils --lib`. Clean, no new warnings.

## Out of scope

- Any instruction that reads or writes these fields. That's the settlement, configuration, and activation tracks this PR is meant to unblock.
- The `UserTokenController` account struct and its init instruction. Per review, this issue only fixes the PDA derivation.
- IDL regeneration. The new `#[constant]` won't appear in `crates/programs/idls/gmsol_store.json` until an `anchor build` picks it up. Nothing in this PR depends on that having happened.
