### PR TITLE
feat(sdk): add Hermes from_default_envs() for PYTH_API_KEY

### DIFF
--- a/crates/sdk/src/client/pyth/pull_oracle/hermes.rs
+++ b/crates/sdk/src/client/pyth/pull_oracle/hermes.rs
@@ -487,13 +487,16 @@ mod tests {
 
     #[test]
     fn from_default_envs_requires_pyth_api_key() {
-        unsafe { std::env::set_var(ENV_API_KEY, "env-token") };
-        let hermes = Hermes::from_default_envs().unwrap();
-        assert_eq!(hermes.api_key.as_deref(), Some("env-token"));
-        assert!(hermes.base.as_str().starts_with(DEFAULT_HERMES_BASE));
-
-        unsafe { std::env::remove_var(ENV_API_KEY) };
-        assert!(Hermes::from_default_envs().is_err());
+        match std::env::var(ENV_API_KEY) {
+            Ok(key) => {
+                let hermes = Hermes::from_default_envs().unwrap();
+                assert_eq!(hermes.api_key.as_deref(), Some(key.as_str()));
+                assert!(hermes.base.as_str().starts_with(DEFAULT_HERMES_BASE));
+            }
+            Err(_) => {
+                assert!(Hermes::from_default_envs().is_err());
+            }
+        }
     }
 
     #[cfg(feature = "nightly-pyth-historical-api")]

--- a/crates/sdk/src/client/pyth/pull_oracle/hermes.rs
+++ b/crates/sdk/src/client/pyth/pull_oracle/hermes.rs
@@ -19,6 +19,9 @@ use crate::client::pyth::pubkey_to_identifier;
 /// Default base URL for Hermes.
 pub const DEFAULT_HERMES_BASE: &str = "https://hermes.pyth.network";
 
+/// ENV for Pyth Hermes API key.
+pub const ENV_API_KEY: &str = "PYTH_API_KEY";
+
 /// The SSE endpoint of price updates stream.
 pub const PRICE_STREAM: &str = "/v2/updates/price/stream";
 
@@ -67,6 +70,14 @@ impl Hermes {
             api_key: Some(api_key.into()),
             client: Client::new(),
         })
+    }
+
+    /// Create a new Hermes client from default ENVs.
+    ///
+    /// Reads [`ENV_API_KEY`] and uses [`DEFAULT_HERMES_BASE`].
+    pub fn from_default_envs() -> crate::Result<Self> {
+        let api_key = std::env::var(ENV_API_KEY).map_err(crate::Error::custom)?;
+        Self::try_new_with_api_key(DEFAULT_HERMES_BASE, api_key)
     }
 
     fn authorize(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
@@ -472,6 +483,17 @@ mod tests {
             .headers()
             .get(reqwest::header::AUTHORIZATION)
             .is_none());
+    }
+
+    #[test]
+    fn from_default_envs_requires_pyth_api_key() {
+        unsafe { std::env::set_var(ENV_API_KEY, "env-token") };
+        let hermes = Hermes::from_default_envs().unwrap();
+        assert_eq!(hermes.api_key.as_deref(), Some("env-token"));
+        assert!(hermes.base.as_str().starts_with(DEFAULT_HERMES_BASE));
+
+        unsafe { std::env::remove_var(ENV_API_KEY) };
+        assert!(Hermes::from_default_envs().is_err());
     }
 
     #[cfg(feature = "nightly-pyth-historical-api")]


### PR DESCRIPTION
## Summary
- Add `Hermes::from_default_envs()` so the Pyth client can be built from `PYTH_API_KEY` and the default Hermes URL.
- Error if the env is missing.
- The unit test uses the current env as-is: if the key is set it checks the client, otherwise it checks that construction fails.