### PR TITLE
fix(store): reject leaving a disabled virtual inventory from an unassociated market

### DIFF
--- a/programs/store/src/states/market/mod.rs
+++ b/programs/store/src/states/market/mod.rs
@@ -564,6 +564,12 @@ impl Market {
 
     /// Leave a disabled virtual inventory.
     ///
+    /// This market must currently be associated with the given [`VirtualInventory`],
+    /// through either of its two references. Otherwise the `ref_count` would be
+    /// decremented on behalf of a market that never joined, which would let the
+    /// virtual inventory reach zero and be closed while other markets still
+    /// reference it.
+    ///
     /// # CHECK
     /// - The address and the provided [`VirtualInventory`] must match.
     pub fn leave_disabled_virtual_inventory_unchecked(
@@ -580,6 +586,9 @@ impl Market {
             self.virtual_inventory_for_swaps = DEFAULT_PUBKEY;
         } else if self.virtual_inventory_for_positions() == Some(address) {
             self.virtual_inventory_for_positions = DEFAULT_PUBKEY;
+        } else {
+            msg!("the market is not associated with this virtual inventory");
+            return err!(CoreError::PreconditionsAreNotMet);
         }
 
         virtual_inventory.leave_unchecked(Delta::new(None, None))?;
@@ -977,5 +986,121 @@ mod tests {
             .expect("failed to serialize `EventOtherState`");
 
         assert_eq!(data, event_data);
+    }
+
+    /// A disabled [`VirtualInventory`] carrying `ref_count` references.
+    fn disabled_virtual_inventory(ref_count: u32) -> VirtualInventory {
+        use bytemuck::Zeroable;
+
+        let mut virtual_inventory = VirtualInventory::zeroed();
+        for _ in 0..ref_count {
+            virtual_inventory
+                .join_unchecked(Delta::new(None, None))
+                .expect("failed to bump `ref_count`");
+        }
+        virtual_inventory
+            .disable()
+            .expect("failed to disable the virtual inventory");
+        virtual_inventory
+    }
+
+    #[test]
+    fn leave_disabled_virtual_inventory_clears_the_swaps_reference() {
+        let address = Pubkey::new_unique();
+        let mut virtual_inventory = disabled_virtual_inventory(1);
+
+        let mut market = Market::default();
+        market.virtual_inventory_for_swaps = address;
+
+        market
+            .leave_disabled_virtual_inventory_unchecked(&address, &mut virtual_inventory)
+            .expect("an associated market must be allowed to leave");
+
+        assert_eq!(market.virtual_inventory_for_swaps(), None);
+        assert_eq!(virtual_inventory.ref_count(), 0);
+    }
+
+    /// The same instruction serves both kinds, so validating only the swaps
+    /// reference would break every market that joined for positions.
+    #[test]
+    fn leave_disabled_virtual_inventory_clears_the_positions_reference() {
+        let address = Pubkey::new_unique();
+        let mut virtual_inventory = disabled_virtual_inventory(1);
+
+        let mut market = Market::default();
+        market.virtual_inventory_for_positions = address;
+
+        market
+            .leave_disabled_virtual_inventory_unchecked(&address, &mut virtual_inventory)
+            .expect("an associated market must be allowed to leave");
+
+        assert_eq!(market.virtual_inventory_for_positions(), None);
+        assert_eq!(virtual_inventory.ref_count(), 0);
+    }
+
+    /// Regression test for the premature-closure bug: a market that never
+    /// joined must not be able to spend a reference it does not hold.
+    #[test]
+    fn leave_disabled_virtual_inventory_rejects_an_unassociated_market() {
+        let address = Pubkey::new_unique();
+        let mut virtual_inventory = disabled_virtual_inventory(2);
+
+        // A market associated with two other virtual inventories.
+        let other_for_swaps = Pubkey::new_unique();
+        let other_for_positions = Pubkey::new_unique();
+        let mut market = Market::default();
+        market.virtual_inventory_for_swaps = other_for_swaps;
+        market.virtual_inventory_for_positions = other_for_positions;
+
+        let err = market
+            .leave_disabled_virtual_inventory_unchecked(&address, &mut virtual_inventory)
+            .unwrap_err();
+        assert_eq!(err, error!(CoreError::PreconditionsAreNotMet));
+
+        // Neither side moved: the counter still reflects the markets that did join,
+        // and the market keeps the references it actually holds.
+        assert_eq!(virtual_inventory.ref_count(), 2);
+        assert_eq!(market.virtual_inventory_for_swaps(), Some(&other_for_swaps));
+        assert_eq!(
+            market.virtual_inventory_for_positions(),
+            Some(&other_for_positions)
+        );
+    }
+
+    /// The unassociated case also covers a market holding no reference at all.
+    #[test]
+    fn leave_disabled_virtual_inventory_rejects_a_market_without_references() {
+        let address = Pubkey::new_unique();
+        let mut virtual_inventory = disabled_virtual_inventory(1);
+        let mut market = Market::default();
+
+        let err = market
+            .leave_disabled_virtual_inventory_unchecked(&address, &mut virtual_inventory)
+            .unwrap_err();
+        assert_eq!(err, error!(CoreError::PreconditionsAreNotMet));
+        assert_eq!(virtual_inventory.ref_count(), 1);
+    }
+
+    /// The disabled precondition is checked before anything else, so an enabled
+    /// virtual inventory is rejected even for a market that did join it.
+    #[test]
+    fn leave_disabled_virtual_inventory_rejects_an_enabled_virtual_inventory() {
+        use bytemuck::Zeroable;
+
+        let address = Pubkey::new_unique();
+        let mut virtual_inventory = VirtualInventory::zeroed();
+        virtual_inventory
+            .join_unchecked(Delta::new(None, None))
+            .expect("failed to bump `ref_count`");
+
+        let mut market = Market::default();
+        market.virtual_inventory_for_swaps = address;
+
+        let err = market
+            .leave_disabled_virtual_inventory_unchecked(&address, &mut virtual_inventory)
+            .unwrap_err();
+        assert_eq!(err, error!(CoreError::PreconditionsAreNotMet));
+        assert_eq!(virtual_inventory.ref_count(), 1);
+        assert_eq!(market.virtual_inventory_for_swaps(), Some(&address));
     }
 }

--- a/tests/anchor_test/mod.rs
+++ b/tests/anchor_test/mod.rs
@@ -19,6 +19,8 @@ mod market;
 
 mod market_status;
 
+mod virtual_inventory;
+
 mod glv;
 
 mod oracle;

--- a/tests/anchor_test/virtual_inventory.rs
+++ b/tests/anchor_test/virtual_inventory.rs
@@ -1,0 +1,153 @@
+use gmsol_programs::gmsol_store::accounts::VirtualInventory;
+use gmsol_sdk::{
+    client::ops::MarketOps, ops::VirtualInventoryOps, utils::zero_copy::ZeroCopy, Client,
+};
+use gmsol_solana_utils::signer::SignerRef;
+use gmsol_store::CoreError;
+use solana_sdk::pubkey::Pubkey;
+
+use crate::anchor_test::setup::{current_deployment, Deployment};
+
+/// The index of the virtual inventory this test creates. The shared fixture uses
+/// `0` and `1`, so this one is only ever touched here.
+const TEST_VIRTUAL_INVENTORY_INDEX: u32 = 1000;
+
+/// Reads the `ref_count` of a virtual inventory account.
+async fn ref_count(client: &Client<SignerRef>, virtual_inventory: &Pubkey) -> eyre::Result<u32> {
+    let account = client
+        .account::<ZeroCopy<VirtualInventory>>(virtual_inventory)
+        .await?
+        .expect("the virtual inventory must exist");
+    Ok(account.0.ref_count)
+}
+
+/// A market may only leave a disabled virtual inventory it is currently
+/// associated with.
+///
+/// Without the association check, an unrelated market can decrement `ref_count`,
+/// which lets the counter reach zero while other markets still reference the
+/// virtual inventory. It can then be closed underneath them, and every operation
+/// that resolves the reference (deposits, withdrawals, orders, swaps) fails for
+/// markets that did nothing wrong.
+#[tokio::test]
+async fn leave_disabled_virtual_inventory_requires_association() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("leave_disabled_virtual_inventory_requires_association");
+    let _enter = span.enter();
+
+    let store = &deployment.store;
+    let token_map = deployment.token_map();
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+
+    // Both markets are created by this test rather than taken from the fixture.
+    // The other tests run concurrently, and a market that is joined to a virtual
+    // inventory must carry that account in every transaction touching it, so
+    // borrowing a shared market would make unrelated tests fail intermittently.
+    let index_token = deployment.token("fETH").expect("must exist").address;
+    let long_token = deployment.token("USDH").expect("must exist");
+    let short_token = deployment.token("fETH").expect("must exist");
+
+    let mut builder = keeper.bundle();
+
+    let (txn, associated_market_token) = keeper
+        .create_market(
+            store,
+            "VI_ASSOCIATED",
+            &index_token,
+            &long_token.address,
+            &short_token.address,
+            false,
+            Some(&token_map),
+        )
+        .await?;
+    builder.push(txn)?;
+
+    // A different index token, so this is a distinct market: the market token mint
+    // is a PDA over the whole (index, long, short) triple.
+    let (txn, unassociated_market_token) = keeper
+        .create_market(
+            store,
+            "VI_UNASSOCIATED",
+            &long_token.address,
+            &long_token.address,
+            &short_token.address,
+            false,
+            Some(&token_map),
+        )
+        .await?;
+    builder.push(txn)?;
+
+    let (txn, virtual_inventory) = keeper
+        .create_virtual_inventory_for_swaps(
+            store,
+            TEST_VIRTUAL_INVENTORY_INDEX,
+            long_token.config.decimals,
+            short_token.config.decimals,
+        )?
+        .swap_output(());
+    builder.push(txn)?;
+
+    builder
+        .build()?
+        .send_all(false)
+        .await
+        .map_err(|(_, err)| err)?;
+
+    let associated_market = keeper.find_market_address(store, &associated_market_token);
+    let unassociated_market = keeper.find_market_address(store, &unassociated_market_token);
+    tracing::info!(%virtual_inventory, %associated_market, %unassociated_market, "created the test accounts");
+
+    // Associate one of the two markets, then disable the virtual inventory so the
+    // `leave_disabled` path becomes the only way out of it.
+    let signature = keeper
+        .join_virtual_inventory_for_swaps(store, &associated_market, &virtual_inventory, None)
+        .await?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "joined the virtual inventory");
+    assert_eq!(ref_count(&keeper, &virtual_inventory).await?, 1);
+
+    let signature = keeper
+        .disable_virtual_inventory(store, &virtual_inventory)?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "disabled the virtual inventory");
+
+    // The market that never joined must not be able to spend the reference.
+    let err = keeper
+        .leave_disabled_virtual_inventory(store, &unassociated_market, &virtual_inventory)?
+        .send()
+        .await
+        .expect_err("an unassociated market must not be able to leave");
+    assert_eq!(
+        gmsol_sdk::Error::from(err).anchor_error_code(),
+        Some(CoreError::PreconditionsAreNotMet.into())
+    );
+
+    // The rejected call left the counter alone. Had it gone through, the
+    // associated market below would have been unable to leave, and the virtual
+    // inventory could have been closed while still referenced.
+    assert_eq!(ref_count(&keeper, &virtual_inventory).await?, 1);
+
+    // The associated market still leaves normally.
+    let signature = keeper
+        .leave_disabled_virtual_inventory(store, &associated_market, &virtual_inventory)?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "the associated market left the virtual inventory");
+    assert_eq!(ref_count(&keeper, &virtual_inventory).await?, 0);
+
+    let market = keeper.market(&associated_market).await?;
+    assert_eq!(market.virtual_inventory_for_swaps, Default::default());
+
+    // The counter is only zero once nothing references the account, so closing is
+    // now safe.
+    let signature = keeper
+        .close_virtual_inventory_account(store, &virtual_inventory)?
+        .send_without_preflight()
+        .await?;
+    tracing::info!(%signature, "closed the virtual inventory");
+
+    Ok(())
+}


### PR DESCRIPTION
> Resubmitted from a branch in this repository so the CI jobs can reach the repo secrets. Supersedes #422, which ran from a fork and therefore never executed the oracle tests.

`leave_disabled_virtual_inventory` decrements a virtual inventory's `ref_count` without checking that the market is associated with it. The `if / else if` clears the market's reference only when the address matches one of its two slots, while the decrement sits outside the branch and always runs.

A market that never joined can therefore spend a reference it does not hold. The counter reaches zero early, `close_virtual_inventory` (which gates only on `ref_count == 0`) succeeds, and markets still referencing the account are left pointing at nothing. `RevertibleMarket::new` resolves that reference against the accounts supplied with the transaction and returns `InvalidArgument` when it is absent, so those markets then fail deposits, withdrawals, orders and swaps.

## Change

Return `PreconditionsAreNotMet` when the address matches neither reference. That is the same error the two healthy leave paths already raise for a missing reference, so this adds no error code and needs no IDL update.

The condition is "associated through either reference" rather than a copy of the swaps wrapper's `require_keys_eq!`. This instruction serves both virtual inventory kinds through the same branch, so validating a single reference would break the positions case.

## Tests

Five unit tests next to the model method (swaps reference cleared, positions reference cleared, unassociated market rejected, market holding no reference rejected, enabled virtual inventory rejected), plus an integration test in `tests/anchor_test/virtual_inventory.rs`. There were no virtual inventory tests of any kind before this.

The integration test creates its own two markets and its own virtual inventory at an unused index. The fixture markets are shared with tests that run concurrently, and a market joined to a virtual inventory must carry that account in every transaction touching it, so borrowing one would make unrelated tests fail intermittently.

Both halves were checked against a build with the fix reverted, so they demonstrably catch the bug rather than merely pass: the two rejection unit tests fail, and in the integration test the unassociated market's `leave_disabled` succeeds and returns a signature. The integration half now runs: this PR is submitted from a branch in this repository, so the `test programs` job has the `PYTH_API_KEY` secret. Both reasons this PR was previously red are now fixed on `main`: the guardian-set regression by [#423](https://github.com/gmsol-labs/gmx-solana/pull/423) and [#425](https://github.com/gmsol-labs/gmx-solana/pull/425), and the `UnsettledBuilderFee` failure (CON-61) by #430, merged 2026-09-04. Rebased onto that `main`.

## Notes

The existing recovery procedure for an already-damaged virtual inventory is unaffected: the markets it has leave are genuinely associated, so they pass the new check.

No repair step is included because there is nothing to repair. Enumerating every virtual inventory and every market of the store program on devnet (34 markets, 3 virtual inventories) and mainnet-beta (101 markets, 2 virtual inventories) shows `ref_count` matching the number of markets actually referencing each account in every case, and no market referencing an account that no longer exists.
