### PR TITLE
feat: builder fee settlement rails, close guard and permissionless settle_builder_fee

### DIFF
--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -7421,7 +7421,11 @@
           "name": "final_output_token_escrow",
           "docs": [
             "Final output token escrow account.",
-            "Only required by decrease and swap orders."
+            "",
+            "Required by decrease and swap orders. Optional for increase orders: when provided, it is",
+            "recorded on the order and becomes the account a builder fee would be paid out of, and when",
+            "omitted the order's final output token is left uninitialized, so no builder fee can be set",
+            "on it later."
           ],
           "writable": true,
           "optional": true,
@@ -19905,6 +19909,311 @@
       "args": []
     },
     {
+      "name": "settle_builder_fee",
+      "docs": [
+        "Settle the builder fee of an order.",
+        "",
+        "Permissionless: any signer may invoke it, no role is required, and",
+        "no specific address can block it. Idempotent: a recorded builder",
+        "fee amount of zero, including orders that never had a builder set,",
+        "is an explicit no-op, so this may be called in any order state,",
+        "before or after terminal.",
+        "",
+        "# Accounts",
+        "*[See the documentation for the accounts.](SettleBuilderFee)*",
+        "",
+        "# Errors",
+        "- The [`order`](SettleBuilderFee::order) must be initialized and owned by the `store`.",
+        "- If the order's recorded builder fee amount is non-zero, [`builder_user`](SettleBuilderFee::builder_user)",
+        "must be provided and must match the builder recorded on the order, and",
+        "[`claim_vault`](SettleBuilderFee::claim_vault) must be provided and must be the",
+        "associated token account of the final output token owned by `builder_user`."
+      ],
+      "discriminator": [
+        209,
+        56,
+        167,
+        214,
+        184,
+        197,
+        10,
+        10
+      ],
+      "accounts": [
+        {
+          "name": "store",
+          "docs": [
+            "Store."
+          ],
+          "relations": [
+            "builder_user"
+          ]
+        },
+        {
+          "name": "order",
+          "docs": [
+            "The order whose builder fee is to be settled."
+          ],
+          "writable": true
+        },
+        {
+          "name": "final_output_token",
+          "docs": [
+            "The final output token mint of the order, i.e. the token the",
+            "builder fee is denominated in."
+          ]
+        },
+        {
+          "name": "escrow",
+          "docs": [
+            "The order's escrow account for the final output token."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "final_output_token"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "builder_user",
+          "docs": [
+            "The builder's User Account.",
+            "",
+            "Only required when the order has a non-zero recorded builder fee",
+            "amount. The no-op path (a recorded amount of zero, including",
+            "orders that never had a builder set) performs no CPI and does not",
+            "need it, so it may be omitted."
+          ],
+          "optional": true
+        },
+        {
+          "name": "claim_vault",
+          "docs": [
+            "The builder's claim vault: the associated token account of the",
+            "final output token owned by the builder's User Account.",
+            "",
+            "Required to already exist, so no `init_if_needed` is used here.",
+            "Nothing currently guarantees that existence ahead of time: the",
+            "instruction that is meant to (CON-40's `set_builder_fee`) has not",
+            "landed yet. Until it does, a missing vault just makes settlement,",
+            "and therefore closing an order with a non-zero fee, fail rather",
+            "than misroute anything. Only required alongside `builder_user`,",
+            "for the same reason."
+          ],
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "builder_user"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "final_output_token"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "toggle_feature",
       "docs": [
         "Enable or disable a feature in this deployment.",
@@ -22376,6 +22685,19 @@
       ]
     },
     {
+      "name": "BuilderFeeSettled",
+      "discriminator": [
+        92,
+        156,
+        185,
+        185,
+        199,
+        171,
+        24,
+        82
+      ]
+    },
+    {
       "name": "DepositCreated",
       "discriminator": [
         146,
@@ -23338,6 +23660,11 @@
       "code": 6129,
       "name": "BuilderFeeFactorExceedsMaxFactor",
       "msg": "builder fee factor exceeds the max builder fee factor"
+    },
+    {
+      "code": 6130,
+      "name": "UnsettledBuilderFee",
+      "msg": "order has an unsettled builder fee"
     }
   ],
   "types": [
@@ -23756,6 +24083,78 @@
                 64
               ]
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFeeSettled",
+      "docs": [
+        "An event indicating that a builder fee has been settled.",
+        "",
+        "Emitted only when settlement actually transfers a non-zero amount; the",
+        "no-op path (a recorded amount of zero) emits nothing."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ts",
+            "docs": [
+              "Timestamp."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slot",
+            "docs": [
+              "Slot."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "store",
+            "docs": [
+              "Store."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "order",
+            "docs": [
+              "The order the settled fee was accrued on."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "builder",
+            "docs": [
+              "The builder's User Account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token",
+            "docs": [
+              "The token mint the fee is denominated in."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recorded_amount",
+            "docs": [
+              "The builder fee amount recorded on the order before settlement."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_amount",
+            "docs": [
+              "The amount actually transferred, clamped to the escrow's balance.",
+              "A value below `recorded_amount` signals a broken invariant, since",
+              "the escrow is expected to always cover the recorded amount."
+            ],
+            "type": "u64"
           }
         ]
       }
@@ -28825,13 +29224,11 @@
             "type": "u64"
           },
           {
-            "name": "padding_1",
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
+            "name": "builder_fee_amount",
+            "docs": [
+              "The builder fee amount charged so far, pending settlement."
+            ],
+            "type": "u64"
           },
           {
             "name": "builder",
@@ -28844,23 +29241,16 @@
           {
             "name": "builder_fee_factor",
             "docs": [
-              "The builder's fee factor, snapshotted at order creation time."
+              "The builder's fee factor, snapshotted when the builder fee is set."
             ],
             "type": "u128"
-          },
-          {
-            "name": "builder_fee_amount",
-            "docs": [
-              "The builder fee amount charged so far, pending settlement."
-            ],
-            "type": "u64"
           },
           {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                72
+                80
               ]
             }
           }

--- a/crates/sdk/src/client/ops/builder_fee.rs
+++ b/crates/sdk/src/client/ops/builder_fee.rs
@@ -1,0 +1,105 @@
+use std::{future::Future, ops::Deref};
+
+use anchor_spl::associated_token::get_associated_token_address_with_program_id;
+use gmsol_programs::gmsol_store::client::{accounts, args};
+use gmsol_solana_utils::transaction_builder::TransactionBuilder;
+use gmsol_utils::pubkey::optional_address;
+use solana_sdk::{pubkey::Pubkey, signer::Signer};
+
+/// Operations for builder fees.
+pub trait BuilderFeeOps<C> {
+    /// Settle the builder fee of the given order.
+    ///
+    /// Permissionless and idempotent: safe to call on any order, in any
+    /// state, whether or not it has a non-zero recorded builder fee
+    /// amount.
+    fn settle_builder_fee(
+        &self,
+        store: &Pubkey,
+        order: &Pubkey,
+        hint: Option<SettleBuilderFeeHint>,
+    ) -> impl Future<Output = crate::Result<TransactionBuilder<C>>>;
+}
+
+/// Hint for [`settle_builder_fee`](BuilderFeeOps::settle_builder_fee), to
+/// avoid an extra fetch of the order account when the caller already has
+/// this data on hand.
+#[derive(Debug, Clone, Copy)]
+pub struct SettleBuilderFeeHint {
+    /// The order's recorded builder fee amount.
+    pub builder_fee_amount: u64,
+    /// The builder's User Account, if the order has a builder attached.
+    pub builder: Option<Pubkey>,
+    /// The order's final output token mint, i.e. the token the builder
+    /// fee is denominated in.
+    pub final_output_token: Pubkey,
+    /// The order's escrow account for the final output token.
+    pub escrow: Pubkey,
+}
+
+impl<C: Deref<Target = impl Signer> + Clone> BuilderFeeOps<C> for crate::Client<C> {
+    async fn settle_builder_fee(
+        &self,
+        store: &Pubkey,
+        order: &Pubkey,
+        hint: Option<SettleBuilderFeeHint>,
+    ) -> crate::Result<TransactionBuilder<C>> {
+        let hint =
+            match hint {
+                Some(hint) => hint,
+                None => {
+                    let account = self.order(order).await?;
+                    let final_output_token =
+                        account.tokens.final_output_token.token().ok_or_else(|| {
+                            crate::Error::custom("order has no final output token")
+                        })?;
+                    let escrow =
+                        account.tokens.final_output_token.account().ok_or_else(|| {
+                            crate::Error::custom("order has no final output token")
+                        })?;
+                    SettleBuilderFeeHint {
+                        builder_fee_amount: account.builder_fee_amount,
+                        builder: optional_address(&account.builder).copied(),
+                        final_output_token,
+                        escrow,
+                    }
+                }
+            };
+
+        // The builder-related accounts are only required for a genuine
+        // settlement: the no-op path performs no CPI and does not touch
+        // them, so they need not even exist on-chain.
+        let (builder_user, claim_vault) = if hint.builder_fee_amount == 0 {
+            (None, None)
+        } else {
+            let builder = hint.builder.ok_or_else(|| {
+                crate::Error::custom(
+                    "order has a non-zero builder fee amount but no builder recorded",
+                )
+            })?;
+            let claim_vault = get_associated_token_address_with_program_id(
+                &builder,
+                &hint.final_output_token,
+                &anchor_spl::token::ID,
+            );
+            (Some(builder), Some(claim_vault))
+        };
+
+        let rpc = self
+            .store_transaction()
+            .anchor_accounts(accounts::SettleBuilderFee {
+                store: *store,
+                order: *order,
+                final_output_token: hint.final_output_token,
+                escrow: hint.escrow,
+                builder_user,
+                claim_vault,
+                token_program: anchor_spl::token::ID,
+                event_authority: self.store_event_authority(),
+                program: *self.store_program_id(),
+            })
+            .anchor_args(args::SettleBuilderFee {});
+
+        Ok(rpc)
+    }
+}

--- a/crates/sdk/src/client/ops/mod.rs
+++ b/crates/sdk/src/client/ops/mod.rs
@@ -57,7 +57,11 @@ pub mod virtual_inventory;
 #[cfg(liquidity_provider)]
 pub mod liquidity_provider;
 
+/// Operations for builder fees.
+pub mod builder_fee;
+
 pub use alt::AddressLookupTableOps;
+pub use builder_fee::BuilderFeeOps;
 pub use config::ConfigOps;
 pub use exchange::ExchangeOps;
 pub use glv::GlvOps;

--- a/programs/store/src/events/builder_fee.rs
+++ b/programs/store/src/events/builder_fee.rs
@@ -1,0 +1,61 @@
+use anchor_lang::prelude::*;
+use gmsol_utils::InitSpace;
+
+use super::Event;
+
+/// An event indicating that a builder fee has been settled.
+///
+/// Emitted only when settlement actually transfers a non-zero amount; the
+/// no-op path (a recorded amount of zero) emits nothing.
+#[event]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone, InitSpace)]
+pub struct BuilderFeeSettled {
+    /// Timestamp.
+    pub ts: i64,
+    /// Slot.
+    pub slot: u64,
+    /// Store.
+    pub store: Pubkey,
+    /// The order the settled fee was accrued on.
+    pub order: Pubkey,
+    /// The builder's User Account.
+    pub builder: Pubkey,
+    /// The token mint the fee is denominated in.
+    pub token: Pubkey,
+    /// The builder fee amount recorded on the order before settlement.
+    pub recorded_amount: u64,
+    /// The amount actually transferred, clamped to the escrow's balance.
+    /// A value below `recorded_amount` signals a broken invariant, since
+    /// the escrow is expected to always cover the recorded amount.
+    pub settled_amount: u64,
+}
+
+impl BuilderFeeSettled {
+    pub(crate) fn new(
+        store: &Pubkey,
+        order: &Pubkey,
+        builder: &Pubkey,
+        token: &Pubkey,
+        recorded_amount: u64,
+        settled_amount: u64,
+    ) -> Result<Self> {
+        let clock = Clock::get()?;
+        Ok(Self {
+            ts: clock.unix_timestamp,
+            slot: clock.slot,
+            store: *store,
+            order: *order,
+            builder: *builder,
+            token: *token,
+            recorded_amount,
+            settled_amount,
+        })
+    }
+}
+
+impl InitSpace for BuilderFeeSettled {
+    const INIT_SPACE: usize = <Self as Space>::INIT_SPACE;
+}
+
+impl Event for BuilderFeeSettled {}

--- a/programs/store/src/events/mod.rs
+++ b/programs/store/src/events/mod.rs
@@ -28,6 +28,10 @@ mod gt;
 /// User account events.
 mod user;
 
+/// Builder fee events.
+mod builder_fee;
+
+pub use builder_fee::*;
 pub use deposit::*;
 pub use glv::*;
 pub use gt::*;

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -1,0 +1,139 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{transfer_checked, Mint, Token, TokenAccount, TransferChecked};
+
+use crate::{
+    events::{BuilderFeeSettled, EventEmitter},
+    states::{user::UserHeader, Order, Store},
+    CoreError,
+};
+
+/// The accounts definition for
+/// [`settle_builder_fee`](crate::gmsol_store::settle_builder_fee).
+#[event_cpi]
+#[derive(Accounts)]
+pub struct SettleBuilderFee<'info> {
+    /// Store.
+    pub store: AccountLoader<'info, Store>,
+    /// The order whose builder fee is to be settled.
+    #[account(
+        mut,
+        constraint = order.load()?.header.store == store.key() @ CoreError::StoreMismatched,
+    )]
+    pub order: AccountLoader<'info, Order>,
+    /// The final output token mint of the order, i.e. the token the
+    /// builder fee is denominated in.
+    pub final_output_token: Box<Account<'info, Mint>>,
+    /// The order's escrow account for the final output token.
+    #[account(
+        mut,
+        associated_token::mint = final_output_token,
+        associated_token::authority = order,
+        constraint = order.load()?.tokens().final_output_token.account() == Some(escrow.key()) @ CoreError::TokenAccountMismatched,
+    )]
+    pub escrow: Box<Account<'info, TokenAccount>>,
+    /// The builder's User Account.
+    ///
+    /// Only required when the order has a non-zero recorded builder fee
+    /// amount. The no-op path (a recorded amount of zero, including
+    /// orders that never had a builder set) performs no CPI and does not
+    /// need it, so it may be omitted.
+    #[account(
+        has_one = store,
+        constraint = builder_user.load()?.is_initialized() @ CoreError::InvalidUserAccount,
+    )]
+    pub builder_user: Option<AccountLoader<'info, UserHeader>>,
+    /// The builder's claim vault: the associated token account of the
+    /// final output token owned by the builder's User Account.
+    ///
+    /// Required to already exist, so no `init_if_needed` is used here.
+    /// Nothing currently guarantees that existence ahead of time: the
+    /// instruction that is meant to (CON-40's `set_builder_fee`) has not
+    /// landed yet. Until it does, a missing vault just makes settlement,
+    /// and therefore closing an order with a non-zero fee, fail rather
+    /// than misroute anything. Only required alongside `builder_user`,
+    /// for the same reason.
+    #[account(
+        mut,
+        associated_token::mint = final_output_token,
+        associated_token::authority = builder_user,
+    )]
+    pub claim_vault: Option<Box<Account<'info, TokenAccount>>>,
+    /// Token program.
+    pub token_program: Program<'info, Token>,
+}
+
+impl SettleBuilderFee<'_> {
+    /// Settle the builder fee of the given order.
+    ///
+    /// Permissionless and idempotent: a recorded amount of zero, including
+    /// orders that never had a builder set, is an explicit no-op that
+    /// performs no token transfer, no state update, and no CPI. This makes
+    /// it safe to call in any order state, before or after terminal.
+    pub(crate) fn invoke(ctx: Context<Self>) -> Result<()> {
+        let recorded_amount = ctx.accounts.order.load()?.builder_fee_amount();
+        if recorded_amount == 0 {
+            return Ok(());
+        }
+
+        let builder_user = ctx
+            .accounts
+            .builder_user
+            .as_ref()
+            .ok_or_else(|| error!(CoreError::TokenAccountNotProvided))?;
+        let claim_vault = ctx
+            .accounts
+            .claim_vault
+            .as_ref()
+            .ok_or_else(|| error!(CoreError::TokenAccountNotProvided))?;
+
+        {
+            // A non-zero recorded amount implies a builder must have been set.
+            let order = ctx.accounts.order.load()?;
+            let builder = order.builder().ok_or_else(|| error!(CoreError::Internal))?;
+            require_keys_eq!(*builder, builder_user.key(), CoreError::InvalidUserAccount);
+        }
+
+        // `claim_vault` is the ATA of (`builder_user`, `final_output_token`) per
+        // the `associated_token` constraint above, so its owner and mint are
+        // already guaranteed here.
+
+        // Under the charging invariant the escrow always covers the recorded
+        // amount, so this clamp should never actually reduce anything; it is
+        // defense in depth, guaranteeing a protocol bug can never make an
+        // order permanently unclosable. Any discrepancy is observable via the
+        // two amounts recorded on the emitted event below.
+        let settled_amount = recorded_amount.min(ctx.accounts.escrow.amount);
+
+        let signer = ctx.accounts.order.load()?.signer();
+        let seeds = signer.as_seeds();
+        transfer_checked(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                TransferChecked {
+                    from: ctx.accounts.escrow.to_account_info(),
+                    mint: ctx.accounts.final_output_token.to_account_info(),
+                    to: claim_vault.to_account_info(),
+                    authority: ctx.accounts.order.to_account_info(),
+                },
+            )
+            .with_signer(&[&seeds]),
+            settled_amount,
+            ctx.accounts.final_output_token.decimals,
+        )?;
+
+        ctx.accounts.order.load_mut()?.builder_fee_amount = 0;
+
+        EventEmitter::new(&ctx.accounts.event_authority, ctx.bumps.event_authority).emit_cpi(
+            &BuilderFeeSettled::new(
+                &ctx.accounts.store.key(),
+                &ctx.accounts.order.key(),
+                &builder_user.key(),
+                &ctx.accounts.final_output_token.key(),
+                recorded_amount,
+                settled_amount,
+            )?,
+        )?;
+
+        Ok(())
+    }
+}

--- a/programs/store/src/instructions/exchange/order.rs
+++ b/programs/store/src/instructions/exchange/order.rs
@@ -700,6 +700,16 @@ impl<'info> internal::Close<'info, Order> for CloseOrderV2<'info> {
     #[inline(never)]
     fn validate(&self) -> Result<()> {
         let order = self.order.load()?;
+        // Applies to every close path (owner close in any state, keeper
+        // close of terminal orders): an order with an unsettled builder
+        // fee must be settled via `settle_builder_fee` first, otherwise
+        // closing would sweep the fee to the receiver along with the
+        // regular output and destroy the beneficiary information.
+        require_eq!(
+            order.builder_fee_amount(),
+            0,
+            CoreError::UnsettledBuilderFee
+        );
         if order.header.action_state()?.is_pending() {
             self.store
                 .load()?

--- a/programs/store/src/instructions/mod.rs
+++ b/programs/store/src/instructions/mod.rs
@@ -43,6 +43,10 @@ pub mod callback;
 /// Instructions for virtual inventories.
 pub mod virtual_inventory;
 
+/// Instructions for builder fees.
+pub mod builder_fee;
+
+pub use builder_fee::*;
 pub use callback::*;
 pub use config::*;
 pub use exchange::*;

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -2254,6 +2254,27 @@ pub mod gmsol_store {
         internal::Close::close(&ctx, &reason)
     }
 
+    /// Settle the builder fee of an order.
+    ///
+    /// Permissionless: any signer may invoke it, no role is required, and
+    /// no specific address can block it. Idempotent: a recorded builder
+    /// fee amount of zero, including orders that never had a builder set,
+    /// is an explicit no-op, so this may be called in any order state,
+    /// before or after terminal.
+    ///
+    /// # Accounts
+    /// *[See the documentation for the accounts.](SettleBuilderFee)*
+    ///
+    /// # Errors
+    /// - The [`order`](SettleBuilderFee::order) must be initialized and owned by the `store`.
+    /// - If the order's recorded builder fee amount is non-zero, [`builder_user`](SettleBuilderFee::builder_user)
+    ///   must be provided and must match the builder recorded on the order, and
+    ///   [`claim_vault`](SettleBuilderFee::claim_vault) must be provided and must be the
+    ///   associated token account of the final output token owned by `builder_user`.
+    pub fn settle_builder_fee(ctx: Context<SettleBuilderFee>) -> Result<()> {
+        SettleBuilderFee::invoke(ctx)
+    }
+
     /// Cancel order if the corresponding position does not exist.
     ///
     /// # Accounts

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -4407,6 +4407,10 @@ pub enum CoreError {
     /// Builder fee factor exceeds the max builder fee factor.
     #[msg("builder fee factor exceeds the max builder fee factor")]
     BuilderFeeFactorExceedsMaxFactor,
+    /// An order cannot be closed while it still has an unsettled builder
+    /// fee; settle it first via `settle_builder_fee`.
+    #[msg("order has an unsettled builder fee")]
+    UnsettledBuilderFee,
     // NOTE: New variants must be appended here to keep existing error codes stable.
 }
 


### PR DESCRIPTION
CON-37: Add builder fee settlement rails: close guard and permissionless settle_builder_fee

## Summary

Adds the two rails ADR-0001 needs before builder fee charging can be safely activated. Once an order executes with a builder fee, the charged amount sits in the order's final output token escrow and is recorded in `order.builder_fee_amount`. Closing an order wipes its on-chain data, so closing one with an unsettled fee would sweep it to the receiver along with the regular output and destroy the beneficiary information. This PR prevents that with a close guard and a dedicated, permissionless `settle_builder_fee` instruction.

Everything here is safe to merge immediately, ahead of activation. Accrual is still inert (`builder_fee_amount` is always 0 in production), so the guard never triggers and settlement always no-ops until a later PR turns real charging on.

Depends on `feat/builder-fee-state-v2` (`Order.builder` / `Order.builder_fee_amount`), hence this PR targets that branch rather than `main`.

## What's implemented

- **Close guard**, in `CloseOrderV2::validate()` (`programs/store/src/instructions/exchange/order.rs`), which Anchor calls before both close paths (owner close in any state, keeper close of terminal orders per `internal::Close::close()`). Rejects with the new `CoreError::UnsettledBuilderFee` whenever `order.builder_fee_amount() != 0`, appended at the end of the `CoreError` enum per the existing "new variants must be appended" convention, so it doesn't shift any existing error codes.
- **`BuilderFeeSettled` event** (`programs/store/src/events/builder_fee.rs`), recording the order, the builder, the token mint, and both the recorded and the actually-settled amounts.
- **`settle_builder_fee` instruction** (`programs/store/src/instructions/builder_fee.rs`), permissionless (no signer role, no `#[access_control]`), transferring `min(builder_fee_amount, escrow.amount)` from the order's final output token escrow to the builder's claim vault (the associated token account of the final output token owned by the builder's User Account), then unconditionally resetting `builder_fee_amount` to 0. `builder_user` and `claim_vault` are both `Option`, required only when the recorded amount is non-zero. When it's 0, including orders that never had a builder set, the handler returns immediately: no deserialization of those accounts, no CPI, no event.
- **SDK support** (`crates/sdk/src/client/ops/builder_fee.rs`, `BuilderFeeOps::settle_builder_fee`), which fetches the order when no hint is given and correctly derives `None`/`None` for the builder accounts on the no-op path rather than needing a placeholder account.


## Testing

- `cargo build --workspace` / `cargo test -p gmsol-store -p gmsol-sdk --lib` / `cargo clippy -p gmsol-store -p gmsol-sdk --lib`. All clean, 34 + 13 tests passing, no new warnings.
- No colocated Rust unit tests added: there's no pure logic here worth extracting (the clamp is a one-line `.min()`), consistent with how `CreateOrderV2`/`CloseOrderV2` and the rest of this instruction layer are already tested only through the `anchor_test` integration suite, not Rust unit tests.
- Did not run the full `anchor_test` suite for this PR (no test scenario exists yet for an order with a non-zero builder fee, since activation hasn't landed), so the close-guard and settlement paths are exercised by code review and by inspection against the acceptance criteria here rather than an integration test run.
