### PR TITLE
docs(store): document the builder fee invariants (CON-42)

### DIFF
--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -27028,7 +27028,10 @@
             "docs": [
               "Max builder fee factor. Reads as `0` on existing stores until a",
               "CONFIG_KEEPER explicitly raises it via `insert_factor`, so no",
-              "non-zero builder fee factor can be configured by default."
+              "non-zero builder fee factor can be configured by default.",
+              "",
+              "The cap the boundedness invariant is stated against; see the builder",
+              "fee invariants on [`crate::states::order`]."
             ],
             "type": "u128"
           },

--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -25040,8 +25040,9 @@
             "name": "settled_amount",
             "docs": [
               "The amount actually transferred, clamped to the escrow's balance.",
-              "A value below `recorded_amount` signals a broken invariant, since",
-              "the escrow is expected to always cover the recorded amount."
+              "A value below `recorded_amount` breaks the coverage invariant (see",
+              "the builder fee invariants on [`crate::states::order`]), which has",
+              "the escrow always covering the recorded amount."
             ],
             "type": "u64"
           }
@@ -34095,7 +34096,19 @@
     {
       "name": "UpdateOrderParams",
       "docs": [
-        "Update Order Params."
+        "Update Order Params.",
+        "",
+        "# Adding a field here is a security decision",
+        "",
+        "These are the only values an update may reach, and the builder fee rests on",
+        "that twice over: a fee is charged at the factor checkpointed on the order,",
+        "and it is taken from the final output token bucket, which",
+        "[`DecreasePositionSwapType::CollateralToPnlToken`] empties. A factor",
+        "reachable by an update would change the amount owed after the owner",
+        "authorized it; a reachable swap type would let an order be checkpointed",
+        "under a benign one and then flipped to one that pays nothing. Neither is",
+        "reachable today, and `update_order_params_field_set_is_pinned` fails the",
+        "build if that changes."
       ],
       "type": {
         "kind": "struct",

--- a/crates/programs/idls/gmsol_timelock.json
+++ b/crates/programs/idls/gmsol_timelock.json
@@ -1194,7 +1194,10 @@
             "docs": [
               "Max builder fee factor. Reads as `0` on existing stores until a",
               "CONFIG_KEEPER explicitly raises it via `insert_factor`, so no",
-              "non-zero builder fee factor can be configured by default."
+              "non-zero builder fee factor can be configured by default.",
+              "",
+              "The cap the boundedness invariant is stated against; see the builder",
+              "fee invariants on [`crate::states::order`]."
             ],
             "type": "u128"
           },

--- a/crates/programs/idls/gmsol_treasury.json
+++ b/crates/programs/idls/gmsol_treasury.json
@@ -3062,7 +3062,10 @@
             "docs": [
               "Max builder fee factor. Reads as `0` on existing stores until a",
               "CONFIG_KEEPER explicitly raises it via `insert_factor`, so no",
-              "non-zero builder fee factor can be configured by default."
+              "non-zero builder fee factor can be configured by default.",
+              "",
+              "The cap the boundedness invariant is stated against; see the builder",
+              "fee invariants on [`crate::states::order`]."
             ],
             "type": "u128"
           },

--- a/programs/store/src/events/builder_fee.rs
+++ b/programs/store/src/events/builder_fee.rs
@@ -27,8 +27,9 @@ pub struct BuilderFeeSettled {
     /// The builder fee amount recorded on the order before settlement.
     pub recorded_amount: u64,
     /// The amount actually transferred, clamped to the escrow's balance.
-    /// A value below `recorded_amount` signals a broken invariant, since
-    /// the escrow is expected to always cover the recorded amount.
+    /// A value below `recorded_amount` breaks the coverage invariant (see
+    /// the builder fee invariants on [`crate::states::order`]), which has
+    /// the escrow always covering the recorded amount.
     pub settled_amount: u64,
 }
 

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -92,6 +92,9 @@ impl SettleBuilderFee<'_> {
             .ok_or_else(|| error!(CoreError::TokenAccountNotProvided))?;
 
         {
+            // Upholds the delivery invariant: a settled fee reaches the
+            // checkpointed builder and nobody else.
+            //
             // A non-zero recorded amount implies a builder must have been set.
             let order = ctx.accounts.order.load()?;
             let builder = order.builder().ok_or_else(|| error!(CoreError::Internal))?;
@@ -226,6 +229,9 @@ pub struct SetBuilderFee<'info> {
 
 impl SetBuilderFee<'_> {
     pub(crate) fn invoke(ctx: Context<Self>, expected_factor: u128) -> Result<()> {
+        // Upholds the liveness invariant: nothing freezes when the mechanism
+        // is switched off.
+        //
         // The only builder-fee instruction behind the feature flag. Settlement,
         // claiming and execution stay ungated on purpose, so disabling the
         // feature stops new orders from taking on a fee without freezing any
@@ -240,6 +246,9 @@ impl SetBuilderFee<'_> {
                 ActionDisabledFlag::Default,
             )?;
 
+        // Upholds the authorization invariant: never charged at a factor
+        // other than the one the owner authorized.
+        //
         // The builder's advertised rate has to match what the owner signed for,
         // exactly and with no tolerance: anything looser lets a builder raise
         // its factor between the owner deciding and the transaction landing.
@@ -250,6 +259,9 @@ impl SetBuilderFee<'_> {
             CoreError::BuilderFeeFactorMismatched
         );
 
+        // Upholds the boundedness invariant: no factor above the cap in force
+        // at checkpoint time is ever checkpointed.
+        //
         // Second enforcement point for the store cap. The builder's rate was
         // already checked against it when advertised, but the cap can be lowered
         // afterwards, and this is the moment the rate becomes payable.

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -102,7 +102,8 @@ impl SettleBuilderFee<'_> {
         // the `associated_token` constraint above, so its owner and mint are
         // already guaranteed here.
 
-        // Under the charging invariant the escrow always covers the recorded
+        // Under the coverage invariant (see the builder fee invariants on
+        // `crate::states::order`) the escrow always covers the recorded
         // amount, so this clamp should never actually reduce anything; it is
         // defense in depth, guaranteeing a protocol bug can never make an
         // order permanently unclosable. Any discrepancy is observable via the

--- a/programs/store/src/instructions/exchange/order.rs
+++ b/programs/store/src/instructions/exchange/order.rs
@@ -700,6 +700,10 @@ impl<'info> internal::Close<'info, Order> for CloseOrderV2<'info> {
     #[inline(never)]
     fn validate(&self) -> Result<()> {
         let order = self.order.load()?;
+        // Upholds delivery (an order cannot be closed while a fee is still
+        // owed) and coverage (nothing drains the escrow before settlement).
+        // See the builder fee invariants on `crate::states::order`.
+        //
         // Applies to every close path (owner close in any state, keeper
         // close of terminal orders): an order with an unsettled builder
         // fee must be settled via `settle_builder_fee` first, otherwise

--- a/programs/store/src/instructions/user.rs
+++ b/programs/store/src/instructions/user.rs
@@ -344,6 +344,11 @@ impl SetBuilderFeeFactor<'_> {
         // a future `set_builder_fee` checkpoints the factor onto an order, so
         // gating belongs there rather than here.
         //
+        // Upholds the boundedness invariant, first of its two enforcement
+        // points; the second is in `set_builder_fee`, because the cap can be
+        // lowered between advertising and checkpointing. See the builder fee
+        // invariants on `crate::states::order`.
+        //
         // A missing cap is treated as `0` (deny by default), so on a store that
         // predates the factor key only opting out remains possible. The key is
         // always wired today, which makes this branch unreachable rather than

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1494,6 +1494,9 @@ impl ValidateOracleTime for ExecuteOrderOperation<'_, '_> {
 /// The amount is rounded up so the fee is never under-collected. Returns
 /// `0` without touching `price` if `factor` is zero, so callers don't need
 /// a meaningful price when no builder fee applies.
+///
+/// Upholds the boundedness and isolation invariants; see the builder fee
+/// invariants on [`crate::states::order`].
 fn compute_builder_fee_amount(
     size_delta_usd: u128,
     factor: u128,
@@ -1517,6 +1520,9 @@ fn compute_builder_fee_amount(
 /// Clamps a computed builder fee down to at most `available`, so a
 /// builder fee never turns an otherwise-fillable order into a hard
 /// failure.
+///
+/// Upholds the coverage invariant on the decrease side: the recorded
+/// amount cannot exceed the output that funds the escrow.
 fn clamp_builder_fee_amount(fee_amount: u128, available: u128) -> u128 {
     fee_amount.min(available)
 }
@@ -1574,6 +1580,8 @@ fn execute_swap(
 /// cover the fee, this returns an error instead of charging a partial
 /// amount. The caller propagates this as a soft failure (the order is
 /// cancelled), not a transaction revert.
+///
+/// Upholds the coverage invariant on the increase side.
 fn charge_builder_fee_on_collateral_increment(
     collateral_increment_amount: u64,
     size_delta_usd: u128,
@@ -1689,9 +1697,9 @@ fn execute_increase_position(
                 position.collateral_price(&prices),
             )?;
 
-        // Recorded on the order and routed into the final output token
-        // escrow: the two go together, since settlement pays the recorded
-        // amount out of that escrow.
+        // Upholds the conservation invariant. Recorded on the order and
+        // routed into the final output token escrow: the two go together,
+        // since settlement pays the recorded amount out of that escrow.
         transfer_out.transfer_out(false, payable_amount)?;
         order.record_builder_fee(payable_amount)?;
         position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
@@ -1787,6 +1795,10 @@ fn execute_increase_position(
 /// the *executed* size delta, which a decrease may enlarge into a full
 /// close. Gating on a non-zero estimate would therefore admit exactly
 /// the orders that go on to incur a fee they can then bypass.
+///
+/// Upholds the isolation invariant: this is the one pre-existing line the
+/// mechanism changed, and at a zero factor it returns its input unchanged
+/// ahead of any arithmetic and of the swap-type check.
 fn estimate_builder_fee_for_collateral_withdrawal(
     collateral_withdrawal_amount: u128,
     size_delta_usd: u128,
@@ -2009,6 +2021,10 @@ fn execute_decrease_position(
             )?;
             let paid_amount = clamp_builder_fee_amount(payable_amount, output_amount.into());
 
+            // Upholds conservation and coverage: the recorded amount is the
+            // clamped one, and the full output lands in the escrow, so the
+            // fee value is already sitting there.
+            //
             // `paid_amount` is clamped to `output_amount`, a `u64`, so the
             // conversion cannot fail.
             let recorded_amount =

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -16,11 +16,11 @@
 //! order's final output token escrow; `settle_builder_fee` moves it to the
 //! builder and zeroes the record.
 //!
-//! **Charging is not yet wired.** Every execution call site currently passes a
-//! literal zero factor rather than reading the checkpoint, so the charging
-//! invariants below hold vacuously today. They describe the mechanism the
-//! checkpoint exists for, and become load-bearing when the call sites start
-//! reading it.
+//! **Charging is wired as of #421.** The execution call sites read the order's
+//! checkpointed factor instead of the literal zero they used to pass, so the
+//! charging invariants below are load-bearing rather than vacuous. An earlier
+//! revision of this document said the opposite and named that change as the
+//! moment they would become live; it landed, so they are.
 //!
 //! ## Conservation
 //!

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -1,3 +1,148 @@
+//! Order accounts, the parameters that create and update them, and the
+//! invariants the builder fee mechanism upholds.
+//!
+//! # Builder fee invariants
+//!
+//! A builder fee is a share of an order's output paid to the interface that
+//! built the order. The mechanism is spread over several instructions and two
+//! execution paths, so the properties it guarantees are stated here once,
+//! together with the argument for each, rather than left implicit at the sites
+//! that enforce them. Comments elsewhere refer to these by name.
+//!
+//! The moving parts: a builder advertises a factor on its own User Account
+//! (`set_builder_fee_factor`); the order's owner checkpoints that builder and
+//! factor onto a pending order (`set_builder_fee`), which is the authorization;
+//! execution charges against the checkpoint and routes the amount into the
+//! order's final output token escrow; `settle_builder_fee` moves it to the
+//! builder and zeroes the record.
+//!
+//! **Charging is not yet wired.** Every execution call site currently passes a
+//! literal zero factor rather than reading the checkpoint, so the charging
+//! invariants below hold vacuously today. They describe the mechanism the
+//! checkpoint exists for, and become load-bearing when the call sites start
+//! reading it.
+//!
+//! ## Conservation
+//!
+//! The amount charged, the amount recorded on the order, the tokens in the
+//! escrow and the amounts on the events all agree.
+//!
+//! Charging is never a lone write. The increase path deducts the fee from the
+//! collateral increment and routes the same number into the final output token
+//! bucket in the same breath; `Order::record_builder_fee` carries that
+//! obligation as a `CHECK:` on itself, because settlement pays the recorded
+//! amount out of that escrow. The decrease path reaches the same state
+//! differently: it records the fee without netting it out of the output, so the
+//! full output lands in the escrow and the fee value is already sitting there.
+//! Recording accumulates with a checked add rather than overwriting, so several
+//! charges against one order sum. `BuilderFeeCharged` and `BuilderFeeSettled`
+//! each carry two amounts rather than one, so a divergence is observable on
+//! chain instead of inferred.
+//!
+//! ## Coverage
+//!
+//! From the moment a fee is recorded until it is settled, the escrow holds at
+//! least the recorded amount.
+//!
+//! On the increase path a fee larger than the collateral increment is refused
+//! outright (`BuilderFeeExceedsCollateral`) and the order is cancelled, since an
+//! increase has no partial outcome to fall back on. On the decrease path
+//! underpayment is tolerated instead, because a decrease may be closing an
+//! insolvent position, so the recorded amount is clamped to the output actually
+//! produced and therefore cannot exceed the escrow. In between, nothing can
+//! drain the escrow first: closing an order with a non-zero recorded amount is
+//! refused (`UnsettledBuilderFee`). Settlement clamps a second time as defence
+//! in depth, and under this invariant that clamp never bites.
+//!
+//! ## Authorization
+//!
+//! An order is never charged a fee its owner did not authorize, and never at a
+//! factor other than the one authorized.
+//!
+//! The factor used is the one checkpointed on the order, not a live read of the
+//! builder's account, so the builder's advertised rate may move afterwards
+//! without changing what an existing order owes. Writing that checkpoint takes
+//! the owner's signature and requires the builder's advertised factor to equal
+//! the factor the owner passed, exactly, which is what stops a builder raising
+//! its rate between the owner deciding and the transaction landing. A builder
+//! can only advertise on its own account, structurally: the User Account PDA
+//! seeds bind it to the signer, so doing otherwise is unconstructible rather
+//! than merely rejected. No update can reach the checkpoint or the swap type it
+//! depends on; see [`UpdateOrderParams`].
+//!
+//! ## Boundedness
+//!
+//! A charge never exceeds the payable fee, and no factor above the cap in force
+//! at checkpoint time is ever checkpointed.
+//!
+//! The store's cap is enforced twice, once when a builder advertises a rate and
+//! again when an owner checkpoints it, because the cap can be lowered in between
+//! and the checkpoint is the moment the rate becomes payable. Both treat a
+//! missing cap as zero, so a store that has never configured one denies every
+//! non-zero factor. The amount itself is bounded by what the order can pay, by
+//! the refusal on the increase path and the clamp on the decrease path. Note the
+//! computed amount rounds **up**, deliberately, so the fee is never
+//! under-collected; the bound on what is taken comes from those two mechanisms,
+//! not from the rounding.
+//!
+//! ## Delivery
+//!
+//! A settled fee reaches the checkpointed builder and nobody else, and an order
+//! cannot be closed while a fee is still owed.
+//!
+//! Settlement requires the passed User Account to equal the builder recorded on
+//! the order, and the destination is the associated token account of that
+//! builder and the final output token, so its owner and mint follow from the
+//! address derivation rather than from a check. The transfer is signed by the
+//! order PDA, so nothing outside the program can move the escrow. The close
+//! guard is the other half: an order with an unsettled fee must be settled
+//! first, since closing would otherwise sweep the fee to the receiver along with
+//! the regular output and destroy the record of who it belonged to.
+//!
+//! ## Isolation
+//!
+//! With no builder fee set, an order behaves as it did before the mechanism
+//! existed, and market-level accounting is untouched.
+//!
+//! Every fee behaviour sits behind a non-zero factor check, and the amount
+//! computation returns zero without even reading a price when the factor is
+//! zero. Only one pre-existing line changed rather than being added: the
+//! decrease path's collateral withdrawal now passes through the fee estimate,
+//! which returns its input unchanged at a zero factor, ahead of any arithmetic.
+//! Market accounting is separate and holds for a different reason: the withheld
+//! amount is deducted before the collateral reaches the position and is counted
+//! only into the transfer-out bucket, so it never enters a market's balances.
+//! The account layout supports this too, the checkpoint fields having been
+//! carved out of existing padding and reserved space, so an order written before
+//! the mechanism existed reads back as carrying no builder fee.
+//!
+//! ## Liveness
+//!
+//! Settlement cannot be blocked, an order is always eventually closable, and
+//! nothing freezes when the mechanism is switched off.
+//!
+//! Settlement is permissionless, so no particular address can withhold it, and
+//! it is idempotent: a recorded amount of zero is an explicit no-op with no
+//! transfer and no CPI, which makes it safe to call in any state. It needs the
+//! builder's claim vault to already exist and deliberately creates nothing, so
+//! that precondition is discharged one instruction earlier, by `set_builder_fee`
+//! requiring the same account; a builder without one is refused at checkpoint
+//! time, where the owner simply does not get a builder attached, rather than at
+//! settlement time, where the order would already be stuck. The feature flag
+//! gates only the checkpoint, leaving settlement, claiming and execution
+//! ungated, so disabling the mechanism stops new orders taking on a fee without
+//! stranding a fee already owed.
+//!
+//! ## What cannot be exercised on chain
+//!
+//! Two cases are argued rather than tested, because no transaction can reach
+//! them. There is no update path through which a forbidden swap type or a
+//! different factor could arrive, so the "reject it at update" case has no code
+//! to exercise; `UpdateOrderParams` pins that, and the compile fails if it
+//! stops being true. And no pending `Liquidation` or `AutoDeleveraging` order
+//! can exist to be checkpointed: order creation refuses both kinds, and the
+//! keeper builds a liquidation inside the transaction that executes it.
+
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use gmsol_model::{
@@ -30,6 +175,18 @@ pub use gmsol_utils::order::{OrderKind, OrderSide};
 gmsol_utils::flags!(OrderFlag, MAX_ORDER_FLAGS, u8);
 
 /// Update Order Params.
+///
+/// # Adding a field here is a security decision
+///
+/// These are the only values an update may reach, and the builder fee rests on
+/// that twice over: a fee is charged at the factor checkpointed on the order,
+/// and it is taken from the final output token bucket, which
+/// [`DecreasePositionSwapType::CollateralToPnlToken`] empties. A factor
+/// reachable by an update would change the amount owed after the owner
+/// authorized it; a reachable swap type would let an order be checkpointed
+/// under a benign one and then flipped to one that pays nothing. Neither is
+/// reachable today, and `update_order_params_field_set_is_pinned` fails the
+/// build if that changes.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace, Copy)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct UpdateOrderParams {
@@ -1026,6 +1183,33 @@ mod tests {
         );
         // u128 requires 16-byte alignment.
         assert_eq!(BUILDER_FEE_FACTOR_OFFSET % 16, 0);
+    }
+
+    #[test]
+    fn update_order_params_field_set_is_pinned() {
+        // Pins what an update may reach. The destructuring is exhaustive and
+        // takes no `..` rest pattern, so a new field on `UpdateOrderParams`
+        // fails to compile here instead of silently widening the update path.
+        //
+        // What that protects is on the struct's own doc comment: a builder fee
+        // is charged at the factor checkpointed on the order, and taken from a
+        // bucket the decrease position swap type can empty, so neither value
+        // may become updatable without revisiting what a checkpoint means. The
+        // runtime half, that an update leaves an existing checkpoint alone, is
+        // covered end to end by `set_builder_fee` in `tests/anchor_test`.
+        let UpdateOrderParams {
+            size_delta_value: _,
+            acceptable_price: _,
+            trigger_price: _,
+            min_output: _,
+            valid_from_ts: _,
+        } = UpdateOrderParams {
+            size_delta_value: None,
+            acceptable_price: None,
+            trigger_price: None,
+            min_output: None,
+            valid_from_ts: None,
+        };
     }
 
     #[test]

--- a/programs/store/src/states/store.rs
+++ b/programs/store/src/states/store.rs
@@ -622,6 +622,9 @@ pub struct Factors {
     /// Max builder fee factor. Reads as `0` on existing stores until a
     /// CONFIG_KEEPER explicitly raises it via `insert_factor`, so no
     /// non-zero builder fee factor can be configured by default.
+    ///
+    /// The cap the boundedness invariant is stated against; see the builder
+    /// fee invariants on [`crate::states::order`].
     pub(crate) max_builder_fee_factor: Factor,
     #[cfg_attr(feature = "debug", debug(skip))]
     reserved: [Factor; 63],

--- a/programs/store/src/states/user.rs
+++ b/programs/store/src/states/user.rs
@@ -162,6 +162,11 @@ impl UserHeader {
     ///
     /// The caller is responsible for validating the factor against the
     /// store-level cap: this only records the advertised rate.
+    ///
+    /// Upholds the authorization invariant structurally: the User Account PDA
+    /// seeds bind the account to its signer, so advertising on someone else's
+    /// account is unconstructible rather than merely rejected. See the builder
+    /// fee invariants on [`crate::states::order`].
     pub(crate) fn set_builder_fee_factor(&mut self, factor: u128) -> u128 {
         std::mem::replace(&mut self.builder_fee_factor, factor)
     }


### PR DESCRIPTION
Documents the properties the builder fee mechanism upholds, as doc comments in the repo rather than as a document elsewhere, so the argument sits next to the code it is about and versions with it.

## What is here

A module-level doc block on `states/order.rs` stating seven invariants and, for each, the argument for why the mechanism upholds it: conservation, coverage, authorization, boundedness, delivery, isolation, liveness. Plus a closing section on the two cases that cannot be exercised on chain and why.

Two existing comments already referred to "the charging invariant" and "a broken invariant" with nothing to point at. Both now name the **coverage** invariant and refer to the catalogue, folding "charging" into it so there is one name per property.

`UpdateOrderParams` gains a doc comment saying that adding a field there is a security decision, and a test pins the field set: the destructuring is exhaustive with no rest pattern, so a new field fails the build rather than silently widening what an update can reach. That matters because a fee is charged at the factor checkpointed on the order and taken from a bucket the decrease position swap type can empty, so neither value may become updatable without revisiting what a checkpoint means.

## Placement

Resolves CON-42.

The catalogue is a module doc on `states/order.rs`, and each enforcement site carries one line naming the invariant it upholds. The split was agreed on the issue.

The second commit adds that per-site layer across 14 sites, covering all seven invariants:

| Invariant | Sites |
|---|---|
| conservation | increase-path record + route, decrease-path record |
| coverage | `clamp_builder_fee_amount`, `charge_builder_fee_on_collateral_increment`, decrease-path record, the close guard |
| authorization | the factor-equality check in `set_builder_fee`, `UserHeader::set_builder_fee_factor` |
| boundedness | `compute_builder_fee_amount`, both cap enforcement points, `Factors::max_builder_fee_factor` |
| delivery | the settlement builder-equality check, the close guard |
| isolation | `compute_builder_fee_amount`, `estimate_builder_fee_for_collateral_withdrawal` |
| liveness | the feature-flag gate |

Convention: name the invariant, with the `crate::states::order` pointer on the first annotation in each file rather than repeated at all fourteen.

## The catalogue says charging is not wired yet

When this branch was first written the execution call sites still passed a literal zero factor, so the charging invariants held vacuously and the doc block said so, naming the change that would make them live. That change is #421, which has since landed, so the doc block now states that charging is wired and the invariants are load-bearing. Rebasing onto it is what surfaced the discrepancy.

## Scope notes

- The IDL carries `docs` arrays, so any annotated item that appears in it is updated too. The delta is three entries across the two commits, `UpdateOrderParams`, `BuilderFeeSettled.settled_amount` and `Factors.max_builder_fee_factor`, grafted onto the checked-in file rather than copied wholesale; nothing else in the generated IDL differed.
- Nothing outside doc comments, one test and that IDL delta is touched. No behaviour changes.