### PR TITLE
feat: add the owner-signed claim_builder_fees instruction

### DIFF
--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -1013,6 +1013,303 @@
       "returns": "bool"
     },
     {
+      "name": "claim_builder_fees",
+      "docs": [
+        "Claim builder fees.",
+        "",
+        "Restricted to the User Account's owner. Idempotent: a claim vault",
+        "with a zero balance is an explicit no-op, so this may be called",
+        "freely once the vault exists. Not gated by the `BuilderFee`",
+        "feature flag.",
+        "",
+        "# Accounts",
+        "*[See the documentation for the accounts.](ClaimBuilderFees)*",
+        "",
+        "# Errors",
+        "- The [`owner`](ClaimBuilderFees::owner) must be a signer and must",
+        "match the owner recorded on [`user_account`](ClaimBuilderFees::user_account).",
+        "- The [`user_account`](ClaimBuilderFees::user_account) must be properly",
+        "initialized and belong to the `store`.",
+        "- The [`claim_vault`](ClaimBuilderFees::claim_vault) must already exist and",
+        "be the associated token account of the [`token_mint`](ClaimBuilderFees::token_mint)",
+        "owned by `user_account`.",
+        "- The [`destination`](ClaimBuilderFees::destination) must be a token account",
+        "for `token_mint`.",
+        "- The [`user_token_controller`](ClaimBuilderFees::user_token_controller) must",
+        "match its PDA derivation from `user_account` and `token_mint`; no other",
+        "validation is performed on it."
+      ],
+      "discriminator": [
+        207,
+        194,
+        126,
+        184,
+        118,
+        67,
+        225,
+        181
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The owner of the [`user_account`](Self::user_account). The only",
+            "signer allowed to claim its builder fees."
+          ],
+          "signer": true,
+          "relations": [
+            "user_account"
+          ]
+        },
+        {
+          "name": "store",
+          "docs": [
+            "Store."
+          ],
+          "relations": [
+            "user_account"
+          ]
+        },
+        {
+          "name": "user_account",
+          "docs": [
+            "The builder's User Account."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "store"
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "The token mint the claim is denominated in."
+          ]
+        },
+        {
+          "name": "claim_vault",
+          "docs": [
+            "The claim vault: the associated token account of `token_mint`",
+            "owned by `user_account`.",
+            "",
+            "Its authority is the program-controlled User Account PDA, so this",
+            "instruction is the only path that can move tokens out of it.",
+            "",
+            "Must already exist; this instruction never creates it. A builder",
+            "with no vault for this mint has never been settled and so has",
+            "nothing to claim, which is rejected outright rather than treated",
+            "as a no-op: the caller asked to be paid, and the useful answer is",
+            "that no such vault exists. Callers holding a `None` vault address",
+            "simply leave the instruction out of the transaction."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user_account"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "destination",
+          "docs": [
+            "The destination token account for `token_mint`, chosen by the",
+            "owner. Not required to be an associated token account, but a",
+            "transferring claim rejects the claim vault itself; see",
+            "[`claim_builder_fees`](crate::gmsol_store::claim_builder_fees)."
+          ],
+          "writable": true
+        },
+        {
+          "name": "user_token_controller",
+          "docs": [
+            "The (per-user, per-token) user token controller PDA.",
+            "",
+            "Reserved for future withdrawal access control (e.g. a timelock).",
+            "It has no backing account and no data today, so the only check",
+            "performed on it is that the passed address matches its PDA",
+            "derivation; adding real behavior behind it later is not a",
+            "breaking change to this instruction's accounts."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114,
+                  95,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  99,
+                  111,
+                  110,
+                  116,
+                  114,
+                  111,
+                  108,
+                  108,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "user_account"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "claim_fees_from_market",
       "docs": [
         "Claim fees from the given market.",
@@ -23001,6 +23298,19 @@
       ]
     },
     {
+      "name": "BuilderFeeClaimed",
+      "discriminator": [
+        173,
+        137,
+        231,
+        148,
+        184,
+        179,
+        14,
+        141
+      ]
+    },
+    {
       "name": "BuilderFeeFactorSet",
       "discriminator": [
         4,
@@ -24478,6 +24788,69 @@
               "The amount actually charged, after shortfall clamping."
             ],
             "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderFeeClaimed",
+      "docs": [
+        "An event indicating that builder fees have been claimed.",
+        "",
+        "Emitted only when the claim actually transfers a non-zero amount; the",
+        "no-op path (an empty claim vault) emits nothing."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ts",
+            "docs": [
+              "Timestamp."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slot",
+            "docs": [
+              "Slot."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "store",
+            "docs": [
+              "Store."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "builder",
+            "docs": [
+              "The builder's User Account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token",
+            "docs": [
+              "The token mint the claim is denominated in."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "The amount transferred, i.e. the claim vault's full prior balance."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "destination",
+            "docs": [
+              "The destination token account the claim was sent to."
+            ],
+            "type": "pubkey"
           }
         ]
       }

--- a/crates/sdk/src/client/mod.rs
+++ b/crates/sdk/src/client/mod.rs
@@ -501,6 +501,20 @@ impl<C: Clone + Deref<Target = impl Signer>> Client<C> {
         crate::pda::find_referral_code_address(store, code, self.store_program_id()).0
     }
 
+    /// Find PDA for the (per-user, per-token) user token controller.
+    pub fn find_user_token_controller_address(
+        &self,
+        user_account: &Pubkey,
+        token_mint: &Pubkey,
+    ) -> Pubkey {
+        crate::pda::find_user_token_controller_address(
+            user_account,
+            token_mint,
+            self.store_program_id(),
+        )
+        .0
+    }
+
     /// Find PDA for GLV token mint.
     pub fn find_glv_token_address(&self, store: &Pubkey, index: u16) -> Pubkey {
         crate::pda::find_glv_token_address(store, index, self.store_program_id()).0

--- a/crates/sdk/src/client/ops/builder_fee.rs
+++ b/crates/sdk/src/client/ops/builder_fee.rs
@@ -40,6 +40,26 @@ pub trait BuilderFeeOps<C> {
         expected_factor: u128,
         hint: Option<SetBuilderFeeHint>,
     ) -> impl Future<Output = crate::Result<TransactionBuilder<C>>>;
+
+    /// Claim the full balance of the caller's own claim vault for the
+    /// given token mint, to a destination token account of their choice.
+    ///
+    /// Restricted to the payer's own User Account by the program: no
+    /// hint is needed, since every account here is a pure function of
+    /// `store`, `token_mint`, `destination`, and the payer's own key.
+    /// Idempotent once the claim vault exists: safe to call whether or
+    /// not it holds a non-zero balance.
+    ///
+    /// The claim vault is required by the program, so a builder that has
+    /// never been settled for this mint fails here rather than silently
+    /// succeeding, which is the more useful answer for a caller who asked
+    /// to be paid.
+    fn claim_builder_fees(
+        &self,
+        store: &Pubkey,
+        token_mint: &Pubkey,
+        destination: &Pubkey,
+    ) -> crate::Result<TransactionBuilder<C>>;
 }
 
 /// Hint for [`settle_builder_fee`](BuilderFeeOps::settle_builder_fee), to
@@ -148,5 +168,40 @@ impl<C: Deref<Target = impl Signer> + Clone> BuilderFeeOps<C> for crate::Client<
         let ag = ix.into_atomic_group(&hint)?;
 
         Ok(self.store_transaction().pre_atomic_group(ag, true))
+    }
+
+    fn claim_builder_fees(
+        &self,
+        store: &Pubkey,
+        token_mint: &Pubkey,
+        destination: &Pubkey,
+    ) -> crate::Result<TransactionBuilder<C>> {
+        let owner = self.payer();
+        let user_account = self.find_user_address(store, &owner);
+        let claim_vault = get_associated_token_address_with_program_id(
+            &user_account,
+            token_mint,
+            &anchor_spl::token::ID,
+        );
+        let user_token_controller =
+            self.find_user_token_controller_address(&user_account, token_mint);
+
+        let rpc = self
+            .store_transaction()
+            .anchor_accounts(accounts::ClaimBuilderFees {
+                owner,
+                store: *store,
+                user_account,
+                token_mint: *token_mint,
+                claim_vault,
+                destination: *destination,
+                user_token_controller,
+                token_program: anchor_spl::token::ID,
+                event_authority: self.store_event_authority(),
+                program: *self.store_program_id(),
+            })
+            .anchor_args(args::ClaimBuilderFees {});
+
+        Ok(rpc)
     }
 }

--- a/programs/store/src/events/builder_fee.rs
+++ b/programs/store/src/events/builder_fee.rs
@@ -119,3 +119,54 @@ impl BuilderFeeSet {
         }
     }
 }
+
+/// An event indicating that builder fees have been claimed.
+///
+/// Emitted only when the claim actually transfers a non-zero amount; the
+/// no-op path (an empty claim vault) emits nothing.
+#[event]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone, InitSpace)]
+pub struct BuilderFeeClaimed {
+    /// Timestamp.
+    pub ts: i64,
+    /// Slot.
+    pub slot: u64,
+    /// Store.
+    pub store: Pubkey,
+    /// The builder's User Account.
+    pub builder: Pubkey,
+    /// The token mint the claim is denominated in.
+    pub token: Pubkey,
+    /// The amount transferred, i.e. the claim vault's full prior balance.
+    pub amount: u64,
+    /// The destination token account the claim was sent to.
+    pub destination: Pubkey,
+}
+
+impl BuilderFeeClaimed {
+    pub(crate) fn new(
+        store: &Pubkey,
+        builder: &Pubkey,
+        token: &Pubkey,
+        amount: u64,
+        destination: &Pubkey,
+    ) -> Result<Self> {
+        let clock = Clock::get()?;
+        Ok(Self {
+            ts: clock.unix_timestamp,
+            slot: clock.slot,
+            store: *store,
+            builder: *builder,
+            token: *token,
+            amount,
+            destination: *destination,
+        })
+    }
+}
+
+impl InitSpace for BuilderFeeClaimed {
+    const INIT_SPACE: usize = <Self as Space>::INIT_SPACE;
+}
+
+impl Event for BuilderFeeClaimed {}

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -3,11 +3,11 @@ use anchor_spl::token::{transfer_checked, Mint, Token, TokenAccount, TransferChe
 use gmsol_model::action::decrease_position::DecreasePositionSwapType;
 
 use crate::{
-    events::{BuilderFeeSet, BuilderFeeSettled, EventEmitter},
+    events::{BuilderFeeClaimed, BuilderFeeSet, BuilderFeeSettled, EventEmitter},
     states::{
         feature::{ActionDisabledFlag, DomainDisabledFlag},
         user::{UserHeader, USER_TOKEN_CONTROLLER_SEED},
-        FactorKey, Order, Store,
+        FactorKey, Order, Seed, Store,
     },
     CoreError,
 };
@@ -363,6 +363,140 @@ impl SetBuilderFee<'_> {
             previous_builder,
             previous_factor,
         ))?;
+
+        Ok(())
+    }
+}
+
+/// The accounts definition for
+/// [`claim_builder_fees`](crate::gmsol_store::claim_builder_fees).
+#[event_cpi]
+#[derive(Accounts)]
+pub struct ClaimBuilderFees<'info> {
+    /// The owner of the [`user_account`](Self::user_account). The only
+    /// signer allowed to claim its builder fees.
+    pub owner: Signer<'info>,
+    /// Store.
+    pub store: AccountLoader<'info, Store>,
+    /// The builder's User Account.
+    #[account(
+        constraint = user_account.load()?.is_initialized() @ CoreError::InvalidUserAccount,
+        has_one = owner,
+        has_one = store,
+        seeds = [UserHeader::SEED, store.key().as_ref(), owner.key().as_ref()],
+        bump = user_account.load()?.bump,
+    )]
+    pub user_account: AccountLoader<'info, UserHeader>,
+    /// The token mint the claim is denominated in.
+    pub token_mint: Box<Account<'info, Mint>>,
+    /// The claim vault: the associated token account of `token_mint`
+    /// owned by `user_account`.
+    ///
+    /// Its authority is the program-controlled User Account PDA, so this
+    /// instruction is the only path that can move tokens out of it.
+    ///
+    /// Must already exist; this instruction never creates it. A builder
+    /// with no vault for this mint has never been settled and so has
+    /// nothing to claim, which is rejected outright rather than treated
+    /// as a no-op: the caller asked to be paid, and the useful answer is
+    /// that no such vault exists. Callers holding a `None` vault address
+    /// simply leave the instruction out of the transaction.
+    #[account(
+        mut,
+        associated_token::mint = token_mint,
+        associated_token::authority = user_account,
+    )]
+    pub claim_vault: Box<Account<'info, TokenAccount>>,
+    /// The destination token account for `token_mint`, chosen by the
+    /// owner. Not required to be an associated token account, but a
+    /// transferring claim rejects the claim vault itself; see
+    /// [`claim_builder_fees`](crate::gmsol_store::claim_builder_fees).
+    #[account(mut, token::mint = token_mint)]
+    pub destination: Box<Account<'info, TokenAccount>>,
+    /// The (per-user, per-token) user token controller PDA.
+    ///
+    /// Reserved for future withdrawal access control (e.g. a timelock).
+    /// It has no backing account and no data today, so the only check
+    /// performed on it is that the passed address matches its PDA
+    /// derivation; adding real behavior behind it later is not a
+    /// breaking change to this instruction's accounts.
+    /// CHECK: only the PDA derivation is verified, by the constraints below.
+    #[account(
+        seeds = [
+            USER_TOKEN_CONTROLLER_SEED,
+            user_account.key().as_ref(),
+            token_mint.key().as_ref(),
+        ],
+        bump,
+    )]
+    pub user_token_controller: UncheckedAccount<'info>,
+    /// Token program.
+    pub token_program: Program<'info, Token>,
+}
+
+impl ClaimBuilderFees<'_> {
+    /// Claim the full balance of a builder's claim vault to an owner-chosen
+    /// destination.
+    ///
+    /// Restricted to the [`user_account`](ClaimBuilderFees::user_account)'s
+    /// owner: no other signer can initiate a claim, and no other instruction
+    /// can move tokens out of a claim vault, since its authority is the
+    /// program-controlled User Account PDA. Idempotent: an existing vault
+    /// with a zero balance is an explicit no-op, performing no token
+    /// transfer, no CPI, and emitting no event, so this is safe to call
+    /// freely once the vault exists. Not gated by the `BuilderFee` feature
+    /// flag, since disabling the feature must never freeze already-settled
+    /// funds.
+    pub(crate) fn invoke(ctx: Context<Self>) -> Result<()> {
+        let claim_vault = &ctx.accounts.claim_vault;
+
+        let amount = claim_vault.amount;
+        if amount == 0 {
+            return Ok(());
+        }
+
+        // Only claims that actually transfer are affected: spl-token
+        // short-circuits a self-transfer to `Ok(())` after validation without
+        // moving any balance, which would emit `BuilderFeeClaimed` for the
+        // full vault balance while the vault still holds it. Checked here
+        // rather than as an account constraint so that it cannot turn a
+        // no-op, which moves nothing and emits nothing either way, into a
+        // failure.
+        require_keys_neq!(
+            ctx.accounts.destination.key(),
+            claim_vault.key(),
+            CoreError::InvalidArgument
+        );
+
+        let store = ctx.accounts.store.key();
+        let owner = ctx.accounts.owner.key();
+        let bump = ctx.accounts.user_account.load()?.bump;
+        let seeds = &[UserHeader::SEED, store.as_ref(), owner.as_ref(), &[bump]];
+
+        transfer_checked(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                TransferChecked {
+                    from: claim_vault.to_account_info(),
+                    mint: ctx.accounts.token_mint.to_account_info(),
+                    to: ctx.accounts.destination.to_account_info(),
+                    authority: ctx.accounts.user_account.to_account_info(),
+                },
+            )
+            .with_signer(&[seeds]),
+            amount,
+            ctx.accounts.token_mint.decimals,
+        )?;
+
+        EventEmitter::new(&ctx.accounts.event_authority, ctx.bumps.event_authority).emit_cpi(
+            &BuilderFeeClaimed::new(
+                &store,
+                &ctx.accounts.user_account.key(),
+                &ctx.accounts.token_mint.key(),
+                amount,
+                &ctx.accounts.destination.key(),
+            )?,
+        )?;
 
         Ok(())
     }

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -3276,6 +3276,33 @@ pub mod gmsol_store {
         instructions::accept_referral_code(ctx)
     }
 
+    /// Claim builder fees.
+    ///
+    /// Restricted to the User Account's owner. Idempotent: a claim vault
+    /// with a zero balance is an explicit no-op, so this may be called
+    /// freely once the vault exists. Not gated by the `BuilderFee`
+    /// feature flag.
+    ///
+    /// # Accounts
+    /// *[See the documentation for the accounts.](ClaimBuilderFees)*
+    ///
+    /// # Errors
+    /// - The [`owner`](ClaimBuilderFees::owner) must be a signer and must
+    ///   match the owner recorded on [`user_account`](ClaimBuilderFees::user_account).
+    /// - The [`user_account`](ClaimBuilderFees::user_account) must be properly
+    ///   initialized and belong to the `store`.
+    /// - The [`claim_vault`](ClaimBuilderFees::claim_vault) must already exist and
+    ///   be the associated token account of the [`token_mint`](ClaimBuilderFees::token_mint)
+    ///   owned by `user_account`.
+    /// - The [`destination`](ClaimBuilderFees::destination) must be a token account
+    ///   for `token_mint`.
+    /// - The [`user_token_controller`](ClaimBuilderFees::user_token_controller) must
+    ///   match its PDA derivation from `user_account` and `token_mint`; no other
+    ///   validation is performed on it.
+    pub fn claim_builder_fees(ctx: Context<ClaimBuilderFees>) -> Result<()> {
+        ClaimBuilderFees::invoke(ctx)
+    }
+
     // ===========================================
     //                GLV Operations
     // ===========================================

--- a/tests/anchor_test/setup.rs
+++ b/tests/anchor_test/setup.rs
@@ -1848,6 +1848,75 @@ impl Deployment {
         Ok(())
     }
 
+    /// Create a fresh mint, along with the associated token account of `owner`
+    /// for it.
+    ///
+    /// The mint is registered nowhere and named by nothing, so no other test
+    /// can touch it. That is what a case asserting on the absence of a token
+    /// account needs, since the suite runs concurrently against one deployment.
+    pub(crate) async fn create_unregistered_mint(
+        &self,
+        owner: &Pubkey,
+    ) -> eyre::Result<(Pubkey, Pubkey)> {
+        use anchor_spl::{
+            associated_token::{
+                spl_associated_token_account,
+                spl_associated_token_account::get_associated_token_address,
+            },
+            token::{spl_token::instruction, Mint, ID},
+        };
+
+        /// Arbitrary; nothing prices this mint.
+        const DECIMALS: u8 = 6;
+
+        let mint = Keypair::generate(&mut rand::thread_rng());
+        let mint_address = mint.pubkey();
+        let payer = self.client.payer();
+        let rent = self
+            .client
+            .store_program()
+            .rpc()
+            .get_minimum_balance_for_rent_exemption(Mint::LEN)
+            .await?;
+
+        let signature = self
+            .client
+            .store_transaction()
+            .signer(&mint)
+            .pre_instruction(
+                system_instruction::create_account(
+                    &payer,
+                    &mint_address,
+                    rent,
+                    Mint::LEN as u64,
+                    &ID,
+                ),
+                true,
+            )
+            .pre_instruction(
+                instruction::initialize_mint2(&ID, &mint_address, &payer, None, DECIMALS)?,
+                true,
+            )
+            .pre_instruction(
+                spl_associated_token_account::instruction::create_associated_token_account_idempotent(
+                    &payer,
+                    owner,
+                    &mint_address,
+                    &ID,
+                ),
+                true,
+            )
+            .send()
+            .await?;
+
+        tracing::info!(%signature, mint=%mint_address, "created an unregistered mint");
+
+        Ok((
+            mint_address,
+            get_associated_token_address(owner, &mint_address),
+        ))
+    }
+
     pub(crate) fn market_token(&self, index: &str, long: &str, short: &str) -> Option<&Pubkey> {
         self.market_tokens
             .get(&[index.to_string(), long.to_string(), short.to_string()])

--- a/tests/anchor_test/user.rs
+++ b/tests/anchor_test/user.rs
@@ -1,5 +1,6 @@
 use std::panic::{resume_unwind, AssertUnwindSafe};
 
+use anchor_spl::associated_token::spl_associated_token_account::get_associated_token_address;
 use futures_util::FutureExt;
 use gmsol_programs::{
     anchor_lang::error::ErrorCode,
@@ -9,11 +10,12 @@ use gmsol_programs::{
     },
 };
 use gmsol_sdk::{
-    client::ops::{ConfigOps, UserOps},
+    client::ops::{BuilderFeeOps, ConfigOps, UserOps},
     constants::MARKET_USD_UNIT,
 };
 use gmsol_store::CoreError;
 use gmsol_utils::config::FactorKey;
+use solana_sdk::{signature::Keypair, signer::Signer};
 
 use crate::anchor_test::setup::{current_deployment, Deployment};
 
@@ -223,6 +225,183 @@ async fn builder_fee_factor() -> eyre::Result<()> {
 
     let signature = restored?;
     tracing::info!(%signature, "closed the mechanism again");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_builder_fees() -> eyre::Result<()> {
+    /// The token the claim is denominated in.
+    const TOKEN: &str = "USDG";
+    /// The balance seeded into the claim vault.
+    const AMOUNT: u64 = 1_234_567;
+
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("claim_builder_fees");
+    let _enter = span.enter();
+
+    let client = deployment.user_client(Deployment::USER_1)?;
+    let other = deployment.user_client(Deployment::DEFAULT_USER)?;
+    let store = &deployment.store;
+    let token = deployment.token(TOKEN).expect("no such token").address;
+
+    let signature = client.prepare_user(store)?.send_without_preflight().await?;
+    tracing::info!(%signature, "prepared user account for the builder");
+
+    let owner = client.payer();
+    let user_account = client.find_user_address(store, &owner);
+    let claim_vault = get_associated_token_address(&user_account, &token);
+
+    // A destination no other test touches. The users' own ATAs are minted
+    // into by tests running concurrently against this same deployment, so
+    // asserting on one of those balances would be flaky.
+    let destination_owner = Keypair::generate(&mut rand::thread_rng()).pubkey();
+    deployment
+        .mint_or_transfer_to(TOKEN, &destination_owner, 0)
+        .await?;
+    let destination = get_associated_token_address(&destination_owner, &token);
+
+    // Seed the claim vault directly. Settlement, the instruction that
+    // normally fills it, lands separately; claiming does not care how the
+    // balance got there.
+    deployment
+        .mint_or_transfer_to(TOKEN, &user_account, AMOUNT)
+        .await?;
+    assert_eq!(
+        deployment.get_ata_amount(&token, &user_account).await?,
+        Some(AMOUNT)
+    );
+
+    // Owner-only: no other signer can claim this vault. The User Account
+    // seeds are derived from the signer, so the address passed here cannot
+    // be the one the constraint derives.
+    let err = other
+        .store_transaction()
+        .anchor_accounts(accounts::ClaimBuilderFees {
+            owner: other.payer(),
+            store: *store,
+            user_account,
+            token_mint: token,
+            claim_vault,
+            destination,
+            user_token_controller: other.find_user_token_controller_address(&user_account, &token),
+            token_program: anchor_spl::token::ID,
+            event_authority: other.store_event_authority(),
+            program: *other.store_program_id(),
+        })
+        .anchor_args(args::ClaimBuilderFees {})
+        .send()
+        .await
+        .expect_err("should reject a claim signed by anyone but the owner");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(ErrorCode::ConstraintSeeds.into())
+    );
+    assert_eq!(
+        deployment.get_ata_amount(&token, &user_account).await?,
+        Some(AMOUNT),
+        "a rejected claim must leave the vault untouched"
+    );
+
+    // A transferring claim cannot send the vault to itself: spl-token
+    // short-circuits a self-transfer to `Ok(())` without moving any
+    // balance, which would emit a claim event for a claim that never
+    // happened. Asserted while the vault still holds a balance, since the
+    // guard deliberately does not apply to the no-op paths.
+    let err = client
+        .claim_builder_fees(store, &token, &claim_vault)?
+        .send()
+        .await
+        .expect_err("should reject the claim vault as its own destination");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(CoreError::InvalidArgument.into())
+    );
+    assert_eq!(
+        deployment.get_ata_amount(&token, &user_account).await?,
+        Some(AMOUNT),
+        "a rejected claim must leave the vault untouched"
+    );
+
+    // The owner claims, and the full balance moves in one go.
+    let signature = client
+        .claim_builder_fees(store, &token, &destination)?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "claimed the builder fees");
+    assert_eq!(
+        deployment.get_ata_amount(&token, &user_account).await?,
+        Some(0)
+    );
+    assert_eq!(
+        deployment
+            .get_ata_amount(&token, &destination_owner)
+            .await?,
+        Some(AMOUNT)
+    );
+
+    // Nothing to claim, with the vault present but empty: succeeds and
+    // moves nothing.
+    let signature = client
+        .claim_builder_fees(store, &token, &destination)?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "claimed again from an empty vault");
+    assert_eq!(
+        deployment.get_ata_amount(&token, &user_account).await?,
+        Some(0)
+    );
+    assert_eq!(
+        deployment
+            .get_ata_amount(&token, &destination_owner)
+            .await?,
+        Some(AMOUNT),
+        "a no-op claim must not move anything"
+    );
+
+    // The self-destination guard covers transferring claims only, so it
+    // cannot turn a no-op into a failure. This call moves nothing either
+    // way, and succeeds.
+    let signature = client
+        .claim_builder_fees(store, &token, &claim_vault)?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "no-op claim into the vault itself");
+
+    // A mint that was never settled has no claim vault, and the claim is
+    // rejected rather than treated as a no-op. The vault is required, so
+    // the missing account is what fails, and nothing creates it.
+    //
+    // The mint is created here rather than picked from the deployment: the
+    // suite's tokens are shared, and a test running concurrently creating a
+    // claim vault for this same builder would silently empty the case out.
+    let (unsettled_token, unsettled_destination) = deployment
+        .create_unregistered_mint(&destination_owner)
+        .await?;
+    assert_eq!(
+        deployment
+            .get_ata_amount(&unsettled_token, &user_account)
+            .await?,
+        None,
+        "the claim vault for this mint must not exist for the case to mean anything"
+    );
+    let err = client
+        .claim_builder_fees(store, &unsettled_token, &unsettled_destination)?
+        .send()
+        .await
+        .expect_err("should reject a claim for a mint that was never settled");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(ErrorCode::AccountNotInitialized.into())
+    );
+    assert_eq!(
+        deployment
+            .get_ata_amount(&unsettled_token, &user_account)
+            .await?,
+        None,
+        "a rejected claim must not create the vault"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## CON-38

## Summary

Adds the owner-signed `claim_builder_fees` instruction from ADR-0001. Settled builder fees accumulate in a builder's claim ATA (a token account whose authority is their User Account PDA), one per token mint, and since only the program can sign for that PDA, moving those tokens anywhere requires a dedicated instruction. This is that instruction.

Independent of fee activation and settlement. Claim ATAs can already receive tokens the moment they exist (any transfer to that ATA works today, with or without `settle_builder_fee`), and this is the only way to move tokens back out of one, so it's useful and safely mergeable on its own.

## What's implemented

- **`BuilderFeeClaimed` event** (`programs/store/src/events/builder_fee.rs`), recording the builder (User Account), the token mint, the amount, and the destination.
- **`claim_builder_fees` instruction** (`programs/store/src/instructions/builder_fee.rs`), transferring the full balance of a builder's claim vault to an owner-chosen destination token account, then done. No partial claims: the technical decision in the issue is that the claim vault is a pure collection account, so partial claims have no use case.
  - Restricted to the User Account's owner via `has_one = owner` on `user_account`, the same pattern `InitializeReferralCode` already uses elsewhere in this file's neighborhood. No other path can move tokens out of the claim vault, since its authority is the program-controlled User Account PDA, not a role or a keeper.
  - `user_token_controller` is checked only for PDA derivation (`seeds = [SEED, user_account, token_mint], bump`), nothing else, exactly the placeholder the issue asks for: reserving the account slot so real access control can be added behind it later without a breaking change.
  - Not gated by the `BuilderFee` feature flag. Disabling the feature must never freeze funds that already settled.
  - Idempotent: an empty claim vault returns immediately, no CPI, no state update, no event.
- **SDK support** (`crates/sdk/src/client/ops/builder_fee.rs`, `BuilderFeeOps::claim_builder_fees`). No hint/fetch step needed here, unlike `settle_builder_fee`: every account is a pure function of `store`, `token_mint`, `destination`, and the caller's own key, so it's synchronous.
- A `Client::find_user_token_controller_address` helper (`crates/sdk/src/client/mod.rs`), matching the existing `find_user_address` / `find_referral_code_address` wrappers around the raw `pda::` functions.

## Testing

- `cargo build --workspace` / `cargo test -p gmsol-store -p gmsol-sdk --lib --features client` / `cargo clippy -p gmsol-store -p gmsol-sdk --lib --features client`. All clean, no new warnings.
- No colocated Rust unit tests: there's no pure logic here worth extracting, consistent with how the rest of this instruction layer is tested only through `anchor_test`.
- No `anchor_test` integration coverage yet for the owner-only gate or the no-op path. Unlike `settle_builder_fee`'s PR, this one doesn't have accrual-is-inert as an excuse: claim vaults are exercisable today, so "only the owner can claim" isn't provable by inspection alone. Flagging as a gap to close before merge rather than deferring it.


