### PR TITLE
fix(store): drop the builder fee recorded by a discarded execution

### DIFF
--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -903,16 +903,9 @@ pub(crate) type ShouldSendTradeEvent = bool;
 
 /// The amounts an execution computes but must not write to the [`Order`] itself.
 ///
-/// The `Order` is the one piece of state `perform_execution` cannot roll back:
-/// the position, the swap markets and the virtual inventories are all revertible
-/// wrappers that only `commit()` at the end, while the order is passed down as a
-/// plain `&mut Order`, so anything written to it during a failed attempt outlives
-/// that attempt. Carrying these amounts out by value instead of writing them where
-/// they are computed keeps the guarantee that a failed execution leaves the order
-/// untouched, which is what the soft-failure arm relies on.
-///
-/// Both fields are applied together at the irreversible point, after the last
-/// fallible step of the execution has passed.
+/// CHECK: the `Order` is not revertible, unlike the position, the swap markets and
+/// the virtual inventories, so both fields are carried out by value and applied by
+/// the caller at the irreversible point rather than written where they are computed.
 struct ExecutionFees {
     /// Order and borrowing fee value paid, the basis for the GT reward.
     paid_fee_value: u128,
@@ -1077,7 +1070,7 @@ impl ExecuteOrderOperation<'_, '_> {
                     &mut market,
                     &mut swap_markets,
                     &mut transfer_out,
-                    &mut *self.order.load_mut()?,
+                    &*self.order.load()?,
                 )?;
                 market.commit();
                 false
@@ -1139,7 +1132,7 @@ impl ExecuteOrderOperation<'_, '_> {
                             &mut swap_markets,
                             &mut transfer_out,
                             &mut *event_loader.load_mut()?,
-                            &mut *self.order.load_mut()?,
+                            &*self.order.load()?,
                             builder_fee_factor,
                         )?;
                         (false, fees)
@@ -1151,7 +1144,7 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut swap_markets,
                         &mut transfer_out,
                         &mut *event_loader.load_mut()?,
-                        &mut *self.order.load_mut()?,
+                        &*self.order.load()?,
                         true,
                         Some(SecondaryOrderType::Liquidation),
                         builder_fee_factor,
@@ -1163,7 +1156,7 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut swap_markets,
                         &mut transfer_out,
                         &mut *event_loader.load_mut()?,
-                        &mut *self.order.load_mut()?,
+                        &*self.order.load()?,
                         true,
                         Some(SecondaryOrderType::AutoDeleveraging),
                         builder_fee_factor,
@@ -1177,7 +1170,7 @@ impl ExecuteOrderOperation<'_, '_> {
                         &mut swap_markets,
                         &mut transfer_out,
                         &mut *event_loader.load_mut()?,
-                        &mut *self.order.load_mut()?,
+                        &*self.order.load()?,
                         false,
                         None,
                         builder_fee_factor,
@@ -1190,20 +1183,9 @@ impl ExecuteOrderOperation<'_, '_> {
                     .load_mut()?
                     .update_with_transfer_out(&transfer_out)?;
 
-                // The irreversible point: every fallible step of the execution has
-                // passed, and what follows only commits the revertible wrappers. Both
-                // writes below land on accounts that cannot be rolled back, so this is
-                // the only place they are allowed to happen.
-                //
-                // The builder fee goes first because it is the only one of the two
-                // that can still fail without having written anything:
-                // `unchecked_process_gt` mints into the store and the user partway
-                // through, so an overflow raised after it had run would send the
-                // execution into the soft-failure arm with that mint left behind.
-                self.order
-                    .load_mut()?
-                    .record_builder_fee(fees.builder_fee_amount)?;
-
+                // The irreversible point. Both writes below land on accounts that
+                // cannot be rolled back, so they are held until every fallible step
+                // of the execution has passed.
                 if gt_minting_enabled {
                     self.order.load_mut()?.unchecked_process_gt(
                         &mut *self.store.load_mut()?,
@@ -1214,6 +1196,14 @@ impl ExecuteOrderOperation<'_, '_> {
                 } else {
                     msg!("[GT] GT minting is disabled for this market");
                 }
+
+                // Last, because it must be the last fallible call in this function:
+                // everything below only commits the revertible wrappers, and the
+                // fallible `handle_executed` runs outside the soft-failure arm, so a
+                // failure there reverts the transaction instead of discarding it.
+                self.order
+                    .load_mut()?
+                    .record_builder_fee(fees.builder_fee_amount)?;
 
                 position.commit();
                 msg!(
@@ -1566,7 +1556,7 @@ fn execute_swap(
     market: &mut RevertibleMarket<'_, '_>,
     swap_markets: &mut SwapMarkets<'_, '_>,
     transfer_out: &mut TransferOut,
-    order: &mut Order,
+    order: &Order,
 ) -> Result<()> {
     let swap_out_token = order
         .tokens
@@ -1645,7 +1635,7 @@ fn execute_increase_position(
     swap_markets: &mut SwapMarkets<'_, '_>,
     transfer_out: &mut TransferOut,
     event: &mut TradeData,
-    order: &mut Order,
+    order: &Order,
     builder_fee_factor: u128,
 ) -> Result<ExecutionFees> {
     // The builder fee is charged in the order's final output token, so for an increase order that
@@ -1751,8 +1741,6 @@ fn execute_increase_position(
     } else {
         (collateral_increment_amount, 0)
     };
-
-    let params = &order.params;
 
     // Increase position.
     let (long_amount, short_amount, paid_order_fee_value) = {
@@ -1869,7 +1857,7 @@ fn execute_decrease_position(
     swap_markets: &mut SwapMarkets<'_, '_>,
     transfer_out: &mut TransferOut,
     event: &mut TradeData,
-    order: &mut Order,
+    order: &Order,
     is_insolvent_close_allowed: bool,
     secondary_order_type: Option<SecondaryOrderType>,
     builder_fee_factor: u128,

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -951,6 +951,19 @@ impl ExecuteOrderOperation<'_, '_> {
         let mut should_throw_error = false;
         let prices = self.prices()?;
         let discount = self.validate_and_get_order_fee_discount()?;
+
+        // The builder fee is recorded onto the order part-way through
+        // execution, and the order account is not revertible: unlike the
+        // position and the markets, it is passed down as a plain `&mut Order`,
+        // so a soft failure below keeps whatever was written to it while
+        // discarding the `TransferOut` that was supposed to fund the fee.
+        //
+        // Snapshotting here keys the record to the outcome rather than to an
+        // ordering of the fallible steps. Moving the record after the last one
+        // would fix the paths that exist today and silently rot the moment a
+        // new fallible step is added after it.
+        let builder_fee_amount_before = self.order.load()?.builder_fee_amount();
+
         let res = match self.perform_execution(&mut should_throw_error, prices, discount) {
             Ok((should_remove_position, mut transfer_out, should_send_trade_event)) => {
                 transfer_out.set_executed(true);
@@ -959,6 +972,13 @@ impl ExecuteOrderOperation<'_, '_> {
             }
             Err(err) if !(should_throw_error || self.throw_on_execution_error) => {
                 msg!("Execute order error: {}", err);
+                // Everything this attempt produced is dropped here, so the fee
+                // it recorded goes with it. The caller cancels the order and
+                // refunds the principal into the very escrow settlement would
+                // otherwise pay the builder from.
+                self.order
+                    .load_mut()?
+                    .restore_builder_fee_amount(builder_fee_amount_before);
                 remove_position = self
                     .position
                     .as_ref()

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -901,6 +901,25 @@ pub(crate) struct ExecuteOrderOperation<'a, 'info> {
 pub(crate) type RemovePosition = bool;
 pub(crate) type ShouldSendTradeEvent = bool;
 
+/// The amounts an execution computes but must not write to the [`Order`] itself.
+///
+/// The `Order` is the one piece of state `perform_execution` cannot roll back:
+/// the position, the swap markets and the virtual inventories are all revertible
+/// wrappers that only `commit()` at the end, while the order is passed down as a
+/// plain `&mut Order`, so anything written to it during a failed attempt outlives
+/// that attempt. Carrying these amounts out by value instead of writing them where
+/// they are computed keeps the guarantee that a failed execution leaves the order
+/// untouched, which is what the soft-failure arm relies on.
+///
+/// Both fields are applied together at the irreversible point, after the last
+/// fallible step of the execution has passed.
+struct ExecutionFees {
+    /// Order and borrowing fee value paid, the basis for the GT reward.
+    paid_fee_value: u128,
+    /// Builder fee charged, pending settlement.
+    builder_fee_amount: u64,
+}
+
 enum SecondaryOrderType {
     Liquidation,
     AutoDeleveraging,
@@ -951,19 +970,6 @@ impl ExecuteOrderOperation<'_, '_> {
         let mut should_throw_error = false;
         let prices = self.prices()?;
         let discount = self.validate_and_get_order_fee_discount()?;
-
-        // The builder fee is recorded onto the order part-way through
-        // execution, and the order account is not revertible: unlike the
-        // position and the markets, it is passed down as a plain `&mut Order`,
-        // so a soft failure below keeps whatever was written to it while
-        // discarding the `TransferOut` that was supposed to fund the fee.
-        //
-        // Snapshotting here keys the record to the outcome rather than to an
-        // ordering of the fallible steps. Moving the record after the last one
-        // would fix the paths that exist today and silently rot the moment a
-        // new fallible step is added after it.
-        let builder_fee_amount_before = self.order.load()?.builder_fee_amount();
-
         let res = match self.perform_execution(&mut should_throw_error, prices, discount) {
             Ok((should_remove_position, mut transfer_out, should_send_trade_event)) => {
                 transfer_out.set_executed(true);
@@ -972,13 +978,6 @@ impl ExecuteOrderOperation<'_, '_> {
             }
             Err(err) if !(should_throw_error || self.throw_on_execution_error) => {
                 msg!("Execute order error: {}", err);
-                // Everything this attempt produced is dropped here, so the fee
-                // it recorded goes with it. The caller cancels the order and
-                // refunds the principal into the very escrow settlement would
-                // otherwise pay the builder from.
-                self.order
-                    .load_mut()?
-                    .restore_builder_fee_amount(builder_fee_amount_before);
                 remove_position = self
                     .position
                     .as_ref()
@@ -1131,9 +1130,9 @@ impl ExecuteOrderOperation<'_, '_> {
                 // case.
                 let builder_fee_factor = self.order.load()?.builder_fee_factor();
 
-                let (should_remove_position, paid_fee_value) = match kind {
+                let (should_remove_position, fees) = match kind {
                     OrderKind::MarketIncrease | OrderKind::LimitIncrease => {
-                        let paid_fee_value = execute_increase_position(
+                        let fees = execute_increase_position(
                             self.oracle,
                             prices,
                             &mut position,
@@ -1143,7 +1142,7 @@ impl ExecuteOrderOperation<'_, '_> {
                             &mut *self.order.load_mut()?,
                             builder_fee_factor,
                         )?;
-                        (false, paid_fee_value)
+                        (false, fees)
                     }
                     OrderKind::Liquidation => execute_decrease_position(
                         self.oracle,
@@ -1191,11 +1190,25 @@ impl ExecuteOrderOperation<'_, '_> {
                     .load_mut()?
                     .update_with_transfer_out(&transfer_out)?;
 
+                // The irreversible point: every fallible step of the execution has
+                // passed, and what follows only commits the revertible wrappers. Both
+                // writes below land on accounts that cannot be rolled back, so this is
+                // the only place they are allowed to happen.
+                //
+                // The builder fee goes first because it is the only one of the two
+                // that can still fail without having written anything:
+                // `unchecked_process_gt` mints into the store and the user partway
+                // through, so an overflow raised after it had run would send the
+                // execution into the soft-failure arm with that mint left behind.
+                self.order
+                    .load_mut()?
+                    .record_builder_fee(fees.builder_fee_amount)?;
+
                 if gt_minting_enabled {
                     self.order.load_mut()?.unchecked_process_gt(
                         &mut *self.store.load_mut()?,
                         &mut *self.user.load_mut()?,
-                        paid_fee_value,
+                        fees.paid_fee_value,
                         position.event_emitter(),
                     )?;
                 } else {
@@ -1634,7 +1647,7 @@ fn execute_increase_position(
     event: &mut TradeData,
     order: &mut Order,
     builder_fee_factor: u128,
-) -> Result<u128> {
+) -> Result<ExecutionFees> {
     // The builder fee is charged in the order's final output token, so for an increase order that
     // token, and therefore the escrow it is paid out of, must belong to the position's collateral
     // token. Orders created before the final output token was initialized at creation time carry
@@ -1690,7 +1703,7 @@ fn execute_increase_position(
     // `TransferOut`'s final-output-token bucket), so
     // `validate_market_balances` further down does not need to be
     // adjusted to cover it.
-    let collateral_increment_amount = if builder_fee_factor != 0 {
+    let (collateral_increment_amount, builder_fee_amount) = if builder_fee_factor != 0 {
         // Initializing the final output token is optional for increase
         // orders (see `CreateIncreaseOrderOperation`), so an order whose
         // creator did not opt in carries `None` here and cannot pay a fee.
@@ -1717,11 +1730,12 @@ fn execute_increase_position(
                 position.collateral_price(&prices),
             )?;
 
-        // Upholds the conservation invariant. Recorded on the order and
-        // routed into the final output token escrow: the two go together,
-        // since settlement pays the recorded amount out of that escrow.
+        // Upholds the conservation invariant. Routed into the final output
+        // token escrow here, but only returned for recording: the two go
+        // together, since settlement pays the recorded amount out of that
+        // escrow, and `TransferOut` is discarded by the same failure that
+        // must leave the record unwritten.
         transfer_out.transfer_out(false, payable_amount)?;
-        order.record_builder_fee(payable_amount)?;
         position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
             order.header().store(),
             &position.market().market_meta().market_token_mint,
@@ -1733,12 +1747,11 @@ fn execute_increase_position(
             payable_amount.into(),
         )?)?;
 
-        collateral_increment_amount
+        (collateral_increment_amount, payable_amount)
     } else {
-        collateral_increment_amount
+        (collateral_increment_amount, 0)
     };
 
-    // Re-borrowed because recording the fee above took `order` mutably.
     let params = &order.params;
 
     // Increase position.
@@ -1783,7 +1796,10 @@ fn execute_increase_position(
             .map_err(|_| error!(CoreError::TokenAmountOverflow))?,
     )?;
 
-    Ok(paid_order_fee_value)
+    Ok(ExecutionFees {
+        paid_fee_value: paid_order_fee_value,
+        builder_fee_amount,
+    })
 }
 
 /// Folds an estimate of the builder fee, denominated in the collateral
@@ -1857,7 +1873,7 @@ fn execute_decrease_position(
     is_insolvent_close_allowed: bool,
     secondary_order_type: Option<SecondaryOrderType>,
     builder_fee_factor: u128,
-) -> Result<(RemovePosition, u128)> {
+) -> Result<(RemovePosition, ExecutionFees)> {
     // Decrease position.
     let report = {
         let params = &order.params;
@@ -1957,6 +1973,11 @@ fn execute_decrease_position(
     };
     let should_remove_position = report.should_remove();
 
+    // Charged inside the swap block below, but carried out to the caller
+    // rather than written to `order` there: the steps that follow it can
+    // still fail, and the order is not revertible.
+    let mut builder_fee_amount = 0u64;
+
     // Perform swaps.
     {
         require!(
@@ -2002,7 +2023,7 @@ fn execute_decrease_position(
         )?;
 
         // Builder fee is charged in the final output token, after the
-        // receive-token swap above. It is only *recorded* here, never
+        // receive-token swap above. It is only *computed* here, never
         // netted out of `output_amount`: the full output amount is routed
         // into the final-output-token bucket as usual, so the fee value
         // physically lands in the order's escrow alongside the user's
@@ -2047,9 +2068,8 @@ fn execute_decrease_position(
             //
             // `paid_amount` is clamped to `output_amount`, a `u64`, so the
             // conversion cannot fail.
-            let recorded_amount =
+            builder_fee_amount =
                 u64::try_from(paid_amount).map_err(|_| error!(CoreError::TokenAmountOverflow))?;
-            order.record_builder_fee(recorded_amount)?;
 
             position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
                 order.header().store(),
@@ -2138,7 +2158,13 @@ fn execute_decrease_position(
             report,
         ))?;
 
-    Ok((should_remove_position, paid_fee_value))
+    Ok((
+        should_remove_position,
+        ExecutionFees {
+            paid_fee_value,
+            builder_fee_amount,
+        },
+    ))
 }
 
 /// Position Cut Operation.

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1183,27 +1183,42 @@ impl ExecuteOrderOperation<'_, '_> {
                     .load_mut()?
                     .update_with_transfer_out(&transfer_out)?;
 
-                // The irreversible point. Both writes below land on accounts that
-                // cannot be rolled back, so they are held until every fallible step
-                // of the execution has passed.
-                if gt_minting_enabled {
-                    self.order.load_mut()?.unchecked_process_gt(
-                        &mut *self.store.load_mut()?,
-                        &mut *self.user.load_mut()?,
-                        fees.paid_fee_value,
-                        position.event_emitter(),
-                    )?;
+                // Overflow is checked here, while a failure is still discarded
+                // cleanly, so that the write itself cannot fail. `None` when
+                // nothing was charged, which keeps a fee-less execution from
+                // touching the field at all.
+                let next_builder_fee_amount = if fees.builder_fee_amount == 0 {
+                    None
                 } else {
-                    msg!("[GT] GT minting is disabled for this market");
-                }
+                    Some(
+                        self.order
+                            .load()?
+                            .builder_fee_amount_after(fees.builder_fee_amount)?,
+                    )
+                };
 
-                // Last, because it must be the last fallible call in this function:
-                // everything below only commits the revertible wrappers, and the
-                // fallible `handle_executed` runs outside the soft-failure arm, so a
-                // failure there reverts the transaction instead of discarding it.
-                self.order
-                    .load_mut()?
-                    .record_builder_fee(fees.builder_fee_amount)?;
+                // The irreversible point. Neither account below is revertible, so
+                // both writes wait until every fallible step has passed, and the
+                // builder fee goes last because it is the only one that cannot
+                // fail: a GT failure here still leaves the order untouched.
+                {
+                    let mut order = self.order.load_mut()?;
+
+                    if gt_minting_enabled {
+                        order.unchecked_process_gt(
+                            &mut *self.store.load_mut()?,
+                            &mut *self.user.load_mut()?,
+                            fees.paid_fee_value,
+                            position.event_emitter(),
+                        )?;
+                    } else {
+                        msg!("[GT] GT minting is disabled for this market");
+                    }
+
+                    if let Some(amount) = next_builder_fee_amount {
+                        order.set_builder_fee_amount(amount);
+                    }
+                }
 
                 position.commit();
                 msg!(

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -909,8 +909,32 @@ pub(crate) type ShouldSendTradeEvent = bool;
 struct ExecutionFees {
     /// Order and borrowing fee value paid, the basis for the GT reward.
     paid_fee_value: u128,
-    /// Builder fee charged, pending settlement.
-    builder_fee_amount: u64,
+    /// The builder fee charge, pending both its record and its announcement.
+    ///
+    /// `None` only when the order carries no builder fee factor. A factor that
+    /// clamps to a zero payment still yields `Some`, because the event's contract
+    /// is that its presence separates "no builder attached" from "builder attached,
+    /// nothing collectible".
+    builder_fee: Option<BuilderFeeCharge>,
+}
+
+/// A builder fee that has been computed but neither recorded nor announced yet.
+///
+/// CHECK: carried by value for the same reason as the rest of [`ExecutionFees`], and
+/// the event is carried for one more. `emit_cpi` is a self-CPI, so the moment it
+/// returns, the event sits in the transaction's inner instructions and a later `Err`
+/// swallowed by the soft-failure arm cannot take it back, exactly as a write to the
+/// non-revertible `Order` cannot be taken back. Announcing a charge that the order
+/// never records is therefore the same defect as recording one that was never funded,
+/// pointed the other way, and it is what this type exists to prevent.
+struct BuilderFeeCharge {
+    /// The token the fee is denominated and paid in.
+    token: Pubkey,
+    /// The computed amount, before shortfall clamping.
+    payable_amount: u128,
+    /// The amount actually charged, after shortfall clamping. Already narrowed, so
+    /// that the conversion cannot fail at the irreversible point.
+    paid_amount: u64,
 }
 
 enum SecondaryOrderType {
@@ -1186,15 +1210,16 @@ impl ExecuteOrderOperation<'_, '_> {
                 // Overflow is checked here, while a failure is still discarded
                 // cleanly, so that the write itself cannot fail. `None` when
                 // nothing was charged, which keeps a fee-less execution from
-                // touching the field at all.
-                let next_builder_fee_amount = if fees.builder_fee_amount == 0 {
-                    None
-                } else {
-                    Some(
+                // touching the field at all. Note this is not the same condition
+                // as the event's: a factor that clamps to a zero payment records
+                // nothing and still announces itself.
+                let next_builder_fee_amount = match &fees.builder_fee {
+                    Some(charge) if charge.paid_amount != 0 => Some(
                         self.order
                             .load()?
-                            .builder_fee_amount_after(fees.builder_fee_amount)?,
-                    )
+                            .builder_fee_amount_after(charge.paid_amount)?,
+                    ),
+                    _ => None,
                 };
 
                 // The irreversible point. Neither account below is revertible, so
@@ -1213,6 +1238,32 @@ impl ExecuteOrderOperation<'_, '_> {
                         )?;
                     } else {
                         msg!("[GT] GT minting is disabled for this market");
+                    }
+
+                    // Announced here rather than where it was computed, because
+                    // `emit_cpi` is a self-CPI: once it returns the event is in
+                    // the transaction and the soft-failure arm cannot take it
+                    // back, so emitting early announces charges that a later
+                    // failure then discards.
+                    //
+                    // Sits immediately before the write and after GT on purpose.
+                    // The emit is the only fallible step left, and the write
+                    // below cannot fail, so a successful emit is always followed
+                    // by its record: the event and the recorded amount cannot
+                    // disagree. The residual is the reverse pair, an `Err` from
+                    // the emit leaving GT processed for an execution that then
+                    // cancels. That is the narrower exposure of the two, since a
+                    // self-CPI failing is not reachable through ordinary business
+                    // outcomes the way the min-output rejection below the old
+                    // emit site was.
+                    if let Some(charge) = &fees.builder_fee {
+                        position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
+                            order.header().store(),
+                            &position.market().market_meta().market_token_mint,
+                            &charge.token,
+                            charge.payable_amount,
+                            charge.paid_amount.into(),
+                        )?)?;
                     }
 
                     if let Some(amount) = next_builder_fee_amount {
@@ -1708,7 +1759,7 @@ fn execute_increase_position(
     // `TransferOut`'s final-output-token bucket), so
     // `validate_market_balances` further down does not need to be
     // adjusted to cover it.
-    let (collateral_increment_amount, builder_fee_amount) = if builder_fee_factor != 0 {
+    let (collateral_increment_amount, builder_fee) = if builder_fee_factor != 0 {
         // Initializing the final output token is optional for increase
         // orders (see `CreateIncreaseOrderOperation`), so an order whose
         // creator did not opt in carries `None` here and cannot pay a fee.
@@ -1741,20 +1792,20 @@ fn execute_increase_position(
         // escrow, and `TransferOut` is discarded by the same failure that
         // must leave the record unwritten.
         transfer_out.transfer_out(false, payable_amount)?;
-        position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
-            order.header().store(),
-            &position.market().market_meta().market_token_mint,
-            position.collateral_token(),
-            payable_amount.into(),
-            // Underpayment errors out above rather than charging a partial
-            // amount, so the paid amount always equals the payable amount
-            // here.
-            payable_amount.into(),
-        )?)?;
 
-        (collateral_increment_amount, payable_amount)
+        (
+            collateral_increment_amount,
+            Some(BuilderFeeCharge {
+                token: *position.collateral_token(),
+                payable_amount: payable_amount.into(),
+                // Underpayment errors out above rather than charging a partial
+                // amount, so the paid amount always equals the payable amount
+                // here.
+                paid_amount: payable_amount,
+            }),
+        )
     } else {
-        (collateral_increment_amount, 0)
+        (collateral_increment_amount, None)
     };
 
     // Increase position.
@@ -1801,7 +1852,7 @@ fn execute_increase_position(
 
     Ok(ExecutionFees {
         paid_fee_value: paid_order_fee_value,
-        builder_fee_amount,
+        builder_fee,
     })
 }
 
@@ -1977,9 +2028,10 @@ fn execute_decrease_position(
     let should_remove_position = report.should_remove();
 
     // Charged inside the swap block below, but carried out to the caller
-    // rather than written to `order` there: the steps that follow it can
-    // still fail, and the order is not revertible.
-    let mut builder_fee_amount = 0u64;
+    // rather than written to `order` or announced there: the steps that follow
+    // it can still fail, the order is not revertible, and an emitted event is
+    // not retractable either.
+    let mut builder_fee = None;
 
     // Perform swaps.
     {
@@ -2071,16 +2123,12 @@ fn execute_decrease_position(
             //
             // `paid_amount` is clamped to `output_amount`, a `u64`, so the
             // conversion cannot fail.
-            builder_fee_amount =
-                u64::try_from(paid_amount).map_err(|_| error!(CoreError::TokenAmountOverflow))?;
-
-            position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
-                order.header().store(),
-                &position.market().market_meta().market_token_mint,
-                &final_output_token,
+            builder_fee = Some(BuilderFeeCharge {
+                token: final_output_token,
                 payable_amount,
-                paid_amount,
-            )?)?;
+                paid_amount: u64::try_from(paid_amount)
+                    .map_err(|_| error!(CoreError::TokenAmountOverflow))?,
+            });
         }
 
         order.validate_decrease_output_amounts(
@@ -2165,7 +2213,7 @@ fn execute_decrease_position(
         should_remove_position,
         ExecutionFees {
             paid_fee_value,
-            builder_fee_amount,
+            builder_fee,
         },
     ))
 }

--- a/programs/store/src/ops/order.rs
+++ b/programs/store/src/ops/order.rs
@@ -1247,23 +1247,32 @@ impl ExecuteOrderOperation<'_, '_> {
                     // failure then discards.
                     //
                     // Sits immediately before the write and after GT on purpose.
-                    // The emit is the only fallible step left, and the write
-                    // below cannot fail, so a successful emit is always followed
-                    // by its record: the event and the recorded amount cannot
-                    // disagree. The residual is the reverse pair, an `Err` from
-                    // the emit leaving GT processed for an execution that then
-                    // cancels. That is the narrower exposure of the two, since a
-                    // self-CPI failing is not reachable through ordinary business
-                    // outcomes the way the min-output rejection below the old
-                    // emit site was.
+                    // The write below cannot fail, so an emitted event is always
+                    // followed by its record and the two cannot disagree.
+                    //
+                    // Panics rather than propagating, which is what makes that
+                    // hold in both directions. A `?` here would be swallowed by
+                    // the soft-failure arm and committed, leaving the GT minted
+                    // above standing for an execution that then cancels; a panic
+                    // aborts the transaction, so nothing in this block outlives a
+                    // failure in it. Neither call is reachable in practice:
+                    // `BuilderFeeCharged::new` fails only if `Clock::get` does,
+                    // and `emit_cpi` only if the self-CPI does. The point of
+                    // spelling it `expect` is that a reader can see at a glance
+                    // that no fallible-and-swallowed step remains past this line.
                     if let Some(charge) = &fees.builder_fee {
-                        position.event_emitter().emit_cpi(&BuilderFeeCharged::new(
+                        let event = BuilderFeeCharged::new(
                             order.header().store(),
                             &position.market().market_meta().market_token_mint,
                             &charge.token,
                             charge.payable_amount,
                             charge.paid_amount.into(),
-                        )?)?;
+                        )
+                        .expect("clock is always available");
+                        position
+                            .event_emitter()
+                            .emit_cpi(&event)
+                            .expect("emitting the builder fee event must not be swallowed");
                     }
 
                     if let Some(amount) = next_builder_fee_amount {

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -624,33 +624,16 @@ impl Order {
     ///
     /// CHECK: the caller must have routed the same amount into the order's
     /// final output token escrow, since settlement pays the recorded
-    /// amount out of that escrow.
+    /// amount out of that escrow, and must call this only once the
+    /// execution that charged the amount can no longer fail. This account
+    /// is not revertible, so a record written by an attempt that is then
+    /// discarded outlives the `TransferOut` that was to fund it.
     pub(crate) fn record_builder_fee(&mut self, amount: u64) -> Result<()> {
         self.builder_fee_amount = self
             .builder_fee_amount
             .checked_add(amount)
             .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
         Ok(())
-    }
-
-    /// Restore the recorded builder fee amount to a previously observed value.
-    ///
-    /// The undo half of [`record_builder_fee`](Self::record_builder_fee),
-    /// for the soft-failure path. The order account is not revertible, so a
-    /// fee recorded by an execution attempt that is then discarded survives
-    /// it, payable out of an escrow the same failure refunded to the owner
-    /// rather than funded.
-    ///
-    /// Takes the previous value instead of zeroing, because the field
-    /// accumulates by contract. Restoring is therefore correct without
-    /// depending on an order being executable at most once, which is what
-    /// makes a prior unsettled charge unreachable today.
-    ///
-    /// CHECK: the caller must be discarding every output of the attempt that
-    /// recorded the amount, so that nothing was routed into the escrow to
-    /// cover it.
-    pub(crate) fn restore_builder_fee_amount(&mut self, amount: u64) {
-        self.builder_fee_amount = amount;
     }
 
     /// Checkpoint a builder and its fee factor onto this order.

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -615,25 +615,31 @@ impl Order {
         self.builder_fee_amount
     }
 
-    /// Record a builder fee amount charged during execution, adding it to
-    /// the amount pending settlement.
+    /// The amount pending settlement after charging `amount` on top of it.
     ///
     /// Accumulates rather than overwrites: the field is the total charged
     /// so far, and `settle_builder_fee` is what zeroes it once the amount
     /// has been paid out to the builder.
     ///
-    /// CHECK: the caller must have routed the same amount into the order's
-    /// final output token escrow, since settlement pays the recorded
-    /// amount out of that escrow, and must call this only once the
-    /// execution that charged the amount can no longer fail. This account
-    /// is not revertible, so a record written by an attempt that is then
-    /// discarded outlives the `TransferOut` that was to fund it.
-    pub(crate) fn record_builder_fee(&mut self, amount: u64) -> Result<()> {
-        self.builder_fee_amount = self
-            .builder_fee_amount
+    /// Split from the write so the overflow check can run while the
+    /// execution is still discardable, leaving [`Self::set_builder_fee_amount`]
+    /// infallible.
+    pub(crate) fn builder_fee_amount_after(&self, amount: u64) -> Result<u64> {
+        self.builder_fee_amount
             .checked_add(amount)
-            .ok_or_else(|| error!(CoreError::TokenAmountOverflow))?;
-        Ok(())
+            .ok_or_else(|| error!(CoreError::TokenAmountOverflow))
+    }
+
+    /// Record a builder fee amount charged during execution.
+    ///
+    /// CHECK: `amount` must come from [`Self::builder_fee_amount_after`], which
+    /// is where the overflow check lives, and the caller must have routed the
+    /// charged amount into the order's final output token escrow, since
+    /// settlement pays the recorded amount out of that escrow. This account is
+    /// not revertible, so the write must come after everything that can still
+    /// fail; it is infallible so that it can be that last step.
+    pub(crate) fn set_builder_fee_amount(&mut self, amount: u64) {
+        self.builder_fee_amount = amount;
     }
 
     /// Checkpoint a builder and its fee factor onto this order.
@@ -1134,8 +1140,8 @@ mod tests {
     #[test]
     fn recorded_builder_fee_amounts_accumulate() {
         let mut order: Order = bytemuck::Zeroable::zeroed();
-        order.record_builder_fee(25).unwrap();
-        order.record_builder_fee(17).unwrap();
+        order.set_builder_fee_amount(order.builder_fee_amount_after(25).unwrap());
+        order.set_builder_fee_amount(order.builder_fee_amount_after(17).unwrap());
         // The field is the total charged so far, so a second charge adds
         // to the first rather than replacing it.
         assert_eq!(order.builder_fee_amount(), 42);
@@ -1180,10 +1186,11 @@ mod tests {
     #[test]
     fn recording_a_builder_fee_rejects_overflow() {
         let mut order: Order = bytemuck::Zeroable::zeroed();
-        order.record_builder_fee(u64::MAX).unwrap();
-        let err = order.record_builder_fee(1).unwrap_err();
+        order.set_builder_fee_amount(order.builder_fee_amount_after(u64::MAX).unwrap());
+        let err = order.builder_fee_amount_after(1).unwrap_err();
         assert_eq!(err, error!(CoreError::TokenAmountOverflow));
-        // The rejected charge leaves the recorded amount untouched.
+        // The overflow is caught before anything is written, so the recorded
+        // amount is untouched.
         assert_eq!(order.builder_fee_amount(), u64::MAX);
     }
 }

--- a/programs/store/src/states/order.rs
+++ b/programs/store/src/states/order.rs
@@ -633,6 +633,26 @@ impl Order {
         Ok(())
     }
 
+    /// Restore the recorded builder fee amount to a previously observed value.
+    ///
+    /// The undo half of [`record_builder_fee`](Self::record_builder_fee),
+    /// for the soft-failure path. The order account is not revertible, so a
+    /// fee recorded by an execution attempt that is then discarded survives
+    /// it, payable out of an escrow the same failure refunded to the owner
+    /// rather than funded.
+    ///
+    /// Takes the previous value instead of zeroing, because the field
+    /// accumulates by contract. Restoring is therefore correct without
+    /// depending on an order being executable at most once, which is what
+    /// makes a prior unsettled charge unreachable today.
+    ///
+    /// CHECK: the caller must be discarding every output of the attempt that
+    /// recorded the amount, so that nothing was routed into the escrow to
+    /// cover it.
+    pub(crate) fn restore_builder_fee_amount(&mut self, amount: u64) {
+        self.builder_fee_amount = amount;
+    }
+
     /// Checkpoint a builder and its fee factor onto this order.
     ///
     /// The only writer of either field. Every validation the checkpoint depends

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -2098,3 +2098,211 @@ async fn soft_failed_execution_records_no_builder_fee() -> eyre::Result<()> {
 
     Ok(())
 }
+
+/// A decrease order that executes successfully must record the builder fee it charged.
+///
+/// The counterpart to [`soft_failed_execution_records_no_builder_fee`]. That test pins the failure
+/// path, where nothing may be recorded; this one pins the success path through the same code, where
+/// the amount has to survive. Only the pair is a real check: an assertion that a soft failure
+/// records zero is equally satisfied by a decrease path that records nothing at all, so moving where
+/// the fee is written to the order could pay builders nothing on every decrease order and still
+/// leave the suite green.
+///
+/// The increase path already has both halves (`charges_builder_fee_on_execution` is its success
+/// half). The decrease path had only the zero.
+///
+/// The bundled close is left enabled, which is the realistic keeper path: the checkpointed factor is
+/// non-zero, so the close guard skips it and the order survives execution carrying the fee. That is
+/// the same gate `revoked_builder_fee_still_closes_in_bundle` covers from the other side.
+///
+/// Trades as the exclusive locked user: it needs a position of its own, and it takes that lock
+/// before the builder fee globals, matching the tests above; no test takes them in the opposite
+/// order.
+#[tokio::test]
+async fn decrease_execution_records_builder_fee() -> eyre::Result<()> {
+    /// One percent, in the market factor unit.
+    const CAP: u128 = MARKET_USD_UNIT / 100;
+
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("decrease_execution_records_builder_fee");
+    let _enter = span.enter();
+
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let builder = deployment.user_client(Deployment::USER_1)?;
+    let store = &deployment.store;
+    let oracle = &deployment.oracle();
+    let fbtc = deployment.token("fBTC").expect("must exist");
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    let owner = deployment.locked_user_client().await?;
+
+    for signature in [
+        owner.prepare_user(store)?.send_without_preflight().await?,
+        builder
+            .prepare_user(store)?
+            .send_without_preflight()
+            .await?,
+    ] {
+        tracing::info!(%signature, "prepared a user account");
+    }
+
+    // `set_builder_fee` requires the claim vault to exist, and settlement below pays into it.
+    let builder_user = builder.find_user_address(store, &builder.payer());
+    deployment
+        .mint_or_transfer_to("fBTC", &builder_user, 0)
+        .await?;
+
+    // Deliberately small: this market is shared with the other order tests, so the position opened
+    // here keeps its footprint on open interest and pool balances negligible. It is closed again by
+    // the decrease order below.
+    let collateral_amount = 10_000;
+    deployment
+        .mint_or_transfer_to("fBTC", &owner.payer(), collateral_amount * 2)
+        .await?;
+
+    let size = 100 * MARKET_USD_UNIT;
+    let (rpc, increase) = owner
+        .market_increase(store, market_token, true, collateral_amount, true, size)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%increase, %signature, "created the increase order");
+
+    let mut execution = keeper.execute_order(store, oracle, &increase, false)?;
+    deployment
+        .execute_with_pyth(
+            execution
+                .add_alt(deployment.common_alt().clone())
+                .add_alt(deployment.market_alt().clone()),
+            None,
+            true,
+            true,
+        )
+        .await?;
+    tracing::info!(%increase, "executed the increase order, opening the position");
+
+    // A full close, so the whole collateral is released and the fee computed from the executed size
+    // is comfortably covered by the output amount it is clamped against. The minimum output is left
+    // at its default, which is the only thing separating this from the soft-failure case.
+    let (rpc, order) = owner
+        .market_decrease(store, market_token, true, 0, true, size)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created the decrease order");
+
+    deployment
+        .with_builder_fee_cap(CAP, async {
+            let signature = builder
+                .set_builder_fee_factor(store, CAP)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder advertised its factor");
+
+            let signature = owner
+                .set_builder_fee(store, &order, &builder_user, CAP, None)
+                .await?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%order, %signature, "checkpointed the builder fee onto the decrease order");
+
+            let claim_vault_before = deployment
+                .get_ata_amount(&fbtc.address, &builder_user)
+                .await?
+                .ok_or_eyre("the claim vault must exist")?;
+
+            // `false` throws on an execution error instead of cancelling, so a failure here is loud
+            // rather than turning into the neighbouring test's scenario.
+            let mut execution = keeper.execute_order(store, oracle, &order, false)?;
+            deployment
+                .execute_with_pyth(
+                    execution
+                        .add_alt(deployment.common_alt().clone())
+                        .add_alt(deployment.market_alt().clone()),
+                    None,
+                    true,
+                    true,
+                )
+                .await?;
+            tracing::info!(%order, "executed the decrease order");
+
+            let executed = owner.order(&order).await?;
+
+            // Without this the non-zero assertion below could be met by an order that never
+            // executed at all, which is the one way this could go quietly vacuous.
+            assert!(
+                matches!(executed.header.action_state()?, ActionState::Completed),
+                "the execution must have completed, not been cancelled"
+            );
+
+            let pending_amount = executed.builder_fee_amount;
+            assert_ne!(
+                pending_amount, 0,
+                "a decrease execution that succeeded must record the fee it charged"
+            );
+            assert_eq!(executed.builder, builder_user);
+
+            // The event is emitted where the fee is computed and the record is written at the end of
+            // the execution, so these two agreeing is a check on the amount surviving the distance
+            // between them, not a restatement.
+            let charged = last_builder_fee_charged(&keeper, &order).await?;
+            assert_eq!(
+                charged.paid_amount,
+                u128::from(pending_amount),
+                "the recorded amount must be the one the event reported as paid"
+            );
+            assert_eq!(charged.token, fbtc.address);
+
+            // The recorded fee blocks the close until it is settled, same as on the increase path.
+            let err = owner
+                .close_order(&order)?
+                .build()
+                .await?
+                .send()
+                .await
+                .expect_err("should reject closing an order with an unsettled builder fee");
+            assert_eq!(
+                gmsol_sdk::Error::from(err).anchor_error_code(),
+                Some(CoreError::UnsettledBuilderFee.into()),
+            );
+
+            let signature = keeper
+                .settle_builder_fee(store, &order, None)
+                .await?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%order, %signature, "settled the builder fee");
+
+            assert_eq!(
+                owner.order(&order).await?.builder_fee_amount,
+                0,
+                "settlement must clear the pending amount"
+            );
+            assert_eq!(
+                deployment
+                    .get_ata_amount(&fbtc.address, &builder_user)
+                    .await?,
+                Some(claim_vault_before + pending_amount),
+                "the settled fee must land in the builder's claim vault"
+            );
+
+            // Closable once nothing is pending.
+            let signature = owner.close_order(&order)?.build().await?.send().await?;
+            tracing::info!(%order, %signature, "closed the settled order");
+
+            let signature = builder
+                .set_builder_fee_factor(store, 0)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder opted back out");
+
+            Ok::<_, eyre::Report>(())
+        })
+        .await?;
+
+    Ok(())
+}

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -20,7 +20,7 @@ use gmsol_sdk::{
 };
 use gmsol_solana_utils::signer::SignerRef;
 use gmsol_store::CoreError;
-use gmsol_utils::{config::FactorKey, market::MarketConfigKey};
+use gmsol_utils::{action::ActionState, config::FactorKey, market::MarketConfigKey};
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use tracing::Instrument;
 
@@ -1923,6 +1923,174 @@ async fn revoked_builder_fee_still_closes_in_bundle() -> eyre::Result<()> {
                 matches!(err, gmsol_sdk::Error::NotFound),
                 "expected the order account to be absent, got {err:?}"
             );
+
+            Ok::<_, eyre::Report>(())
+        })
+        .await?;
+
+    Ok(())
+}
+
+/// An execution that soft-fails must leave no builder fee recorded on the order.
+///
+/// The fee is written to the `Order` account part-way through execution, and that account is not
+/// revertible: `perform_execution` takes it as a plain `&mut Order`, unlike the position and the
+/// markets. When a later step fails and the keeper opted into cancellation, the `TransferOut` that
+/// was supposed to fund the fee is discarded while the record survives it, leaving an amount payable
+/// out of an escrow nothing was routed into. The order is then refused by every close path until
+/// someone calls `settle_builder_fee`, and on the increase path the principal refunded by the same
+/// cancellation lands in the very escrow settlement pays from.
+///
+/// The lever is a decrease order with an unreachable `min_output_amount`, which fails
+/// `validate_decrease_output_amounts` after the fee has been recorded, with `should_throw_error`
+/// left `false` so the failure lands in the soft-failure arm rather than reverting the transaction.
+/// The decrease path is used because that minimum is a parameter the test controls; the increase
+/// path reaches the same arm only through a market condition.
+///
+/// Executes with the bundled close disabled, so the assertion lands on the recorded amount itself
+/// rather than on the close guard tripping. Closing is then exercised separately, since being unable
+/// to close without an extra settlement is the user-visible half of the defect.
+///
+/// Trades as the exclusive locked user: it needs a position of its own, and the position for
+/// [`Deployment::DEFAULT_USER`] on this market is opened and closed by `balanced_market_order`
+/// running concurrently. It takes that lock before the builder fee globals, matching
+/// `set_builder_fee_rejects_collateral_to_pnl_swap`; no test takes them in the opposite order.
+#[tokio::test]
+async fn soft_failed_execution_records_no_builder_fee() -> eyre::Result<()> {
+    /// One percent, in the market factor unit.
+    const CAP: u128 = MARKET_USD_UNIT / 100;
+
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("soft_failed_execution_records_no_builder_fee");
+    let _enter = span.enter();
+
+    let keeper = deployment.user_client(Deployment::DEFAULT_KEEPER)?;
+    let builder = deployment.user_client(Deployment::USER_1)?;
+    let store = &deployment.store;
+    let oracle = &deployment.oracle();
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    let owner = deployment.locked_user_client().await?;
+
+    for signature in [
+        owner.prepare_user(store)?.send_without_preflight().await?,
+        builder
+            .prepare_user(store)?
+            .send_without_preflight()
+            .await?,
+    ] {
+        tracing::info!(%signature, "prepared a user account");
+    }
+
+    // `set_builder_fee` requires the claim vault to exist, even though nothing is ever settled here.
+    let builder_user = builder.find_user_address(store, &builder.payer());
+    deployment
+        .mint_or_transfer_to("fBTC", &builder_user, 0)
+        .await?;
+
+    // Deliberately small: this market is shared with the other order tests and the position opened
+    // here is left behind, so it keeps its footprint on open interest and pool balances negligible.
+    let collateral_amount = 10_000;
+    deployment
+        .mint_or_transfer_to("fBTC", &owner.payer(), collateral_amount * 2)
+        .await?;
+
+    let size = 100 * MARKET_USD_UNIT;
+    let (rpc, increase) = owner
+        .market_increase(store, market_token, true, collateral_amount, true, size)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%increase, %signature, "created the increase order");
+
+    let mut execution = keeper.execute_order(store, oracle, &increase, false)?;
+    deployment
+        .execute_with_pyth(
+            execution
+                .add_alt(deployment.common_alt().clone())
+                .add_alt(deployment.market_alt().clone()),
+            None,
+            true,
+            true,
+        )
+        .await?;
+    tracing::info!(%increase, "executed the increase order, opening the position");
+
+    // A full close, so the whole collateral is released and the fee computed from the executed size
+    // is comfortably covered by the output amount it is clamped against. The minimum output is what
+    // makes the execution fail, after that fee has been recorded. The swap type is left at its
+    // default: `CollateralToPnlToken` is refused a non-zero checkpoint outright.
+    let (rpc, order) = owner
+        .market_decrease(store, market_token, true, 0, true, size)
+        .min_output_amount(u128::MAX)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created a decrease order that cannot meet its minimum output");
+
+    deployment
+        .with_builder_fee_cap(CAP, async {
+            let signature = builder
+                .set_builder_fee_factor(store, CAP)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder advertised its factor");
+
+            let signature = owner
+                .set_builder_fee(store, &order, &builder_user, CAP, None)
+                .await?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%order, %signature, "checkpointed the builder fee onto the decrease order");
+
+            let before = owner.order(&order).await?;
+            assert_eq!(before.builder_fee_factor, CAP);
+            let recorded_before = before.builder_fee_amount;
+
+            // `true` opts into cancellation, which is what routes the failure into the soft-failure
+            // arm instead of reverting the whole transaction and with it the record.
+            let mut execution = keeper.execute_order(store, oracle, &order, true)?;
+            deployment
+                .execute_with_pyth(
+                    execution
+                        .close(false)
+                        .add_alt(deployment.common_alt().clone())
+                        .add_alt(deployment.market_alt().clone()),
+                    None,
+                    true,
+                    true,
+                )
+                .await?;
+            tracing::info!(%order, "executed the decrease order, which must have soft-failed");
+
+            let executed = owner.order(&order).await?;
+
+            // Without this the test would also pass on a successful execution that happened to
+            // charge nothing, which is the one way it could go quietly vacuous.
+            assert!(
+                matches!(executed.header.action_state()?, ActionState::Cancelled),
+                "the execution must have failed and cancelled the order, not completed it"
+            );
+
+            assert_eq!(
+                executed.builder_fee_amount, recorded_before,
+                "a discarded execution must leave the recorded builder fee untouched"
+            );
+
+            // The other half of the defect: the close guard refuses any order carrying a recorded
+            // fee, so before the fix this order could not be closed until it had been settled.
+            let signature = owner.close_order(&order)?.build().await?.send().await?;
+            tracing::info!(%order, %signature, "closed the cancelled order without settling anything");
+
+            let signature = builder
+                .set_builder_fee_factor(store, 0)?
+                .send_without_preflight()
+                .await?;
+            tracing::info!(%signature, "the builder opted back out");
 
             Ok::<_, eyre::Report>(())
         })

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -48,6 +48,31 @@ async fn last_builder_fee_charged(
         .ok_or_eyre("no `BuilderFeeCharged` event was emitted")
 }
 
+/// Counts the [`BuilderFeeCharged`] events on the most recent transaction touching `order`,
+/// alongside the total number of events read.
+///
+/// The total is the positive control, and the reason this is not just [`last_builder_fee_charged`]
+/// with the result inverted: that helper's `Err` covers both "the event is absent" and "the read
+/// failed", so asserting on it would let a broken reader pass as a passing test. `(0, 0)` means
+/// nothing was read and proves nothing; `(0, n)` for `n > 0` is a real absence.
+async fn builder_fee_charged_count(
+    client: &Client<SignerRef>,
+    order: &Pubkey,
+) -> eyre::Result<(usize, usize)> {
+    let slot = client.get_slot(None).await?;
+    let events = client
+        .last_order_events(order, slot, CommitmentConfig::confirmed())
+        .await?;
+
+    let total = events.len();
+    let charged = events
+        .iter()
+        .filter(|event| matches!(event, GMSOLCPIEvent::BuilderFeeCharged(_)))
+        .count();
+
+    Ok((charged, total))
+}
+
 #[tokio::test]
 async fn balanced_market_order() -> eyre::Result<()> {
     let deployment = current_deployment().await?;
@@ -2079,6 +2104,23 @@ async fn soft_failed_execution_records_no_builder_fee() -> eyre::Result<()> {
             assert_eq!(
                 executed.builder_fee_amount, recorded_before,
                 "a discarded execution must leave the recorded builder fee untouched"
+            );
+
+            // The event half of the same defect, reported externally on #433. `BuilderFeeCharged`
+            // used to be emitted where the fee was computed, several fallible steps above the
+            // record, and `emit_cpi` is a self-CPI: once it returns, the event is in the
+            // transaction, and the soft-failure arm commits that transaction rather than reverting
+            // it. So a discarded execution announced a charge the order never recorded. Measured
+            // before the fix, this returned payable/paid `(13, 13)` against a recorded 0.
+            let (charged, total) = builder_fee_charged_count(&keeper, &order).await?;
+            assert!(
+                total > 0,
+                "read no events at all from the cancelled execution, so the absence asserted \
+                 below would prove nothing"
+            );
+            assert_eq!(
+                charged, 0,
+                "a discarded execution must not announce a builder fee charge"
             );
 
             // The other half of the defect: the close guard refuses any order carrying a recorded


### PR DESCRIPTION
> Resubmitted from a branch in this repository so the CI jobs can reach the repo secrets. Supersedes #424, which ran from a fork and therefore never executed the oracle tests.

`Order` is not revertible. `perform_execution` takes it as a plain `&mut Order`, unlike `RevertiblePosition` and the markets, so anything written to it survives a soft failure. The builder fee was recorded part-way through execution, and when a later step fails with `cancel_on_execution_error` set, the `TransferOut` that was supposed to fund that fee is replaced by `Default::default()` while the record stays. The order is then cancelled, and every close path refuses it until `settle_builder_fee` has run against an escrow nothing was routed into.

Introduced by #421, which replaced four hardcoded zero fee factors with the order's checkpointed one; before that `record_builder_fee(0)` made the path unreachable.

### The fix

The execution no longer writes the fee onto the order until it has succeeded.

`execute_increase_position` and `execute_decrease_position` return the charged amount in `ExecutionFees`, alongside the `paid_fee_value` they already returned, and `perform_execution` calls `record_builder_fee` once, after the last fallible step, next to `unchecked_process_gt`. That is the shape `paid_fee_value` has always had: compute it during the attempt, apply it at the irreversible point.

The fee is still computed where it was, because both paths need it locally. Increase deducts it from the collateral before `position.increase()`, decrease clamps it against the realised output. Only the write to `Order` moved, and in a later round the event followed it, see "The event" below.

`record_builder_fee` runs just before `unchecked_process_gt` rather than after it. `unchecked_process_gt` mints into the store and the user part-way through, so an overflow raised after it had run would land in the soft-failure arm with that mint left behind.

An earlier revision of this PR snapshotted the amount before `perform_execution` and restored it in the soft-failure arm. The review on this PR pointed out that this trades a global property, that `perform_execution` leaves no state behind on failure, for a per-writer undo obligation, and that is the better reading: `paid_fee_value` carries exactly the same exposure to a fallible step being added later, so the builder fee was the only field defending itself differently. `restore_builder_fee_amount` goes away with it.

A hard failure needs no handling: the runtime reverts the account write.

### The event

Added after `mv-reyes` pointed out that the fix above splits a pair which used to agree. `BuilderFeeCharged` was still emitted where the fee is computed, several fallible steps above the record, and `emit_cpi` is a self-CPI: once it returns the event sits in the transaction's inner instructions, and the soft-failure arm commits that transaction rather than reverting it. A discarded execution therefore announced a charge the order never recorded. Reproduced before changing anything: `payable/paid = (13, 13)` against a recorded `0`.

The divergence is new in this PR rather than pre-existing. Before it the record was written next to the emit, so the two were wrong together; moving the record without the emit is what split them.

The charge now travels out in `ExecutionFees` as `Option<BuilderFeeCharge>` and is emitted inside the irreversible block. `Some` is set from the fee factor rather than from the amount, because the event's documented contract is that its presence separates "no builder attached" from "builder attached, nothing collectible", so a charge clamped to zero must still announce itself while recording nothing.

**The ordering inside that block is a trade, not a clean win.** The emit sits after `unchecked_process_gt` and immediately before `set_builder_fee_amount`. The write cannot fail, so a successful emit is always followed by its record and the two can no longer disagree. The residual is the reverse pair: an `Err` out of `emit_cpi` would leave GT counted for an execution that then cancels, which is the round 2 review point again. I took that over the alternative because placing the emit after the write reproduces the CON-59 shape, a record with nothing funding it, and because a self-CPI failing is not reachable through ordinary business outcomes the way the min-output rejection above the old emit site was. Narrowed rather than eliminated, and worth a second opinion.

### Tests

`soft_failed_execution_records_no_builder_fee` checkpoints a fee onto a `MarketDecrease` with an unreachable `min_output_amount`, which fails `validate_decrease_output_amounts` after the fee is charged and with `should_throw_error` left false, so the failure lands in the soft-failure arm. It asserts the order is `Cancelled`, that the recorded amount is unchanged, and that the order closes without settling anything. It now also asserts that no `BuilderFeeCharged` event was emitted, counted rather than looked up: the helper returns the number of matching events alongside the total read, so a run that read nothing at all fails on the total instead of passing on the absence.

`decrease_execution_records_builder_fee` is new, and is the half that was missing. The decrease path had no success-side coverage, and the assertion above, that a soft failure records zero, is equally satisfied by a decrease path that records nothing at all. A change to where the fee is written could therefore have stopped paying builders on every decrease order with the suite still green. The new test executes the same order shape with a reachable minimum and asserts the order is `Completed`, the recorded amount is non-zero, the `BuilderFeeCharged` event agrees with it, the close is refused until settlement, and the settled amount lands in the builder's claim vault.

The increase path already had both halves; `charges_builder_fee_on_execution` is its success side.

### Both ways

Each regression test was run against a deliberately broken build as well as the real one, since a test that has only ever passed proves nothing. Both breaks were injected into the code as it stands here, not into the earlier revision, and the two are different mistakes because the two tests guard opposite directions.

| test | injected break | broken build | real build |
| --- | --- | --- | --- |
| `soft_failed_execution_records_no_builder_fee` | record at the decrease charge site instead of deferring, i.e. the pre-fix behaviour | `FAILED`, `left: 13, right: 0` | `ok` |
| `decrease_execution_records_builder_fee` | drop the charged amount instead of returning it, so nothing is ever recorded | `FAILED`, order `Completed` carrying `0` | `ok` |

The first is the original bug reappearing: a discarded execution charging 13 against an order whose principal had been refunded. The second is the failure mode this restructure introduces the risk of, and the reason the test was added: builders silently paid nothing on every decrease order. `cargo clippy` does flag that second mistake (`unused variable`, `unused_mut`), but CI runs clippy without `-D warnings`, so the lint alone would not have stopped it.

One more thing worth flagging: the comment at `programs/store/src/instructions/builder_fee.rs:336` already asserts that "a failed execution charges a zero fee". That was false on `main` and is true again with this change.
