### PR TITLE
fix(store): drop the builder fee recorded by a discarded execution

### DIFF
--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -951,6 +951,19 @@ impl ExecuteOrderOperation<'_, '_> {
         let mut should_throw_error = false;
         let prices = self.prices()?;
         let discount = self.validate_and_get_order_fee_discount()?;
+
+        // The builder fee is recorded onto the order part-way through
+        // execution, and the order account is not revertible: unlike the
+        // position and the markets, it is passed down as a plain `&mut Order`,
+        // so a soft failure below keeps whatever was written to it while
+        // discarding the `TransferOut` that was supposed to fund the fee.
+        //
+        // Snapshotting here keys the record to the outcome rather than to an
+        // ordering of the fallible steps. Moving the record after the last one
+        // would fix the paths that exist today and silently rot the moment a
+        // new fallible step is added after it.
+        let builder_fee_amount_before = self.order.load()?.builder_fee_amount();
+
         let res = match self.perform_execution(&mut should_throw_error, prices, discount) {
             Ok((should_remove_position, mut transfer_out, should_send_trade_event)) => {
                 transfer_out.set_executed(true);
@@ -959,6 +972,13 @@ impl ExecuteOrderOperation<'_, '_> {
             }
             Err(err) if !(should_throw_error || self.throw_on_execution_error) => {
                 msg!("Execute order error: {}", err);
+                // Everything this attempt produced is dropped here, so the fee
+                // it recorded goes with it. The caller cancels the order and
+                // refunds the principal into the very escrow settlement would
+                // otherwise pay the builder from.
+                self.order
+                    .load_mut()?
+                    .restore_builder_fee_amount(builder_fee_amount_before);
                 remove_position = self
                     .position
                     .as_ref()

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -572,6 +572,26 @@ impl Order {
         Ok(())
     }
 
+    /// Restore the recorded builder fee amount to a previously observed value.
+    ///
+    /// The undo half of [`record_builder_fee`](Self::record_builder_fee),
+    /// for the soft-failure path. The order account is not revertible, so a
+    /// fee recorded by an execution attempt that is then discarded survives
+    /// it, payable out of an escrow the same failure refunded to the owner
+    /// rather than funded.
+    ///
+    /// Takes the previous value instead of zeroing, because the field
+    /// accumulates by contract. Restoring is therefore correct without
+    /// depending on an order being executable at most once, which is what
+    /// makes a prior unsettled charge unreachable today.
+    ///
+    /// CHECK: the caller must be discarding every output of the attempt that
+    /// recorded the amount, so that nothing was routed into the escrow to
+    /// cover it.
+    pub(crate) fn restore_builder_fee_amount(&mut self, amount: u64) {
+        self.builder_fee_amount = amount;
+    }
+
     /// Checkpoint a builder and its fee factor onto this order.
     ///
     /// The only writer of either field. Every validation the checkpoint depends

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -20,7 +20,7 @@ use gmsol_sdk::{
 };
 use gmsol_solana_utils::signer::SignerRef;
 use gmsol_store::CoreError;
-use gmsol_utils::{config::FactorKey, market::MarketConfigKey};
+use gmsol_utils::{action::ActionState, config::FactorKey, market::MarketConfigKey};
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use tracing::Instrument;
 
@@ -1813,6 +1813,174 @@ async fn charges_builder_fee_on_execution() -> eyre::Result<()> {
             // Closable once nothing is pending.
             let signature = owner.close_order(&order)?.build().await?.send().await?;
             tracing::info!(%order, %signature, "closed the settled order");
+
+            Ok::<_, eyre::Report>(())
+        })
+        .await?;
+
+    Ok(())
+}
+
+/// An execution that soft-fails must leave no builder fee recorded on the order.
+///
+/// The fee is written to the `Order` account part-way through execution, and that account is not
+/// revertible: `perform_execution` takes it as a plain `&mut Order`, unlike the position and the
+/// markets. When a later step fails and the keeper opted into cancellation, the `TransferOut` that
+/// was supposed to fund the fee is discarded while the record survives it, leaving an amount payable
+/// out of an escrow nothing was routed into. The order is then refused by every close path until
+/// someone calls `settle_builder_fee`, and on the increase path the principal refunded by the same
+/// cancellation lands in the very escrow settlement pays from.
+///
+/// The lever is a decrease order with an unreachable `min_output_amount`, which fails
+/// `validate_decrease_output_amounts` after the fee has been recorded, with `should_throw_error`
+/// left `false` so the failure lands in the soft-failure arm rather than reverting the transaction.
+/// The decrease path is used because that minimum is a parameter the test controls; the increase
+/// path reaches the same arm only through a market condition.
+///
+/// Executes with the bundled close disabled, so the assertion lands on the recorded amount itself
+/// rather than on the close guard tripping. Closing is then exercised separately, since being unable
+/// to close without an extra settlement is the user-visible half of the defect.
+///
+/// Trades as the exclusive locked user: it needs a position of its own, and the position for
+/// [`Deployment::DEFAULT_USER`] on this market is opened and closed by `balanced_market_order`
+/// running concurrently. It takes that lock before the builder fee globals, matching
+/// `set_builder_fee_rejects_collateral_to_pnl_swap`; no test takes them in the opposite order.
+#[tokio::test]
+async fn soft_failed_execution_records_no_builder_fee() -> eyre::Result<()> {
+    /// One percent, in the market factor unit.
+    const CAP: u128 = MARKET_USD_UNIT / 100;
+
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("soft_failed_execution_records_no_builder_fee");
+    let _enter = span.enter();
+
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let builder = deployment.user_client(Deployment::USER_1)?;
+    let store = &deployment.store;
+    let oracle = &deployment.oracle();
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    let owner = deployment.locked_user_client().await?;
+
+    for signature in [
+        owner.prepare_user(store)?.send_without_preflight().await?,
+        builder
+            .prepare_user(store)?
+            .send_without_preflight()
+            .await?,
+    ] {
+        tracing::info!(%signature, "prepared a user account");
+    }
+
+    // `set_builder_fee` requires the claim vault to exist, even though nothing is ever settled here.
+    let builder_user = builder.find_user_address(store, &builder.payer());
+    deployment
+        .mint_or_transfer_to("fBTC", &builder_user, 0)
+        .await?;
+
+    // Deliberately small: this market is shared with the other order tests and the position opened
+    // here is left behind, so it keeps its footprint on open interest and pool balances negligible.
+    let collateral_amount = 10_000;
+    deployment
+        .mint_or_transfer_to("fBTC", &owner.payer(), collateral_amount * 2)
+        .await?;
+
+    let size = 100 * MARKET_USD_UNIT;
+    let (rpc, increase) = owner
+        .market_increase(store, market_token, true, collateral_amount, true, size)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%increase, %signature, "created the increase order");
+
+    let mut execution = keeper.execute_order(store, oracle, &increase, false)?;
+    deployment
+        .execute_with_pyth(
+            execution
+                .add_alt(deployment.common_alt().clone())
+                .add_alt(deployment.market_alt().clone()),
+            None,
+            true,
+            true,
+        )
+        .await?;
+    tracing::info!(%increase, "executed the increase order, opening the position");
+
+    // A full close, so the whole collateral is released and the fee computed from the executed size
+    // is comfortably covered by the output amount it is clamped against. The minimum output is what
+    // makes the execution fail, after that fee has been recorded. The swap type is left at its
+    // default: `CollateralToPnlToken` is refused a non-zero checkpoint outright.
+    let (rpc, order) = owner
+        .market_decrease(store, market_token, true, 0, true, size)
+        .min_output_amount(u128::MAX)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created a decrease order that cannot meet its minimum output");
+
+    deployment
+        .with_builder_fee_cap(CAP, async {
+            let signature = builder
+                .set_builder_fee_factor(store, CAP)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder advertised its factor");
+
+            let signature = owner
+                .set_builder_fee(store, &order, &builder_user, CAP, None)
+                .await?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%order, %signature, "checkpointed the builder fee onto the decrease order");
+
+            let before = owner.order(&order).await?;
+            assert_eq!(before.builder_fee_factor, CAP);
+            let recorded_before = before.builder_fee_amount;
+
+            // `true` opts into cancellation, which is what routes the failure into the soft-failure
+            // arm instead of reverting the whole transaction and with it the record.
+            let mut execution = keeper.execute_order(store, oracle, &order, true)?;
+            deployment
+                .execute_with_pyth(
+                    execution
+                        .close(false)
+                        .add_alt(deployment.common_alt().clone())
+                        .add_alt(deployment.market_alt().clone()),
+                    None,
+                    true,
+                    true,
+                )
+                .await?;
+            tracing::info!(%order, "executed the decrease order, which must have soft-failed");
+
+            let executed = owner.order(&order).await?;
+
+            // Without this the test would also pass on a successful execution that happened to
+            // charge nothing, which is the one way it could go quietly vacuous.
+            assert!(
+                matches!(executed.header.action_state()?, ActionState::Cancelled),
+                "the execution must have failed and cancelled the order, not completed it"
+            );
+
+            assert_eq!(
+                executed.builder_fee_amount, recorded_before,
+                "a discarded execution must leave the recorded builder fee untouched"
+            );
+
+            // The other half of the defect: the close guard refuses any order carrying a recorded
+            // fee, so before the fix this order could not be closed until it had been settled.
+            let signature = owner.close_order(&order)?.build().await?.send().await?;
+            tracing::info!(%order, %signature, "closed the cancelled order without settling anything");
+
+            let signature = builder
+                .set_builder_fee_factor(store, 0)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder opted back out");
 
             Ok::<_, eyre::Report>(())
         })


### PR DESCRIPTION
`Order` is not revertible. `perform_execution` takes it as a plain `&mut Order`, unlike `RevertiblePosition` and the markets, so anything written to it survives a soft failure. The builder fee is recorded part-way through execution, and when a later step fails with `cancel_on_execution_error` set, the `TransferOut` that was supposed to fund that fee is replaced by `Default::default()` while the record stays. The order is then cancelled, and every close path refuses it until `settle_builder_fee` has run against an escrow nothing was routed into.

Introduced by #421, which replaced four hardcoded zero fee factors with the order's checkpointed one; before that `record_builder_fee(0)` made the path unreachable.

### The fix

Snapshot `builder_fee_amount` before `perform_execution` and restore it in the soft-failure arm, next to where `transfer_out` is discarded.

Keyed on the outcome rather than on an ordering. Moving the record after "the last fallible step" is not sufficient: `perform_execution` still calls `write_to_event` and `update_with_transfer_out` after `execute_increase_position` returns, and any such list has to be re-derived every time the function changes.

Restores rather than zeroes, because `record_builder_fee` accumulates via `checked_add` (pinned by `recorded_builder_fee_amounts_accumulate`). Restoring is correct without depending on an order being executable at most once.

A hard failure needs no handling: the runtime reverts the account write.

### Why the snapshot window is safe

If anything could zero the field between snapshot and restore, restoring would resurrect an amount settlement had already paid out. The only callback CPI inside `ExecuteOrderOperation` is in `handle_executed`, which runs after the match arm; the rest of the window is token-program transfers and the store's own `emit_cpi`. The only two writers of the field are `record_builder_fee` and the settlement zeroing.

### Test

`soft_failed_execution_records_no_builder_fee` checkpoints a fee onto a `MarketDecrease` with an unreachable `min_output_amount`, which fails `validate_decrease_output_amounts` after the fee is recorded and with `should_throw_error` left false, so the failure lands in the soft-failure arm. It asserts the order is `Cancelled`, that the recorded amount is back to its pre-execution value, and that the order closes without settling anything.

The decrease path is used because that minimum is a parameter the test controls; the increase path reaches the same arm only through a market condition. It executes with the bundled close disabled, so the assertion lands on the recorded amount itself rather than on the close guard tripping.

### Note for reviewers

The regression test has now been run locally, both ways. The only difference between the two runs is the two-file fix in `programs/store`:

| code | result |
| --- | --- |
| without the fix | `FAILED. 0 passed; 1 failed`, 105.73s |
| with the fix | `ok. 1 passed; 0 failed`, 113.26s |

It fails on its own assertion rather than on infrastructure:

```
assertion `left == right` failed: a discarded execution must leave the recorded builder fee untouched
  left: 13
 right: 0
```

So a discarded execution recorded a builder fee of 13 against an order whose principal had been refunded, and the fix brings it to 0.

**CI status.** [#423](https://github.com/gmsol-labs/gmx-solana/pull/423) and [#425](https://github.com/gmsol-labs/gmx-solana/pull/425) are both merged, and this branch is rebased on top of them, so the validator starts and the suite runs.

One gap is left, and it is not fixable from this PR: the `test programs` job has no `PYTH_API_KEY` secret, so every oracle test gets a 401 from Hermes, **including the regression test added here**. Only an admin can add the secret. The rest of the suite runs normally.

Locally, with the key set, the test was run both ways and the results are in the table above.

One more thing worth flagging: the comment at `programs/store/src/instructions/builder_fee.rs:336` already asserts that "a failed execution charges a zero fee". That was false on `main` and is true again with this change.