### PR TITLE
Activate builder fee charging in order execution

### DIFF
--- a/crates/decode/src/gmsol.rs
+++ b/crates/decode/src/gmsol.rs
@@ -9,12 +9,12 @@ pub mod programs {
             Store, UserHeader, VirtualInventory, Withdrawal,
         },
         events::{
-            BorrowingFeesUpdated, BuilderFeeFactorSet, BuilderFeeSet, DepositExecuted,
-            DepositRemoved, GlvDepositRemoved, GlvPricing, GlvTokenValue, GlvWithdrawalRemoved,
-            GtBuyback, GtUpdated, InsufficientFundingFeePayment, MarketFeesUpdated,
-            MarketStateUpdated, MarketTokenValue, OrderRemoved, OrderUpdated, PositionDecreased,
-            PositionIncreased, ShiftRemoved, SwapExecuted, TradeEvent, WithdrawalExecuted,
-            WithdrawalRemoved,
+            BorrowingFeesUpdated, BuilderFeeCharged, BuilderFeeFactorSet, BuilderFeeSet,
+            DepositExecuted, DepositRemoved, GlvDepositRemoved, GlvPricing, GlvTokenValue,
+            GlvWithdrawalRemoved, GtBuyback, GtUpdated, InsufficientFundingFeePayment,
+            MarketFeesUpdated, MarketStateUpdated, MarketTokenValue, OrderRemoved, OrderUpdated,
+            PositionDecreased, PositionIncreased, ShiftRemoved, SwapExecuted, TradeEvent,
+            WithdrawalExecuted, WithdrawalRemoved,
         },
     };
 
@@ -54,6 +54,7 @@ pub mod programs {
     impl_decode_for_cpi_event!(GtBuyback);
     impl_decode_for_cpi_event!(MarketTokenValue);
     impl_decode_for_cpi_event!(GlvTokenValue);
+    impl_decode_for_cpi_event!(BuilderFeeCharged);
     impl_decode_for_cpi_event!(BuilderFeeFactorSet);
     impl_decode_for_cpi_event!(BuilderFeeSet);
 
@@ -104,6 +105,7 @@ pub mod programs {
             GtBuyback,
             MarketTokenValue,
             GlvTokenValue,
+            BuilderFeeCharged,
             BuilderFeeFactorSet,
             BuilderFeeSet,
             UnknownOwnedData

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1099,6 +1099,18 @@ impl ExecuteOrderOperation<'_, '_> {
 
                 position.on_validate().map_err(ModelError::from)?;
 
+                // The factor checkpointed onto the order by `set_builder_fee`, not the one the
+                // builder currently advertises: what the order owes is fixed when the owner signs
+                // the checkpoint, and stays fixed however the builder moves its factor afterwards.
+                // Orders that never took a checkpoint carry zero here, which every fee path below
+                // reads as "no builder fee" and short-circuits on.
+                //
+                // Liquidation and ADL orders are created by the keeper rather than the owner, and
+                // `set_builder_fee` accepts only user-initiated kinds, so their factor is always
+                // zero; they are passed the same value for uniformity rather than as a special
+                // case.
+                let builder_fee_factor = self.order.load()?.builder_fee_factor();
+
                 let (should_remove_position, paid_fee_value) = match kind {
                     OrderKind::MarketIncrease | OrderKind::LimitIncrease => {
                         let paid_fee_value = execute_increase_position(
@@ -1109,9 +1121,7 @@ impl ExecuteOrderOperation<'_, '_> {
                             &mut transfer_out,
                             &mut *event_loader.load_mut()?,
                             &mut *self.order.load_mut()?,
-                            // TODO(builder-fee): read the snapshot factor from
-                            // the order once it is captured at order creation.
-                            0,
+                            builder_fee_factor,
                         )?;
                         (false, paid_fee_value)
                     }
@@ -1125,9 +1135,7 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut *self.order.load_mut()?,
                         true,
                         Some(SecondaryOrderType::Liquidation),
-                        // TODO(builder-fee): read the snapshot factor from
-                        // the order once it is captured at order creation.
-                        0,
+                        builder_fee_factor,
                     )?,
                     OrderKind::AutoDeleveraging => execute_decrease_position(
                         self.oracle,
@@ -1139,9 +1147,7 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut *self.order.load_mut()?,
                         true,
                         Some(SecondaryOrderType::AutoDeleveraging),
-                        // TODO(builder-fee): read the snapshot factor from
-                        // the order once it is captured at order creation.
-                        0,
+                        builder_fee_factor,
                     )?,
                     OrderKind::MarketDecrease
                     | OrderKind::LimitDecrease
@@ -1155,9 +1161,7 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut *self.order.load_mut()?,
                         false,
                         None,
-                        // TODO(builder-fee): read the snapshot factor from
-                        // the order once it is captured at order creation.
-                        0,
+                        builder_fee_factor,
                     )?,
                     _ => unreachable!(),
                 };

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -6,6 +6,7 @@ use gmsol_programs::{
     anchor_lang::error::ErrorCode,
     gmsol_store::{
         client::{accounts, args},
+        events::BuilderFeeCharged,
         types::{DecreasePositionSwapType, UpdateOrderParams},
     },
 };
@@ -13,13 +14,39 @@ use gmsol_sdk::{
     builders::order::SetBuilderFeeHint,
     client::ops::{BuilderFeeOps, ConfigOps, ExchangeOps, MarketOps, UserOps},
     constants::MARKET_USD_UNIT,
+    decode::gmsol::programs::GMSOLCPIEvent,
     pda::find_user_token_controller_address,
+    Client,
 };
+use gmsol_solana_utils::signer::SignerRef;
 use gmsol_store::CoreError;
 use gmsol_utils::{config::FactorKey, market::MarketConfigKey};
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use tracing::Instrument;
 
 use crate::anchor_test::setup::{current_deployment, Deployment};
+
+/// Read the [`BuilderFeeCharged`] event emitted by the most recent transaction touching `order`.
+///
+/// Errors when the order's last transaction emitted none, which is what a case asserting that a fee
+/// was charged wants: the absence of the event is exactly the failure being guarded against.
+async fn last_builder_fee_charged(
+    client: &Client<SignerRef>,
+    order: &Pubkey,
+) -> eyre::Result<BuilderFeeCharged> {
+    let slot = client.get_slot(None).await?;
+    let events = client
+        .last_order_events(order, slot, CommitmentConfig::confirmed())
+        .await?;
+
+    events
+        .into_iter()
+        .find_map(|event| match event {
+            GMSOLCPIEvent::BuilderFeeCharged(event) => Some(event),
+            _ => None,
+        })
+        .ok_or_eyre("no `BuilderFeeCharged` event was emitted")
+}
 
 #[tokio::test]
 async fn balanced_market_order() -> eyre::Result<()> {
@@ -1603,6 +1630,193 @@ async fn set_builder_fee_rejects_collateral_to_pnl_swap() -> eyre::Result<()> {
 
     let signature = owner.close_order(&order)?.build().await?.send().await?;
     tracing::info!(%order, %signature, "cancelled the decrease order");
+
+    Ok(())
+}
+
+/// Executing a fee-bearing order charges the fee.
+///
+/// The amount follows the factor checkpointed onto the order rather than whatever the builder
+/// advertises by the time the order executes; the pending amount recorded on the order, the balance
+/// left in the order's escrow and the `BuilderFeeCharged` event all agree; and the order cannot be
+/// closed until the fee has been settled into the builder's claim vault.
+///
+/// Trades as the exclusive locked user: the assertions read an escrow and a claim vault that no
+/// concurrently running test may also be moving.
+#[tokio::test]
+async fn charges_builder_fee_on_execution() -> eyre::Result<()> {
+    /// One percent, in the market factor unit.
+    const CAP: u128 = MARKET_USD_UNIT / 100;
+
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("charges_builder_fee_on_execution");
+    let _enter = span.enter();
+
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let builder = deployment.user_client(Deployment::USER_1)?;
+    let store = &deployment.store;
+    let oracle = &deployment.oracle();
+    let fbtc = deployment.token("fBTC").expect("must exist");
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    let owner = deployment.locked_user_client().await?;
+
+    for signature in [
+        owner.prepare_user(store)?.send_without_preflight().await?,
+        builder
+            .prepare_user(store)?
+            .send_without_preflight()
+            .await?,
+    ] {
+        tracing::info!(%signature, "prepared a user account");
+    }
+
+    // The vault settlement pays into. `set_builder_fee` requires it to exist; the balance it starts
+    // from is read under the lock below, since this builder is shared with the other builder fee
+    // tests and one of them settles into this very vault.
+    let builder_user = builder.find_user_address(store, &builder.payer());
+    deployment
+        .mint_or_transfer_to("fBTC", &builder_user, 0)
+        .await?;
+
+    // Deliberately small: this market is shared with the other order tests and the position opened
+    // here is left behind, so it keeps its footprint on open interest and pool balances negligible.
+    let collateral_amount = 10_000;
+    deployment
+        .mint_or_transfer_to("fBTC", &owner.payer(), collateral_amount)
+        .await?;
+
+    let size = 100 * MARKET_USD_UNIT;
+
+    deployment
+        .with_builder_fee_cap(CAP, async {
+            let claim_vault_before = deployment
+                .get_ata_amount(&fbtc.address, &builder_user)
+                .await?
+                .ok_or_eyre("the claim vault must exist")?;
+
+            let signature = builder
+                .set_builder_fee_factor(store, CAP)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder advertised its factor");
+
+            // The escrow is what makes an increase order fee-eligible: the fee is charged in the
+            // final output token and lands in that token's escrow under the order.
+            let (rpc, order) = owner
+                .market_increase(store, market_token, true, collateral_amount, true, size)
+                .prepare_final_output_token_escrow(true)
+                .build_with_address()
+                .await?;
+            let signature = rpc.send().await?;
+            tracing::info!(%order, %signature, "created a fee-eligible increase order");
+
+            let signature = owner
+                .set_builder_fee(store, &order, &builder_user, CAP, None)
+                .await?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%order, %signature, "checkpointed the builder fee onto the order");
+
+            // Whatever the builder advertises from here on must not reach this order. Opting out
+            // entirely is the strongest form of that: the charge below is non-zero only if it is
+            // computed from the checkpoint rather than from the builder's current factor.
+            let signature = builder
+                .set_builder_fee_factor(store, 0)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder opted back out after the checkpoint");
+
+            let escrow = owner
+                .order(&order)
+                .await?
+                .tokens
+                .final_output_token
+                .account()
+                .ok_or_eyre("the order must carry a final output token escrow")?;
+
+            let mut execution = keeper.execute_order(store, oracle, &order, false)?;
+            deployment
+                .execute_with_pyth(
+                    execution
+                        .add_alt(deployment.common_alt().clone())
+                        .add_alt(deployment.market_alt().clone()),
+                    None,
+                    true,
+                    true,
+                )
+                .await?;
+            tracing::info!(%order, "executed the fee-bearing order");
+
+            let executed = owner.order(&order).await?;
+            let pending_amount = executed.builder_fee_amount;
+            assert_ne!(
+                pending_amount, 0,
+                "the checkpointed factor must be charged even though the builder now advertises 0"
+            );
+            assert_eq!(executed.builder, builder_user);
+
+            // The escrow of an increase order receives nothing but the fee, so its whole balance is
+            // what settlement has to pay out.
+            assert_eq!(
+                deployment.get_token_account_amount(&escrow).await?,
+                Some(pending_amount),
+                "the escrow must hold exactly the amount recorded as pending"
+            );
+
+            let charged = last_builder_fee_charged(&keeper, &order).await?;
+            assert_eq!(charged.paid_amount, u128::from(pending_amount));
+            assert_eq!(
+                charged.payable_amount, charged.paid_amount,
+                "an increase order errors out rather than charging a partial amount"
+            );
+            assert_eq!(charged.token, fbtc.address);
+
+            // The fee is unsettled, so the order is not closable yet.
+            let err = owner
+                .close_order(&order)?
+                .build()
+                .await?
+                .send()
+                .await
+                .expect_err("should reject closing an order with an unsettled builder fee");
+            assert_eq!(
+                gmsol_sdk::Error::from(err).anchor_error_code(),
+                Some(CoreError::UnsettledBuilderFee.into()),
+            );
+
+            // Settlement is permissionless, so the keeper can do it.
+            let signature = keeper
+                .settle_builder_fee(store, &order, None)
+                .await?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%order, %signature, "settled the builder fee");
+
+            assert_eq!(
+                owner.order(&order).await?.builder_fee_amount,
+                0,
+                "settlement must clear the pending amount"
+            );
+            assert_eq!(
+                deployment
+                    .get_ata_amount(&fbtc.address, &builder_user)
+                    .await?,
+                Some(claim_vault_before + pending_amount),
+                "the settled fee must land in the builder's claim vault"
+            );
+
+            // Closable once nothing is pending.
+            let signature = owner.close_order(&order)?.build().await?.send().await?;
+            tracing::info!(%order, %signature, "closed the settled order");
+
+            Ok::<_, eyre::Report>(())
+        })
+        .await?;
 
     Ok(())
 }

--- a/tests/anchor_test/setup.rs
+++ b/tests/anchor_test/setup.rs
@@ -1747,15 +1747,25 @@ impl Deployment {
         token: &Pubkey,
         user: &Pubkey,
     ) -> eyre::Result<Option<u64>> {
-        use anchor_spl::{
-            associated_token::spl_associated_token_account::get_associated_token_address,
-            token::TokenAccount,
-        };
+        use anchor_spl::associated_token::spl_associated_token_account::get_associated_token_address;
 
-        let ata = get_associated_token_address(user, token);
+        self.get_token_account_amount(&get_associated_token_address(user, token))
+            .await
+    }
+
+    /// Read the balance of a token account by address, `None` if the account does not exist.
+    ///
+    /// Unlike [`get_ata_amount`](Self::get_ata_amount) this makes no assumption about how the
+    /// account is derived, which is what an order's escrow needs.
+    pub(crate) async fn get_token_account_amount(
+        &self,
+        account: &Pubkey,
+    ) -> eyre::Result<Option<u64>> {
+        use anchor_spl::token::TokenAccount;
+
         let account = self
             .client
-            .account_with_config::<TokenAccount>(&ata, Default::default())
+            .account_with_config::<TokenAccount>(account, Default::default())
             .await?
             .into_value();
         Ok(account.map(|a| a.amount))


### PR DESCRIPTION
Every earlier builder fee change shipped inert. Computation, state, configuration and
the settlement and claim rails all landed without charging anything. This branch is the
switch that makes them live.

The switch itself sits in `programs/store/src/ops/order.rs`. All four execution arms
passed a hardcoded zero factor behind a `TODO(builder-fee)` marker. They now read the
factor checkpointed onto the order by `set_builder_fee`.

```rust
let builder_fee_factor = self.order.load()?.builder_fee_factor();
```

The factor is read from the order rather than from the builder's User Account, which is
what fixes the amount owed at the moment the owner signs the checkpoint. Orders that
never took a checkpoint carry zero, and every fee path already short circuits on zero.
Liquidation and ADL orders are passed the same value rather than handled as a special
case, because `set_builder_fee` accepts only user initiated kinds, so their factor is
always zero.

`crates/decode/src/gmsol.rs` gains the `BuilderFeeCharged` variant. The event already
existed on chain and in the IDL, but nothing could decode it, so no test or indexer
could observe a charge. `BuilderFeeSettled` is still absent and would be the same one
line addition if it is wanted.

`tests/anchor_test/setup.rs` gains `get_token_account_amount`, which reads a token
account balance by address. The existing helper derives an associated token account,
which an order escrow is not.

## Acceptance criteria

| Criterion | Where it is covered |
| --- | --- |
| Orders with no checkpoint execute as before | A zeroed order reads as factor zero, which the `existing_zeroed_accounts_read_as_no_builder_fee` unit test and every other order test already exercise |
| The checkpointed factor decides the amount | `charges_builder_fee_on_execution`, where the builder drops its advertised factor to zero after the checkpoint and the charge still lands |
| Pending amount, escrow and `BuilderFeeCharged` agree | `charges_builder_fee_on_execution`, on the increase path |
| Fee caused failures cancel rather than revert | No test. See the note below |
| The fee can be settled, and the order cannot close until it is | `charges_builder_fee_on_execution` |

The fourth criterion holds structurally rather than by test. Its own wording says that
returning an error is enough, and what this branch adds is one value passed to four call
sites, with no CPI call and no panic anywhere near them. The guards it names already
existed and already returned plain errors before this change.

## Scope of the testing

One integration test for a four line change is deliberate. The charging behaviour was
written and unit tested in the earlier builder fee work, so what this branch actually
needs to prove is narrower, that the checkpointed factor reaches execution and produces a
charge that settles. An earlier revision of this branch carried three integration tests
and roughly 536 lines of test code. That was out of proportion to the change, so two were
dropped.

## Testing

`cargo check`, `cargo clippy`, `cargo fmt --check` and the 31 `gmsol-store` unit tests
pass locally.

The new integration test has never run. It goes through `execute_with_pyth`, and CI is
currently blocked before any test starts, because `anchor test` cannot clone the Wormhole
guardian set accounts named in `Anchor.toml`. Those accounts have gone missing from
devnet, which is unrelated to this branch and fails the same way on `main`. Two
assumptions inside the test are therefore unverified, and each would fail the test rather
than the program.

* `last_order_events` returns the execution transaction's events, which assumes the
  history stream is ordered newest first.
* An increase order's escrow receives nothing but the fee, so the balance equals the
  pending amount exactly.
