### PR TITLE
fix(test): clone the active Wormhole guardian set at index 0

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -99,33 +99,9 @@ address = "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"
 address = "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX"
 
 # BEGIN guardian-sets (managed by xtask; run `just rotate-guardian-set`)
-# Wormhole Guardian Set account (index = 1)
-# [[test.validator.clone]]
-# address = "8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5"
-
-# Wormhole Guardian Set account (index = 2)
-# [[test.validator.clone]]
-# address = "izDSKeLVBe4fT3HawjGfnwbMwUQSw1LLoFG9QvZ9Asz"
-
-# Wormhole Guardian Set account (index = 3)
-# [[test.validator.clone]]
-# address = "D2JSt6eTTzsmmap3HtCmcQCM3gBcsz6EiB36zYWNRN3k"
-
-# Wormhole Guardian Set account (index = 4)
-# [[test.validator.clone]]
-# address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"
-
-# Wormhole Guardian Set account (index = 5)
-# [[test.validator.clone]]
-# address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni"
-
-# Wormhole Guardian Set account (index = 6)
+# Wormhole Guardian Set account (index = 0)
 [[test.validator.clone]]
-address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf"
-
-# Wormhole Guardian Set account (index = 7)
-[[test.validator.clone]]
-address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"
+address = "C7RmcKdjeFscYSyekkmCjvHcnBQd7qJDkeB9RmRtuB3L"
 # END guardian-sets
 
 # Pyth Config account

--- a/scripts/start_localnet.sh
+++ b/scripts/start_localnet.sh
@@ -11,7 +11,7 @@ RUST_LOG=trace \
   --limit-ledger-size 1000000000 \
   --log-messages-bytes-limit 1000000000 \
   --compute-unit-limit 1000000000 \
-  --clone 5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn \
+  --clone C7RmcKdjeFscYSyekkmCjvHcnBQd7qJDkeB9RmRtuB3L \
   --clone DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b \
   --upgradeable-program rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ external-programs/pyth-receiver.so $ADDRESS \
   --upgradeable-program pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT external-programs/pyth-push-oracle.so $ADDRESS \

--- a/xtask/src/guardian_set.rs
+++ b/xtask/src/guardian_set.rs
@@ -2,7 +2,7 @@
 
 use std::str::FromStr;
 
-use eyre::{eyre, OptionExt, Result};
+use eyre::{eyre, Result};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
 
@@ -20,8 +20,15 @@ pub fn guardian_set_address(index: u32) -> Pubkey {
 }
 
 pub struct Detected {
-    /// Highest existing guardian-set index (= the active set).
-    pub active: u32,
+    /// Highest existing guardian-set index (= the active set), or `None` when the
+    /// probe succeeded and found nothing.
+    ///
+    /// `None` is deliberately not an `Err`. A failed query and an empty cluster are
+    /// different events and the caller must be able to treat them differently: the
+    /// first is a network blip worth skipping over, the second is an outage. Folding
+    /// them into one `Err` is what let the 2026-08-26 Pyth Core upgrade pass
+    /// `guardian-set check` while the validator could not start.
+    pub active: Option<u32>,
     /// All indices in `0..=max_probe` whose account exists on the cluster.
     pub existing: Vec<u32>,
 }
@@ -44,11 +51,7 @@ pub fn detect(rpc_url: &str, max_probe: u32) -> Result<Detected> {
         .zip(accounts.iter())
         .filter_map(|(&i, acc)| acc.as_ref().map(|_| i))
         .collect();
-    let active = existing
-        .iter()
-        .copied()
-        .max()
-        .ok_or_eyre("no guardian-set accounts found on cluster")?;
+    let active = existing.iter().copied().max();
     if existing.contains(&max_probe) {
         eprintln!(
             "warning: highest probed guardian-set index ({max_probe}) exists; a newer set \

--- a/xtask/src/guardian_set.rs
+++ b/xtask/src/guardian_set.rs
@@ -22,18 +22,19 @@ pub fn guardian_set_address(index: u32) -> Pubkey {
 pub struct Detected {
     /// Highest existing guardian-set index (= the active set).
     pub active: u32,
-    /// All indices in `1..=max_probe` whose account exists on the cluster.
+    /// All indices in `0..=max_probe` whose account exists on the cluster.
     pub existing: Vec<u32>,
 }
 
-/// One `getMultipleAccounts` call over indices `1..=max_probe`; the highest existing
+/// One `getMultipleAccounts` call over indices `0..=max_probe`; the highest existing
 /// index is the active set (indices increment by +1 per rotation, newest is active).
-/// Index 0 (the 2021 genesis set) is intentionally skipped: it is never used to sign
-/// current VAAs, and skipping it keeps `existing` deterministic regardless of whether
-/// the genesis account sits at the standard PDA.
+/// Index 0 is included. It used to be skipped as "the 2021 genesis set, never used to
+/// sign current VAAs", which stopped holding at the 2026-08-26 Pyth Core upgrade: the
+/// program was upgraded in place and the set it signs with is index 0, so a probe that
+/// starts at 1 reports no guardian sets at all and hides an otherwise healthy cluster.
 pub fn detect(rpc_url: &str, max_probe: u32) -> Result<Detected> {
     let client = RpcClient::new(rpc_url.to_string());
-    let indices: Vec<u32> = (1..=max_probe).collect();
+    let indices: Vec<u32> = (0..=max_probe).collect();
     let addresses: Vec<Pubkey> = indices.iter().map(|&i| guardian_set_address(i)).collect();
     let accounts = client
         .get_multiple_accounts(&addresses)
@@ -64,7 +65,8 @@ mod tests {
     #[test]
     fn derives_known_guardian_set_addresses() {
         let cases = [
-            (1u32, "8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5"),
+            (0u32, "C7RmcKdjeFscYSyekkmCjvHcnBQd7qJDkeB9RmRtuB3L"),
+            (1, "8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5"),
             (4, "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"),
             (6, "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf"),
             (7, "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -55,6 +55,7 @@ fn cmd_check() -> ExitCode {
         Ok(d) => d,
         Err(e) => {
             // Soft-pass: a network blip must not masquerade as "rotation needed".
+            // This covers a failed query only; an empty answer is handled below.
             eprintln!(
                 "warning: could not check guardian set ({e}); skipping. \
                        anchor's --clone will surface a real outage."
@@ -63,7 +64,19 @@ fn cmd_check() -> ExitCode {
         }
     };
 
-    let active_addr = guardian_set::guardian_set_address(detected.active).to_string();
+    // An answered query that found nothing is an outage, not a blip, so it must fail
+    // rather than soft-pass. This is the case that went undetected on 2026-08-26.
+    let Some(active) = detected.active else {
+        eprintln!(
+            "error: no Wormhole guardian set exists at indices 0..={MAX_PROBE} on {rpc}.\n\
+             The cluster answered, so this is not a network problem: either the program \
+             moved or its sets were withdrawn. `just rotate-guardian-set` cannot help, \
+             since there is nothing to rotate onto."
+        );
+        return ExitCode::FAILURE;
+    };
+
+    let active_addr = guardian_set::guardian_set_address(active).to_string();
     let cloned = match anchor_toml::uncommented_addresses(&contents) {
         Ok(addrs) => addrs,
         Err(e) => {
@@ -73,13 +86,12 @@ fn cmd_check() -> ExitCode {
     };
 
     if cloned.iter().any(|a| a == &active_addr) {
-        println!("guardian set {} is active and cloned; ok.", detected.active);
+        println!("guardian set {active} is active and cloned; ok.");
         ExitCode::SUCCESS
     } else {
         eprintln!(
-            "error: Wormhole guardian set {} is active but not cloned in {ANCHOR_TOML}.\n\
-             Run `just rotate-guardian-set` to update it.",
-            detected.active
+            "error: Wormhole guardian set {active} is active but not cloned in {ANCHOR_TOML}.\n\
+             Run `just rotate-guardian-set` to update it."
         );
         ExitCode::FAILURE
     }
@@ -103,7 +115,18 @@ fn cmd_rotate() -> ExitCode {
         }
     };
 
-    let interior = anchor_toml::render_interior(&detected.existing, detected.active, |i| {
+    // Same distinction as in `cmd_check`: nothing to rotate onto is a hard failure,
+    // and writing an empty managed block would silently disarm the check.
+    let Some(active) = detected.active else {
+        eprintln!(
+            "error: no Wormhole guardian set exists at indices 0..={MAX_PROBE} on {rpc}; \
+             there is nothing to rotate onto. The program has most likely moved or its \
+             sets were withdrawn, which needs an address change rather than a rotation."
+        );
+        return ExitCode::FAILURE;
+    };
+
+    let interior = anchor_toml::render_interior(&detected.existing, active, |i| {
         guardian_set::guardian_set_address(i).to_string()
     });
     let updated = match anchor_toml::splice_managed_block(&contents, &interior) {
@@ -115,21 +138,17 @@ fn cmd_rotate() -> ExitCode {
     };
 
     if updated == contents {
-        println!(
-            "guardian set {} already current; no change.",
-            detected.active
-        );
+        println!("guardian set {active} already current; no change.");
         return ExitCode::SUCCESS;
     }
     if let Err(e) = std::fs::write(ANCHOR_TOML, &updated) {
         eprintln!("error: failed to write {ANCHOR_TOML}: {e}");
         return ExitCode::FAILURE;
     }
-    let previous = detected.active.saturating_sub(1);
+    let previous = active.saturating_sub(1);
     println!(
-        "updated {ANCHOR_TOML}: guardian set {} active, {previous} kept as previous \
-         (older commented). Review and commit.",
-        detected.active
+        "updated {ANCHOR_TOML}: guardian set {active} active, {previous} kept as previous \
+         (older commented). Review and commit."
     );
     ExitCode::SUCCESS
 }


### PR DESCRIPTION
`CI for Programs` has been failing on `main` since the [Pyth Core upgrade](https://docs.pyth.network/price-feeds/core/upgrade) of 2026-08-26 16:00 UTC. Anchor clones the Wormhole guardian set listed in `Anchor.toml`, that account stopped resolving at the cutover, and a clone that does not resolve kills the validator before any test runs. The last green run on `main` was `fa626ae9`, at 14:49 UTC that day.

## What actually happened

The programs were **upgraded in place, at the same addresses**. [OP-PIP-131](https://forum.pyth.network/t/passed-op-pip-131-pyth-core-deprecation-svm/2671) executed at the cutover and did three things: `set_data_sources` on the Pyth Solana Receiver, `set_fee` to 0, and a `BPFLoaderUpgradeable::Upgrade` of the Wormhole receiver at `HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ`. So every program id this repo already references is still the right one, and the on-chain deploy history agrees: that Wormhole program was redeployed 6.8 days ago on mainnet-beta and the receiver 1.6 days ago on devnet.

What moved is the guardian set. The upgraded program signs with **index 0**, and the sets at indices 1 through 7 are gone on both devnet and mainnet-beta. Index 0 exists under the same program, `C7RmcKdjeFscYSyekkmCjvHcnBQd7qJDkeB9RmRtuB3L`, 124 bytes, 5 guardians, on both clusters.

## Change

Three lines of substance.

- `Anchor.toml`: the managed guardian-set block collapses to the single index-0 entry.
- `xtask/src/guardian_set.rs`: the probe range becomes `0..=max_probe`. It started at 1 because index 0 used to be an unused 2021 genesis set, which the in-place upgrade made false. That off-by-one is why `cargo xtask guardian-set check` reported "no guardian-set accounts found on cluster" rather than naming a stale index, and it is worth fixing on its own: the check will otherwise keep hiding a healthy cluster.
- `scripts/start_localnet.sh`: the same clone, which pointed at the index-4 account.

The test vector for index 0 is not self-referential; that account is on devnet and mainnet-beta owned by the same Wormhole program, so it pins the seed scheme against something observable.

## The check that should have caught this, and did not

`cargo xtask guardian-set check` soft-passed the outage. `detect` returned `Err` both when the RPC call failed and when it succeeded but found nothing, and the caller treated any `Err` as a network blip worth skipping, returning `SUCCESS`. So the one signal that existed reported ok while the validator could not start.

The two are now different values rather than one error: `Detected.active` is `Option<u32>`, an `Err` still means the query failed and is still soft-passed, and `None` means the cluster answered with nothing and is a hard failure in both `check` and `rotate`. The message says which of the two happened, and that rotating cannot help because there is nothing to rotate onto.

Confirmed by a control run rather than by reading. Pointed at a program id with no guardian sets, the check exits `1` with the new message; against the real one it exits `0` with `guardian set 0 is active and cloned; ok.`

## Verified

`cargo xtask guardian-set check` goes from "no guardian-set accounts found" to "guardian set 0 is active and cloned; ok". Locally the validator then starts and `anchor_test::oracle` is `2 passed; 0 failed` in 75.8s.

The Pyth-backed tests stay red, on the Hermes API key rather than on anything here: price routes answer `401` without one while metadata routes still answer `200`. On a branch with this fix the suite reaches `running 50 tests` and ends `17 passed; 33 failed`, against no `running N tests` line at all on `main`.

## Note

An earlier revision of this PR migrated four program addresses to `rec2HHDD...`, `pyt2F414...` and `HDw2E7P8...`, on the assumption that Pyth had deployed a new generation. That was wrong. Those programs exist, but they were last deployed 118 days ago on mainnet-beta and 143 on devnet, months before the cutover, so they are not what the upgrade produced. The address migration is dropped; nothing in the repo needs a new program id, and by extension the `pyth-solana-receiver-sdk` pin at 1.0.1 remains correct.
