### PR TITLE
fix(sdk): skip the bundled close when a builder fee will be charged

### DIFF
--- a/crates/sdk/src/client/ops/exchange/order.rs
+++ b/crates/sdk/src/client/ops/exchange/order.rs
@@ -775,6 +775,15 @@ pub struct ExecuteOrderHint {
     store: Arc<Store>,
     market_token: Pubkey,
     position: Option<Pubkey>,
+    /// The order's checkpointed builder fee factor, zero when no fee is
+    /// payable. Written by `set_builder_fee` before execution, so it is
+    /// observable here even though the fee itself is only charged during
+    /// execution.
+    ///
+    /// The factor rather than the builder, because the two disagree: a
+    /// zero-factor checkpoint is how a builder fee is revoked, and it leaves
+    /// the builder set on an order that will never be charged.
+    builder_fee_factor: u128,
     owner: Pubkey,
     receiver: Pubkey,
     rent_receiver: Pubkey,
@@ -882,6 +891,10 @@ where
     }
 
     /// Set whether to close order after execution.
+    ///
+    /// Requesting the close is not a guarantee of one: it is skipped for an
+    /// order carrying a non-zero builder fee factor, whose fee has to be
+    /// settled by `settle_builder_fee` before a close can succeed.
     pub fn close(&mut self, close: bool) -> &mut Self {
         self.close = close;
         self
@@ -924,6 +937,7 @@ where
             store: store.clone(),
             market_token,
             position: optional_address(&params.position).copied(),
+            builder_fee_factor: order.builder_fee_factor,
             owner,
             receiver: order.header.receiver,
             rent_receiver,
@@ -1252,7 +1266,25 @@ where
             execute_order = prepare_event_buffer.merge(execute_order);
         }
 
-        if self.close {
+        // An order that will be charged a builder fee cannot be closed in the
+        // same bundle: execution charges the fee onto the order, and
+        // `CloseOrderV2` rejects a non-zero `builder_fee_amount`
+        // (`CoreError::UnsettledBuilderFee`) so the fee is not swept to the
+        // wrong receiver. Bundling the close would revert the whole execution.
+        // The fee must be settled first via the separate, permissionless
+        // `settle_builder_fee`, so leave the order open here and let the keeper
+        // settle and close it afterwards.
+        //
+        // Gated on the factor and not on `builder`, which stays set through a
+        // revocation: a zero-factor checkpoint charges nothing, so the close
+        // still succeeds and skipping it would strand the order open.
+        //
+        // Narrows the revert rather than removing it. The checkpoint is read
+        // when the bundle is built and `set_builder_fee` stays callable while
+        // the order is pending, so an owner attaching a fee after this read
+        // still reverts the execution. Callers that must not fail on it should
+        // pass `close(false)` and settle and close separately.
+        if self.close && hint.builder_fee_factor == 0 {
             let mut close = self
                 .client
                 .close_order(&self.order)?

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -1820,3 +1820,113 @@ async fn charges_builder_fee_on_execution() -> eyre::Result<()> {
 
     Ok(())
 }
+
+/// An order whose builder fee was revoked must still be closed by the bundled close.
+///
+/// Revocation writes the builder key like any other checkpoint (see `set_builder_fee`, which
+/// asserts the same pair), so the order is left with `builder` set and `builder_fee_factor` at
+/// zero. Nothing is charged, `builder_fee_amount` stays zero, and `CloseOrderV2` therefore
+/// accepts the close. Gating the bundled close on the builder's presence rather than on the
+/// factor skips a close that works and leaves the order open, with no `settle_builder_fee`
+/// command in the CLI to recover it.
+///
+/// Trades as the exclusive locked user: it executes an order and leaves a position behind.
+#[tokio::test]
+async fn revoked_builder_fee_still_closes_in_bundle() -> eyre::Result<()> {
+    /// One percent, in the market factor unit.
+    const CAP: u128 = MARKET_USD_UNIT / 100;
+
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("revoked_builder_fee_still_closes_in_bundle");
+    let _enter = span.enter();
+
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let store = &deployment.store;
+    let oracle = &deployment.oracle();
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    let owner = deployment.locked_user_client().await?;
+
+    let signature = owner.prepare_user(store)?.send_without_preflight().await?;
+    tracing::info!(%signature, "prepared a user account");
+
+    // The revocation checkpoint names the owner's own User Account, which advertises zero. Its
+    // claim vault still has to exist, and minting zero is how the fixture opens an ATA.
+    let owner_user = owner.find_user_address(store, &owner.payer());
+    deployment
+        .mint_or_transfer_to("fBTC", &owner_user, 0)
+        .await?;
+
+    // Deliberately small, for the same reason as the charging test: this market is shared and
+    // the position opened here is left behind.
+    let collateral_amount = 10_000;
+    deployment
+        .mint_or_transfer_to("fBTC", &owner.payer(), collateral_amount)
+        .await?;
+
+    let size = 100 * MARKET_USD_UNIT;
+
+    deployment
+        .with_builder_fee_cap(CAP, async {
+            let (rpc, order) = owner
+                .market_increase(store, market_token, true, collateral_amount, true, size)
+                .prepare_final_output_token_escrow(true)
+                .build_with_address()
+                .await?;
+            let signature = rpc.send().await?;
+            tracing::info!(%order, %signature, "created a fee-eligible increase order");
+
+            // Straight to the revoked state: a zero-advertising account is what clears a
+            // checkpoint, and checkpointing one on a fresh order reaches the same pair without
+            // needing a paying checkpoint first.
+            let signature = owner
+                .set_builder_fee(store, &order, &owner_user, 0, None)
+                .await?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%order, %signature, "checkpointed a zero-advertising account");
+
+            let checkpointed = owner.order(&order).await?;
+            assert_eq!(
+                checkpointed.builder, owner_user,
+                "the checkpoint must leave the builder set, which is what makes this case"
+            );
+            assert_eq!(
+                checkpointed.builder_fee_factor, 0,
+                "the checkpoint must leave nothing payable"
+            );
+
+            // The default bundled close, i.e. what the CLI keeper runs.
+            let mut execution = keeper.execute_order(store, oracle, &order, false)?;
+            deployment
+                .execute_with_pyth(
+                    execution
+                        .add_alt(deployment.common_alt().clone())
+                        .add_alt(deployment.market_alt().clone()),
+                    None,
+                    true,
+                    true,
+                )
+                .await?;
+            tracing::info!(%order, "executed the order with the bundled close");
+
+            let err = owner
+                .order(&order)
+                .await
+                .err()
+                .ok_or_eyre("the bundled close must have closed an order that pays no fee")?;
+            assert!(
+                matches!(err, gmsol_sdk::Error::NotFound),
+                "expected the order account to be absent, got {err:?}"
+            );
+
+            Ok::<_, eyre::Report>(())
+        })
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
> Resubmitted from a branch in this repository so the CI jobs can reach the repo secrets. Supersedes #428, which ran from a fork and therefore never executed the oracle tests.

## What

`ExecuteOrderBuilder` merges a `CloseOrderV2` into the execution bundle by default (`close = true`).
For an order that gets charged a builder fee that reverts the whole execution: execution charges the
fee onto the order, and `CloseOrderV2::validate` rejects a non-zero `builder_fee_amount` with
`UnsettledBuilderFee`. The fee must first be settled through the separate, permissionless
`settle_builder_fee`.

This skips the bundled close when the order's checkpointed builder fee factor is non-zero, leaving
the order open for the keeper to settle and close afterwards. Orders that will not be charged are
unaffected.

## Why it matters

The CLI keeper runs `execute-order` with the bundled close on by default
(`crates/cli/src/commands/exchange/mod.rs:2205`), with no settle in its path, so before this a keeper
executing any fee-bearing order reverted with `UnsettledBuilderFee` unless the operator knew to pass
`--skip-close` and settle and close by hand.

## Change

- `ExecuteOrderHint` carries the order's `builder_fee_factor`, checkpointed by `set_builder_fee`
  before execution so it is observable at build time even though the fee is only charged during
  execution.
- The bundled close is gated on `hint.builder_fee_factor == 0`.
- A test covers the revoked case, which the suite did not reach before.
- `PositionCutBuilder` (liquidation/ADL) is untouched: `is_user_initiated_position` excludes those
  kinds, so `set_builder_fee` rejects them and they can never carry a fee.

## Why the factor and not the builder

`Order.builder` stays set through a revocation. Clearing a checkpoint is done by re-checkpointing
with a User Account that advertises `0`, and that writes the builder key like any other checkpoint.
The result is `builder = Some` with `builder_fee_factor = 0`, where execution charges nothing,
`builder_fee_amount` stays `0`, and the close succeeds. Gating on the builder's presence would skip a
close that works and leave the order open with no fee to settle, and the CLI has no
`settle_builder_fee` command to recover it. The on-chain code draws the same line, gating its
swap-type rule on `factor != 0` for this reason.

That state was already asserted in the suite before this PR: `order::set_builder_fee` checks
`revoked.builder == owner_user` and `revoked.builder_fee_factor == 0` together, so the old gate was
skipping the close for a state the tests already demonstrate is reachable.

## Known residual

The factor is read when the bundle is built, and `set_builder_fee` stays callable while the order is
pending. An owner attaching a fee between that read and the transaction landing still reverts the
execution, exactly as before. Callers that must not fail on it should pass `close(false)` and settle
and close separately.

## Test

`order::charges_builder_fee_on_execution` (added in #421, which merged with CI skipped so it never
ran) already covers the paying case: it relies on the default bundled close and then separately
exercises close-fails / settle / close, so the bundled close must not fire during execution.

`order::revoked_builder_fee_still_closes_in_bundle` is new here and covers the zero-factor case
argued above, which nothing exercised before: it checkpoints a zero-advertising account, executes
with the default bundled close, and asserts the order account is gone.

Oracle tests run in CI on this PR: it is submitted from a branch in this repository, so the
`PYTH_API_KEY` secret is available to the job (a fork PR gets none, which is why the results below
were produced locally). The new test was run both ways locally to confirm it discriminates:

- Old gate (`hint.builder.is_none()`): `FAILED. 0 passed; 1 failed` in 99.95s, on `the bundled close
  must have closed an order that pays no fee`. The order was left open.
- New gate: `ok. 1 passed; 0 failed` in 98.63s.
- Whole module on the new gate: `anchor_test::order` gives `11 passed; 0 failed` in 592.78s,
  including `balanced_market_order` and `single_token_market_order` for the path that must still
  close.
- Before the fix, on `main` `ce245b9f`: `charges_builder_fee_on_execution` FAILED at `Instruction 4:
  custom program error: 0x17f2` (`UnsettledBuilderFee`).
