### PR TITLE
feat(store): add permissionless set_builder_fee_factor on the user account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- programs(store): Added the permissionless `set_builder_fee_factor` instruction, with which a User Account owner advertises a builder fee factor on their own account, bounded by the store's `MaxBuilderFeeFactor` (which reads `0` until a config keeper raises it). Emits a `BuilderFeeFactorSet` event.
 - sdk(sdk): Added `CreateOrderBuilder::prepare_final_output_token_escrow`, opting an increase order into providing its final output token escrow at creation. The escrow is what a builder fee would be paid out of, so an increase order created without it cannot be given one. Off by default, leaving the previous behavior unchanged.
+- sdk(sdk): Added `UserOps::set_builder_fee_factor` for building the instruction.
+- sdk(decode): Added `BuilderFeeFactorSet` to `GMSOLCPIEvent`, so the event decodes into its typed form instead of `UnknownOwnedData`.
 - sdk(solana-utils): Added `Bundle::send_all_with_opts_detailed`, returning one `Result` per transaction with stable bundle indices.
 - sdk(solana-utils): Added `Error::SendAborted` for unsent transactions after an early bundle abort.
 - sdk(solana-utils): Made `compress_send_results` public so callers can map detailed results to the legacy signature list.

--- a/crates/decode/src/gmsol.rs
+++ b/crates/decode/src/gmsol.rs
@@ -9,11 +9,11 @@ pub mod programs {
             Store, UserHeader, VirtualInventory, Withdrawal,
         },
         events::{
-            BorrowingFeesUpdated, DepositExecuted, DepositRemoved, GlvDepositRemoved, GlvPricing,
-            GlvTokenValue, GlvWithdrawalRemoved, GtBuyback, GtUpdated,
-            InsufficientFundingFeePayment, MarketFeesUpdated, MarketStateUpdated, MarketTokenValue,
-            OrderRemoved, OrderUpdated, PositionDecreased, PositionIncreased, ShiftRemoved,
-            SwapExecuted, TradeEvent, WithdrawalExecuted, WithdrawalRemoved,
+            BorrowingFeesUpdated, BuilderFeeFactorSet, DepositExecuted, DepositRemoved,
+            GlvDepositRemoved, GlvPricing, GlvTokenValue, GlvWithdrawalRemoved, GtBuyback,
+            GtUpdated, InsufficientFundingFeePayment, MarketFeesUpdated, MarketStateUpdated,
+            MarketTokenValue, OrderRemoved, OrderUpdated, PositionDecreased, PositionIncreased,
+            ShiftRemoved, SwapExecuted, TradeEvent, WithdrawalExecuted, WithdrawalRemoved,
         },
     };
 
@@ -53,6 +53,7 @@ pub mod programs {
     impl_decode_for_cpi_event!(GtBuyback);
     impl_decode_for_cpi_event!(MarketTokenValue);
     impl_decode_for_cpi_event!(GlvTokenValue);
+    impl_decode_for_cpi_event!(BuilderFeeFactorSet);
 
     untagged!(
         GMSOLAccountData,
@@ -101,6 +102,7 @@ pub mod programs {
             GtBuyback,
             MarketTokenValue,
             GlvTokenValue,
+            BuilderFeeFactorSet,
             UnknownOwnedData
         ]
     );

--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -19050,6 +19050,138 @@
       ]
     },
     {
+      "name": "set_builder_fee_factor",
+      "docs": [
+        "Set the builder fee factor advertised by the user.",
+        "",
+        "This instruction is permissionless: any User Account owner can set the",
+        "factor on their own account, and the account seeds make it impossible",
+        "to target another user's account. The factor is only an advertisement:",
+        "nothing is charged here, and no instruction reads it yet. A future",
+        "`set_builder_fee` will checkpoint it onto an order and validate it",
+        "against the cap a second time, and only a factor checkpointed that way",
+        "is ever paid.",
+        "",
+        "# Accounts",
+        "*[See the documentation for the accounts.](SetBuilderFeeFactor)*",
+        "",
+        "# Arguments",
+        "- `factor`: The builder fee factor to advertise. `0` opts out.",
+        "",
+        "# Errors",
+        "- The [`owner`](SetBuilderFeeFactor::owner) must be a signer.",
+        "- The [`store`](SetBuilderFeeFactor::store) must be properly initialized.",
+        "- The [`user`](SetBuilderFeeFactor::user) must be:",
+        "- Properly initialized",
+        "- Correspond to the `owner`",
+        "- The `factor` must not exceed the store's",
+        "[`MaxBuilderFeeFactor`](crate::states::FactorKey::MaxBuilderFeeFactor),",
+        "which reads `0` until a config keeper raises it."
+      ],
+      "discriminator": [
+        12,
+        9,
+        172,
+        156,
+        43,
+        229,
+        239,
+        121
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Owner."
+          ],
+          "signer": true,
+          "relations": [
+            "user"
+          ]
+        },
+        {
+          "name": "store",
+          "docs": [
+            "Store."
+          ],
+          "relations": [
+            "user"
+          ]
+        },
+        {
+          "name": "user",
+          "docs": [
+            "User Account.",
+            "",
+            "The seeds bind this account to the signing `owner`, so setting the",
+            "factor on someone else's User Account is unconstructible rather than",
+            "merely rejected. This is what makes the instruction permissionless",
+            "without granting anyone reach beyond their own account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "store"
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "factor",
+          "type": "u128"
+        }
+      ]
+    },
+    {
       "name": "set_expected_provider",
       "docs": [
         "Set the expected provider for the given token.",
@@ -22231,6 +22363,19 @@
       ]
     },
     {
+      "name": "BuilderFeeFactorSet",
+      "discriminator": [
+        4,
+        62,
+        202,
+        111,
+        226,
+        46,
+        131,
+        203
+      ]
+    },
+    {
       "name": "DepositCreated",
       "discriminator": [
         146,
@@ -23188,6 +23333,11 @@
       "code": 6128,
       "name": "ProviderDoesNotSupportMarketStatus",
       "msg": "market status flags are not yet supported for this price provider"
+    },
+    {
+      "code": 6129,
+      "name": "BuilderFeeFactorExceedsMaxFactor",
+      "msg": "builder fee factor exceeds the max builder fee factor"
     }
   ],
   "types": [
@@ -23557,6 +23707,54 @@
                   }
                 ]
               }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFeeFactorSet",
+      "docs": [
+        "Builder fee factor set event."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user",
+            "docs": [
+              "The User Account whose builder fee factor was set."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "The owner of the User Account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "previous_factor",
+            "docs": [
+              "The builder fee factor before this update."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "factor",
+            "docs": [
+              "The builder fee factor after this update."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
             }
           }
         ]

--- a/crates/sdk/src/client/ops/user.rs
+++ b/crates/sdk/src/client/ops/user.rs
@@ -52,6 +52,16 @@ pub trait UserOps<C> {
         code: ReferralCodeBytes,
         hint_owner: Option<Pubkey>,
     ) -> impl Future<Output = crate::Result<TransactionBuilder<C>>>;
+
+    /// Set the builder fee factor advertised by the payer's user account.
+    ///
+    /// The factor must not exceed the store's `MaxBuilderFeeFactor`, which
+    /// reads `0` until a config keeper raises it. Passing `0` opts out.
+    fn set_builder_fee_factor(
+        &self,
+        store: &Pubkey,
+        factor: u128,
+    ) -> crate::Result<TransactionBuilder<C>>;
 }
 
 impl<C: Deref<Target = impl Signer> + Clone> UserOps<C> for crate::Client<C> {
@@ -232,6 +242,26 @@ impl<C: Deref<Target = impl Signer> + Clone> UserOps<C> for crate::Client<C> {
                 receiver_user,
             })
             .anchor_args(args::AcceptReferralCode {});
+        Ok(rpc)
+    }
+
+    fn set_builder_fee_factor(
+        &self,
+        store: &Pubkey,
+        factor: u128,
+    ) -> crate::Result<TransactionBuilder<C>> {
+        let owner = self.payer();
+        let user = self.find_user_address(store, &owner);
+        let rpc = self
+            .store_transaction()
+            .anchor_accounts(accounts::SetBuilderFeeFactor {
+                owner,
+                store: *store,
+                user,
+                event_authority: self.store_event_authority(),
+                program: *self.store_program_id(),
+            })
+            .anchor_args(args::SetBuilderFeeFactor { factor });
         Ok(rpc)
     }
 }

--- a/programs/store/src/events/mod.rs
+++ b/programs/store/src/events/mod.rs
@@ -25,6 +25,9 @@ mod market;
 /// GT events.
 mod gt;
 
+/// User account events.
+mod user;
+
 pub use deposit::*;
 pub use glv::*;
 pub use gt::*;
@@ -33,6 +36,7 @@ pub use order::*;
 pub use shift::*;
 pub use swap::*;
 pub use trade::*;
+pub use user::*;
 pub use withdrawal::*;
 
 use anchor_lang::prelude::*;

--- a/programs/store/src/events/user.rs
+++ b/programs/store/src/events/user.rs
@@ -1,0 +1,39 @@
+use anchor_lang::prelude::*;
+use borsh::BorshSerialize;
+
+use super::Event;
+
+/// Builder fee factor set event.
+#[event]
+#[cfg_attr(feature = "debug", derive(derive_more::Debug))]
+#[derive(InitSpace)]
+pub struct BuilderFeeFactorSet {
+    /// The User Account whose builder fee factor was set.
+    pub user: Pubkey,
+    /// The owner of the User Account.
+    pub owner: Pubkey,
+    /// The builder fee factor before this update.
+    pub previous_factor: u128,
+    /// The builder fee factor after this update.
+    pub factor: u128,
+    #[cfg_attr(feature = "debug", debug(skip))]
+    reserved: [u8; 64],
+}
+
+impl gmsol_utils::InitSpace for BuilderFeeFactorSet {
+    const INIT_SPACE: usize = <Self as Space>::INIT_SPACE;
+}
+
+impl Event for BuilderFeeFactorSet {}
+
+impl BuilderFeeFactorSet {
+    pub(crate) fn new(user: Pubkey, owner: Pubkey, previous_factor: u128, factor: u128) -> Self {
+        Self {
+            user,
+            owner,
+            previous_factor,
+            factor,
+            reserved: [0; 64],
+        }
+    }
+}

--- a/programs/store/src/instructions/user.rs
+++ b/programs/store/src/instructions/user.rs
@@ -2,9 +2,10 @@ use anchor_lang::prelude::*;
 use gmsol_utils::InitSpace;
 
 use crate::{
+    events::{BuilderFeeFactorSet, EventEmitter},
     states::{
         user::{ReferralCodeBytes, ReferralCodeV2, UserHeader},
-        Seed, Store,
+        FactorKey, Seed, Store,
     },
     CoreError,
 };
@@ -305,6 +306,72 @@ pub(crate) fn cancel_referral_code_transfer(
         code.code,
         code.next_owner(),
     );
+
+    Ok(())
+}
+
+/// The accounts definitions for
+/// [`set_builder_fee_factor`](crate::gmsol_store::set_builder_fee_factor) instruction.
+#[event_cpi]
+#[derive(Accounts)]
+pub struct SetBuilderFeeFactor<'info> {
+    /// Owner.
+    pub owner: Signer<'info>,
+    /// Store.
+    pub store: AccountLoader<'info, Store>,
+    /// User Account.
+    ///
+    /// The seeds bind this account to the signing `owner`, so setting the
+    /// factor on someone else's User Account is unconstructible rather than
+    /// merely rejected. This is what makes the instruction permissionless
+    /// without granting anyone reach beyond their own account.
+    #[account(
+        mut,
+        has_one = owner,
+        has_one = store,
+        constraint = user.load()?.is_initialized() @ CoreError::InvalidUserAccount,
+        seeds = [UserHeader::SEED, store.key().as_ref(), owner.key().as_ref()],
+        bump = user.load()?.bump,
+    )]
+    pub user: AccountLoader<'info, UserHeader>,
+}
+
+pub(crate) fn set_builder_fee_factor(
+    ctx: Context<SetBuilderFeeFactor>,
+    factor: u128,
+) -> Result<()> {
+    // Note that this instruction is deliberately not gated by the
+    // `BuilderFee` domain flag: it only records an advertised rate, and no
+    // instruction charges a fee off it today. A fee can only be charged after
+    // a future `set_builder_fee` checkpoints the factor onto an order, so
+    // gating belongs there rather than here.
+    //
+    // A missing cap is treated as `0` (deny by default), so on a store that
+    // predates the factor key only opting out remains possible. The key is
+    // always wired today, which makes this branch unreachable rather than
+    // merely unlikely.
+    let max_factor = ctx
+        .accounts
+        .store
+        .load()?
+        .get_factor_by_key(FactorKey::MaxBuilderFeeFactor)
+        .copied()
+        .unwrap_or(0);
+    require_gte!(
+        max_factor,
+        factor,
+        CoreError::BuilderFeeFactorExceedsMaxFactor
+    );
+
+    let previous_factor = ctx.accounts.user.load_mut()?.set_builder_fee_factor(factor);
+
+    let event_emitter = EventEmitter::new(&ctx.accounts.event_authority, ctx.bumps.event_authority);
+    event_emitter.emit_cpi(&BuilderFeeFactorSet::new(
+        ctx.accounts.user.key(),
+        ctx.accounts.owner.key(),
+        previous_factor,
+        factor,
+    ))?;
 
     Ok(())
 }

--- a/programs/store/src/instructions/user.rs
+++ b/programs/store/src/instructions/user.rs
@@ -336,42 +336,42 @@ pub struct SetBuilderFeeFactor<'info> {
     pub user: AccountLoader<'info, UserHeader>,
 }
 
-pub(crate) fn set_builder_fee_factor(
-    ctx: Context<SetBuilderFeeFactor>,
-    factor: u128,
-) -> Result<()> {
-    // Note that this instruction is deliberately not gated by the
-    // `BuilderFee` domain flag: it only records an advertised rate, and no
-    // instruction charges a fee off it today. A fee can only be charged after
-    // a future `set_builder_fee` checkpoints the factor onto an order, so
-    // gating belongs there rather than here.
-    //
-    // A missing cap is treated as `0` (deny by default), so on a store that
-    // predates the factor key only opting out remains possible. The key is
-    // always wired today, which makes this branch unreachable rather than
-    // merely unlikely.
-    let max_factor = ctx
-        .accounts
-        .store
-        .load()?
-        .get_factor_by_key(FactorKey::MaxBuilderFeeFactor)
-        .copied()
-        .unwrap_or(0);
-    require_gte!(
-        max_factor,
-        factor,
-        CoreError::BuilderFeeFactorExceedsMaxFactor
-    );
+impl SetBuilderFeeFactor<'_> {
+    pub(crate) fn invoke(ctx: Context<Self>, factor: u128) -> Result<()> {
+        // Note that this instruction is deliberately not gated by the
+        // `BuilderFee` domain flag: it only records an advertised rate, and no
+        // instruction charges a fee off it today. A fee can only be charged after
+        // a future `set_builder_fee` checkpoints the factor onto an order, so
+        // gating belongs there rather than here.
+        //
+        // A missing cap is treated as `0` (deny by default), so on a store that
+        // predates the factor key only opting out remains possible. The key is
+        // always wired today, which makes this branch unreachable rather than
+        // merely unlikely.
+        let max_factor = ctx
+            .accounts
+            .store
+            .load()?
+            .get_factor_by_key(FactorKey::MaxBuilderFeeFactor)
+            .copied()
+            .unwrap_or(0);
+        require_gte!(
+            max_factor,
+            factor,
+            CoreError::BuilderFeeFactorExceedsMaxFactor
+        );
 
-    let previous_factor = ctx.accounts.user.load_mut()?.set_builder_fee_factor(factor);
+        let previous_factor = ctx.accounts.user.load_mut()?.set_builder_fee_factor(factor);
 
-    let event_emitter = EventEmitter::new(&ctx.accounts.event_authority, ctx.bumps.event_authority);
-    event_emitter.emit_cpi(&BuilderFeeFactorSet::new(
-        ctx.accounts.user.key(),
-        ctx.accounts.owner.key(),
-        previous_factor,
-        factor,
-    ))?;
+        let event_emitter =
+            EventEmitter::new(&ctx.accounts.event_authority, ctx.bumps.event_authority);
+        event_emitter.emit_cpi(&BuilderFeeFactorSet::new(
+            ctx.accounts.user.key(),
+            ctx.accounts.owner.key(),
+            previous_factor,
+            factor,
+        ))?;
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -196,6 +196,7 @@
 //! - [`transfer_referral_code`](gmsol_store::transfer_referral_code): Transfer the referral code to others.
 //! - [`cancel_referral_code_transfer`](gmsol_store::cancel_referral_code_transfer): Cancel the referral code transfer.
 //! - [`accept_referral_code`](gmsol_store::accept_referral_code): Complete the referral code transfer.
+//! - [`set_builder_fee_factor`](gmsol_store::set_builder_fee_factor): Set the builder fee factor advertised by the user.
 //!
 //! ## GT Model
 //!
@@ -3105,6 +3106,35 @@ pub mod gmsol_store {
         instructions::set_referrer(ctx, code)
     }
 
+    /// Set the builder fee factor advertised by the user.
+    ///
+    /// This instruction is permissionless: any User Account owner can set the
+    /// factor on their own account, and the account seeds make it impossible
+    /// to target another user's account. The factor is only an advertisement:
+    /// nothing is charged here, and no instruction reads it yet. A future
+    /// `set_builder_fee` will checkpoint it onto an order and validate it
+    /// against the cap a second time, and only a factor checkpointed that way
+    /// is ever paid.
+    ///
+    /// # Accounts
+    /// *[See the documentation for the accounts.](SetBuilderFeeFactor)*
+    ///
+    /// # Arguments
+    /// - `factor`: The builder fee factor to advertise. `0` opts out.
+    ///
+    /// # Errors
+    /// - The [`owner`](SetBuilderFeeFactor::owner) must be a signer.
+    /// - The [`store`](SetBuilderFeeFactor::store) must be properly initialized.
+    /// - The [`user`](SetBuilderFeeFactor::user) must be:
+    ///   - Properly initialized
+    ///   - Correspond to the `owner`
+    /// - The `factor` must not exceed the store's
+    ///   [`MaxBuilderFeeFactor`](crate::states::FactorKey::MaxBuilderFeeFactor),
+    ///   which reads `0` until a config keeper raises it.
+    pub fn set_builder_fee_factor(ctx: Context<SetBuilderFeeFactor>, factor: u128) -> Result<()> {
+        instructions::set_builder_fee_factor(ctx, factor)
+    }
+
     /// Transfer referral code.
     ///
     /// # Accounts
@@ -4371,6 +4401,12 @@ pub enum CoreError {
     /// Market status flags are not yet supported for this price provider.
     #[msg("market status flags are not yet supported for this price provider")]
     ProviderDoesNotSupportMarketStatus,
+    // ===========================================
+    //              Builder Fee Errors
+    // ===========================================
+    /// Builder fee factor exceeds the max builder fee factor.
+    #[msg("builder fee factor exceeds the max builder fee factor")]
+    BuilderFeeFactorExceedsMaxFactor,
     // NOTE: New variants must be appended here to keep existing error codes stable.
 }
 

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -3132,7 +3132,7 @@ pub mod gmsol_store {
     ///   [`MaxBuilderFeeFactor`](crate::states::FactorKey::MaxBuilderFeeFactor),
     ///   which reads `0` until a config keeper raises it.
     pub fn set_builder_fee_factor(ctx: Context<SetBuilderFeeFactor>, factor: u128) -> Result<()> {
-        instructions::set_builder_fee_factor(ctx, factor)
+        SetBuilderFeeFactor::invoke(ctx, factor)
     }
 
     /// Transfer referral code.

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -157,6 +157,14 @@ impl UserHeader {
     pub fn builder_fee_factor(&self) -> u128 {
         self.builder_fee_factor
     }
+
+    /// Set this user's builder fee factor, as a builder, returning the previous one.
+    ///
+    /// The caller is responsible for validating the factor against the
+    /// store-level cap: this only records the advertised rate.
+    pub(crate) fn set_builder_fee_factor(&mut self, factor: u128) -> u128 {
+        std::mem::replace(&mut self.builder_fee_factor, factor)
+    }
 }
 
 impl Seed for UserHeader {

--- a/tests/anchor_test/user.rs
+++ b/tests/anchor_test/user.rs
@@ -1,6 +1,19 @@
-use gmsol_programs::gmsol_store::accounts::ReferralCodeV2;
-use gmsol_sdk::client::ops::UserOps;
+use std::panic::{resume_unwind, AssertUnwindSafe};
+
+use futures_util::FutureExt;
+use gmsol_programs::{
+    anchor_lang::error::ErrorCode,
+    gmsol_store::{
+        accounts::ReferralCodeV2,
+        client::{accounts, args},
+    },
+};
+use gmsol_sdk::{
+    client::ops::{ConfigOps, UserOps},
+    constants::MARKET_USD_UNIT,
+};
 use gmsol_store::CoreError;
+use gmsol_utils::config::FactorKey;
 
 use crate::anchor_test::setup::{current_deployment, Deployment};
 
@@ -84,6 +97,127 @@ async fn referral() -> eyre::Result<()> {
         gmsol_sdk::Error::from(err).anchor_error_code(),
         Some(CoreError::MutualReferral.into())
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn builder_fee_factor() -> eyre::Result<()> {
+    /// One percent, in the market factor unit.
+    const CAP: u128 = MARKET_USD_UNIT / 100;
+
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("builder_fee_factor");
+    let _enter = span.enter();
+
+    // The keeper holds the `CONFIG_KEEPER` role, which is what may raise the cap.
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let client = deployment.user_client(Deployment::USER_1)?;
+    let store = &deployment.store;
+
+    let signature = client.prepare_user(store)?.send_without_preflight().await?;
+    tracing::info!(%signature, "prepared user account for the builder");
+
+    let user_address = client.find_user_address(store, &client.payer());
+
+    // The cap is zero until a config keeper raises it, so the mechanism is
+    // closed and no nonzero rate can be advertised yet.
+    let err = client
+        .set_builder_fee_factor(store, 1)?
+        .send()
+        .await
+        .expect_err("should reject any nonzero factor while the cap is zero");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(CoreError::BuilderFeeFactorExceedsMaxFactor.into())
+    );
+
+    let signature = keeper
+        .insert_global_factor_by_key(store, FactorKey::MaxBuilderFeeFactor, &CAP)
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "opened the mechanism by raising the cap");
+
+    // Everything that needs the cap raised runs inside this block, so that the
+    // restore below is reached however the block ends. The store is a fixture
+    // shared with every test in this binary, and they run concurrently, so a
+    // cap left raised would leak into unrelated tests. Catching the unwind is
+    // what covers a failing assertion; an early return alone would not.
+    let result = AssertUnwindSafe(async {
+        // Setting the factor exactly at the cap is allowed.
+        let signature = client
+            .set_builder_fee_factor(store, CAP)?
+            .send_without_preflight()
+            .await?;
+        tracing::info!(%signature, "advertised a builder fee factor at the cap");
+        assert_eq!(client.user(&user_address).await?.builder_fee_factor, CAP);
+
+        // One unit above the cap is not.
+        let err = client
+            .set_builder_fee_factor(store, CAP + 1)?
+            .send()
+            .await
+            .expect_err("should reject a factor above the cap");
+        assert_eq!(
+            gmsol_sdk::Error::from(err).anchor_error_code(),
+            Some(CoreError::BuilderFeeFactorExceedsMaxFactor.into())
+        );
+        assert_eq!(
+            client.user(&user_address).await?.builder_fee_factor,
+            CAP,
+            "a rejected update must leave the stored factor untouched"
+        );
+
+        // Zero always succeeds: it is how a builder opts out.
+        let signature = client
+            .set_builder_fee_factor(store, 0)?
+            .send_without_preflight()
+            .await?;
+        tracing::info!(%signature, "opted out of the builder fee");
+        assert_eq!(client.user(&user_address).await?.builder_fee_factor, 0);
+
+        // Setting the factor on someone else's User Account is unconstructible:
+        // the account seeds are derived from the signer, so the address passed
+        // here cannot be the one the constraint derives.
+        let err = keeper
+            .store_transaction()
+            .anchor_accounts(accounts::SetBuilderFeeFactor {
+                owner: keeper.payer(),
+                store: *store,
+                user: user_address,
+                event_authority: keeper.store_event_authority(),
+                program: *keeper.store_program_id(),
+            })
+            .anchor_args(args::SetBuilderFeeFactor { factor: 0 })
+            .send()
+            .await
+            .expect_err("should reject setting the factor on another user's account");
+        assert_eq!(
+            gmsol_sdk::Error::from(err).anchor_error_code(),
+            Some(ErrorCode::ConstraintSeeds.into())
+        );
+
+        Ok::<_, eyre::Report>(())
+    })
+    .catch_unwind()
+    .await;
+
+    // Leave the store as it was found.
+    let restored = keeper
+        .insert_global_factor_by_key(store, FactorKey::MaxBuilderFeeFactor, &0)
+        .send_without_preflight()
+        .await;
+
+    // The body's failure is the interesting one, so report it before the
+    // restore's.
+    match result {
+        Ok(result) => result?,
+        Err(panic) => resume_unwind(panic),
+    }
+
+    let signature = restored?;
+    tracing::info!(%signature, "closed the mechanism again");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds `set_builder_fee_factor`, a permissionless instruction with which a User Account owner records the
builder fee factor advertised on their **own** account, bounded by the store-level `MaxBuilderFeeFactor`.

The factor is only an advertisement, and nothing is charged here. An order will pay it only once its owner
checkpoints the factor onto that order, where it is re-validated (ADR-0001); that checkpointing instruction
is a separate issue and is not part of this PR. The cap is therefore enforced in both places on purpose:
here for immediate feedback to the builder, and again at checkpoint time because the cap is
runtime-adjustable and may be lowered after a factor was legally set.

Builds on the state carve-outs merged in #407: `UserHeader.builder_fee_factor` and
`FactorKey::MaxBuilderFeeFactor`.

## What's here

- `SetBuilderFeeFactor` follows `set_referrer`'s account shape: `owner: Signer`, `store`, and the `user`
  account constrained by `has_one = owner`, `has_one = store`, `is_initialized()` and the PDA seeds
  `[UserHeader::SEED, store, owner]`. The seeds are what make this safe to expose permissionlessly: the
  account address is derived from the signer, so setting a factor on someone else's account is
  unconstructible rather than merely rejected.
- The handler reads the cap, rejects anything above it with a new `CoreError::BuilderFeeFactorExceedsMaxFactor`,
  writes the factor and emits `BuilderFeeFactorSet` with the user, its owner, and the previous and new
  factors. The previous value comes from the setter itself, so no second account read is needed.
- `UserHeader` gains a `pub(crate)` setter; #407 shipped the getter only.
- New `events/user.rs` for the event. The order-side builder-fee events live in `events/order.rs`, but this
  one describes the user account, so it gets its own module rather than being filed under orders.
- SDK: `UserOps::set_builder_fee_factor`, mirroring `set_referrer`. Synchronous, since there is no hint to
  fetch.
- A `CHANGELOG.md` entry for the instruction and the SDK method.

## On the feature flag

The instruction is deliberately **not** gated by the `BuilderFee` domain flag, and the handler carries a
comment saying so, because the omission is easy to read as an oversight. It records an advertised rate and
nothing charges a fee off it today; a fee can only be charged once the factor is checkpointed onto an order,
so the gate belongs on that instruction rather than this one.

## On the unset cap

The cap is read with `get_factor_by_key(FactorKey::MaxBuilderFeeFactor)`, and a missing key is treated as
`0` rather than raised as `Unimplemented`, so the failure mode is deny-by-default: on a store where the key
was never wired, only opting out (`0`) remains possible and no nonzero factor is configurable. Since #407
always wires the key, that branch is unreachable today rather than merely unlikely, but the choice matters
because the wrong default here is "unbounded" rather than "denied".

The practical consequence is worth stating explicitly: on every existing store the cap reads `0` until a
config keeper raises it, so this instruction is inert until the protocol deliberately opens the mechanism.

## On the checkpoint-immutability criterion

One acceptance criterion states that changing the factor never affects factors already checkpointed on
orders. Nothing in this PR implements it, and that is intentional, as agreed before implementation started.

The advertisement (`UserHeader.builder_fee_factor`) and the checkpoint (`Order.builder_fee_factor`) are
separate fields on separate accounts, and nothing here writes the checkpoint. So this instruction cannot
affect a checkpoint either way, and the invariant cannot be exercised until the checkpointing instruction
exists. It is stated and owned by that issue, where re-checkpointing semantics are defined in full.

## On the IDL

This PR updates `crates/programs/idls/gmsol_store.json`, which feature PRs normally leave to the separate
`chore: update idls` runs. It is unavoidable here: `declare_program!` generates the SDK's `accounts` and
`args` types from that file, so the SDK support this issue asks for does not compile without it, and
`cargo check --workspace --all-features` would fail on CI.

The diff is additive only: 197 insertions, 0 deletions, covering exactly the instruction, the event, its
type and the new error code. No existing entry is modified. Happy to split it out if you would rather the
IDL moved on its own schedule.

## Tests

One case in `tests/anchor_test/user.rs`, walking the whole lifecycle in the order a builder would hit it:

1. A nonzero factor is rejected while the cap is still `0`, which is the state of every existing store.
2. A config keeper raises the cap, opening the mechanism.
3. Setting the factor exactly at the cap succeeds, and the stored value is read back from the account rather
   than inferred from the transaction succeeding.
4. One unit above the cap is rejected with the new error, and the stored factor is asserted unchanged.
5. `0` succeeds, since that is how a builder opts out.
6. A hand-rolled instruction pointing at another owner's User Account fails on the seeds constraint.

The test restores the cap to `0` at the end, since the fixture is shared with the rest of the suite.

## Out of scope

- `set_builder_fee` and anything about checkpointing a factor onto an order.
- Fee computation, accrual and payout.
- Raising the cap on any live store: that stays a config-keeper decision, and until it happens this
  instruction accepts only `0`.