### PR TITLE
fix(store)!: prevent over-minting GT on insolvent liquidation/ADL closes

### DIFF
--- a/crates/model/src/action/decrease_position/collateral_processor.rs
+++ b/crates/model/src/action/decrease_position/collateral_processor.rs
@@ -557,10 +557,10 @@ where
                         // Empty the fees since the amount was entirely paid to the pool instead of for fees.
                         // It is possible for the txn execution to still complete even in this case
                         // as long as the remaining_cost is still zero.
-                        fees.clear_fees_excluding_funding();
-
-                        // Also, clear the `paid_order_and_borrowing_fee_value` for the same reason.
-                        fees.set_paid_order_and_borrowing_fee_value(Zero::zero());
+                        //
+                        // This also clears `paid_order_and_borrowing_fee_value`, which must not
+                        // outlive the fees it accounts for.
+                        fees.clear_uncollected_fees_excluding_funding();
                     }
                     Ok(())
                 },

--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -6,8 +6,8 @@ use crate::{
     params::fee::PositionFees,
     pool::delta::PriceImpact,
     position::{
-        CollateralDelta, Position, PositionExt, PositionMut, PositionMutExt, PositionStateExt,
-        WillCollateralBeSufficient,
+        CollateralDelta, InsolventCloseStep, Position, PositionExt, PositionMut, PositionMutExt,
+        PositionStateExt, WillCollateralBeSufficient,
     },
     price::{Price, Prices},
     BorrowingFeeMarketExt, PerpMarketMut, PoolExt,
@@ -158,6 +158,31 @@ impl DecreasePositionFlags {
         self.is_insolvent_close_allowed = is_full_close && self.is_insolvent_close_allowed;
 
         Ok(())
+    }
+}
+
+/// Whether an insolvent close reported at `step` short-circuited the collateral
+/// pipeline before the fee step had a chance to collect anything.
+///
+/// The pipeline runs, in order: `Funding`, `Pnl`, `Fees`, `Impact`, `Diff` (see
+/// `process_collateral`). An insolvent close stops at the step that ran out of funds, so
+/// a step reported here means every later step was skipped.
+///
+/// Matched exhaustively rather than compared by ordering: the declaration order of
+/// [`InsolventCloseStep`] does not match the pipeline order, and the enum derives no
+/// `Ord`. Being in the crate that defines it, an exhaustive match also forces a decision
+/// here if a step is ever added.
+fn insolvency_preempted_fee_collection(step: InsolventCloseStep) -> bool {
+    match step {
+        // Both run before `pay_for_fees_excluding_funding`, so no order or borrowing fee
+        // was collected and the values computed up front must not be reported as paid.
+        InsolventCloseStep::Funding | InsolventCloseStep::Pnl => true,
+        // The fee step itself already clears what it failed to collect, on the
+        // partial-payment branch that credits the amount to the pool instead.
+        InsolventCloseStep::Fees => false,
+        // Both run after the fee step, so the fees were genuinely collected. Clearing
+        // here would under-report them and under-mint GT.
+        InsolventCloseStep::Impact | InsolventCloseStep::Diff => false,
     }
 }
 
@@ -426,6 +451,19 @@ where
 
             result
         };
+
+        // An insolvent close short-circuits the pipeline above at the step that ran out of
+        // funds, so every step after it is skipped. When that step precedes the fee step,
+        // `pay_for_fees_excluding_funding` never ran: no fees were collected, but `fees`
+        // still carries the values computed up front, including
+        // `paid_order_and_borrowing_fee_value`. Leaving it set would let the caller mint GT
+        // against fees that were never paid.
+        if result
+            .insolvent_close_step
+            .is_some_and(insolvency_preempted_fee_collection)
+        {
+            fees.clear_uncollected_fees_excluding_funding();
+        }
 
         // Handle initial collateral delta amount with price impact diff.
         // The price_impact_diff has been deducted from the output amount or the position's collateral

--- a/crates/model/src/action/decrease_position/mod.rs
+++ b/crates/model/src/action/decrease_position/mod.rs
@@ -856,4 +856,83 @@ mod tests {
         println!("{market:#?}");
         Ok(())
     }
+
+    /// A test for the step-to-clear decision.
+    ///
+    /// The last three rows guard against a blanket `is_some()` check, which would
+    /// under-report fees that were collected.
+    #[test]
+    fn insolvency_preempted_fee_collection_decision_table() {
+        for (step, expected) in [
+            (InsolventCloseStep::Funding, true),
+            (InsolventCloseStep::Pnl, true),
+            (InsolventCloseStep::Fees, false),
+            (InsolventCloseStep::Impact, false),
+            (InsolventCloseStep::Diff, false),
+        ] {
+            assert_eq!(insolvency_preempted_fee_collection(step), expected);
+        }
+    }
+
+    /// Opens a leveraged long and fully closes it at `close_price`.
+    ///
+    /// Insolvent close is always allowed, so solvency is the only variable.
+    fn close_long_at(
+        close_price: u64,
+    ) -> crate::Result<Box<DecreasePositionReport<u64, <u64 as Unsigned>::Signed>>> {
+        let mut market = TestMarket::<u64, 9>::default();
+        let prices = Prices::new_for_test(120, 120, 1);
+        market.deposit(1_000_000_000, 0, prices)?.execute()?;
+        market.deposit(0, 1_000_000_000, prices)?.execute()?;
+
+        let mut position = TestPosition::long(true);
+        let _ = position
+            .ops(&mut market)
+            .increase(
+                Prices::new_for_test(123, 123, 1),
+                100_000_000,
+                80_000_000_000,
+                None,
+            )?
+            .execute()?;
+
+        let mut ops = position.ops(&mut market);
+        ops.decrease(
+            Prices::new_for_test(close_price, close_price, 1),
+            80_000_000_000,
+            None,
+            0,
+            DecreasePositionFlags {
+                is_insolvent_close_allowed: true,
+                is_liquidation_order: false,
+                is_cap_size_delta_usd_allowed: true,
+            },
+        )?
+        .execute()
+    }
+
+    /// A test for an insolvent close that stops before the fee step.
+    #[test]
+    fn insolvent_close_at_pnl_step_reports_no_paid_fee() -> crate::Result<()> {
+        let report = close_long_at(100)?;
+
+        assert!(matches!(
+            report.insolvent_close_step(),
+            Some(InsolventCloseStep::Pnl)
+        ));
+        assert_eq!(*report.fees().paid_order_and_borrowing_fee_value(), 0);
+
+        Ok(())
+    }
+
+    /// A test for a solvent close, which must still report its paid fee.
+    #[test]
+    fn solvent_close_still_reports_paid_fee() -> crate::Result<()> {
+        let report = close_long_at(122)?;
+
+        assert!(report.insolvent_close_step().is_none());
+        assert!(*report.fees().paid_order_and_borrowing_fee_value() > 0);
+
+        Ok(())
+    }
 }

--- a/crates/model/src/params/fee.rs
+++ b/crates/model/src/params/fee.rs
@@ -816,6 +816,24 @@ impl<T> PositionFees<T> {
         self.liquidation = None;
     }
 
+    /// Clear the fees excluding funding fee, along with the accounting value
+    /// derived from them.
+    ///
+    /// For use on paths where those fees were never actually collected. Both
+    /// the fee breakdown and
+    /// [`paid_order_and_borrowing_fee_value`](Self::paid_order_and_borrowing_fee_value)
+    /// describe the same collection, and the latter is what GT minting is
+    /// derived from, so clearing one without the other would mint GT with no
+    /// fee backing. Kept in a single helper so the two cannot drift apart
+    /// across call sites.
+    pub(crate) fn clear_uncollected_fees_excluding_funding(&mut self)
+    where
+        T: Zero,
+    {
+        self.clear_fees_excluding_funding();
+        self.set_paid_order_and_borrowing_fee_value(Zero::zero());
+    }
+
     /// Set borrowing fees.
     pub fn set_borrowing_fees<const DECIMALS: u8>(
         mut self,

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -1033,6 +1033,42 @@ mod tests {
     }
 
     #[test]
+    fn zero_paid_fee_value_mints_no_gt() {
+        // The model reports a zero paid fee value when an insolvent close never
+        // reached the fee step. This early return is what turns that into no GT,
+        // so removing it would restore minting without fee backing.
+        let mut order: Order = bytemuck::Zeroable::zeroed();
+        let mut store: Box<Store> = Box::new(bytemuck::Zeroable::zeroed());
+        let mut user: Box<UserHeader> = Box::new(bytemuck::Zeroable::zeroed());
+
+        // A placeholder account is enough, since nothing is emitted.
+        let key = Pubkey::new_unique();
+        let owner = crate::ID;
+        let mut lamports = 0u64;
+        let mut data: [u8; 0] = [];
+        let event_authority = AccountInfo::new(
+            &key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+        let event_emitter = EventEmitter::new(&event_authority, 0);
+
+        order
+            .unchecked_process_gt(&mut store, &mut user, 0, &event_emitter)
+            .unwrap();
+
+        assert_eq!(order.gt_reward, 0);
+        assert_eq!(user.gt.amount(), 0);
+        assert_eq!(user.gt.paid_fee_value(), 0);
+        assert_eq!(user.gt.minted_fee_value(), 0);
+    }
+
+    #[test]
     fn recording_a_builder_fee_rejects_overflow() {
         let mut order: Order = bytemuck::Zeroable::zeroed();
         order.record_builder_fee(u64::MAX).unwrap();


### PR DESCRIPTION
## Problem

During an insolvent Liquidation or ADL close, `paid_order_and_borrowing_fee_value` could stay non zero even though the matching fees were never collected. The Store program mints GT from that value, so those closes created GT with no fee backing.

The collateral pipeline in `decrease_position/mod.rs` runs in this order.

| # | Stage | Insolvency step |
|---|---|---|
| 4 | `pay_for_funding_fees` | `Funding` |
| 5 | `pay_for_pnl_if_negative` | `Pnl` |
| 6 | `pay_for_fees_excluding_funding` | `Fees` |
| 7 | `pay_for_price_impact_if_negative` | `Impact` |
| 8 | `pay_for_price_impact_diff` | `Diff` |

`CollateralProcessor::process` swallows `InsufficientFundsToPayForCosts` when insolvent close is allowed and returns the report early, so every stage after the failing one is skipped. Liquidation and ADL are the two order kinds that allow it.

When insolvency tripped at stage 4 or 5, stage 6 never ran. Stage 6 held the only code that zeroed `paid_order_and_borrowing_fee_value`, on its partial payment branch. The field therefore kept the value computed up front, and that value flows unguarded into `unchecked_process_gt`.

Reproduced before the fix. A full close after a price crash reported `paid_order_and_borrowing_fee_value == 40_000_000` having collected nothing.

## Fix

Clear the uncollected fees once the pipeline returns, when the reported step precedes the fee step.

Only `Funding` and `Pnl` qualify.

* `Fees` already clears what it failed to collect.
* `Impact` and `Diff` run after the fee step, so their fees were genuinely collected. A blanket `insolvent_close_step.is_some()` check would under mint GT for them.

The decision lives in `insolvency_preempted_fee_collection` so it can be tested on its own. It matches exhaustively rather than comparing by ordering, because the declaration order of `InsolventCloseStep` is `Pnl, Fees, Funding, Impact, Diff`, which does not match pipeline order, and the enum derives no `Ord`. Being in the crate that defines the enum, the exhaustive match also forces a decision if a sixth step is ever added.

Fixed in the model rather than at the GT call site, so every consumer of the report sees a consistent value and the ordering decision is not duplicated where two copies could drift.

## Testing

`cargo test -p gmsol-model` passes 36 tests and `cargo test -p gmsol-store --lib` passes 32. `cargo fmt --check` is clean and clippy reports nothing on the touched files. The regression test was confirmed to fail when the fix is reverted.

No IDL regeneration is needed, since this changes values rather than the shape of `DecreasePositionReport` or `PositionDecreased`.

## Coverage gap

There is no end to end anchor test for the fixed path. Driving an on chain position into `Pnl` step insolvency requires the index price to move far enough that PnL exceeds collateral, and `execute_with_pyth` sources prices from live Hermes feeds with no override. That is why the existing `liquidation` test forces liquidatability by raising `MinCollateralFactorForLiquidation` at the live price instead, which is a solvent close that never reaches this path.

Covering it on chain would need new harness capability, such as a price override or a mock feed. The model tests cover the logic, and commit 4 pins the store side link that turns a zero value into zero GT.

`Funding` step insolvency is covered by the decision table but not end to end either. It shares a branch with `Pnl`, and driving a close insolvent on funding fees alone would require advancing funding state until it exceeds collateral.
