### PR TITLE
ci: pass PYTH_API_KEY into the test-programs job

### DIFF
--- a/.github/workflows/ci-programs.yml
+++ b/.github/workflows/ci-programs.yml
@@ -78,6 +78,8 @@ jobs:
       - name: Build programs
         run: just build-test-programs
       - name: "just test-programs (one retry, skip build)"
+        env:
+          PYTH_API_KEY: ${{ secrets.PYTH_API_KEY }}
         run: just test-programs --skip-build || { echo "::warning::first attempt failed, retrying once"; pkill -f solana-test-validator || true; sleep 2; just test-programs --skip-build; }
       - name: Upload anchor logs
         if: failure()


### PR DESCRIPTION
Wires the `PYTH_API_KEY` secret into the step that runs the program tests. Without this the secret exists in repo settings and the tests never see it, so every Hermes call still returns 401.

Two lines, scoped to the one step that needs it rather than to the job or the whole workflow.

### What this does and does not fix

It makes the oracle-driven tests runnable on **`push` to `main` and `v*`**, which is where the post-merge signal comes from.

It does **not** help on pull requests opened from a fork. GitHub does not pass repository secrets to workflows triggered by `pull_request` from a forked repository, and this PR is itself an example: it comes from `crypto1gmt`, so its own `test programs` run will still 401 on the oracle tests. That is expected here, and is not a reason to hold the change.

Switching the trigger to `pull_request_target` would make secrets available to fork PRs, and is deliberately **not** done: it runs with the base repository's secrets in a context a forked branch can influence, which is how a key ends up handed to any PR a stranger opens.

### Note

`ci-programs.yml` already documents this job as advisory ("failures have a structural floor. Treat results as signal, not a gate"), so oracle tests failing on fork PRs stays consistent with how the job is meant to be read.