### PR TITLE
fix(test): clone the active Wormhole guardian set at index 1

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -102,6 +102,10 @@ address = "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX"
 # Wormhole Guardian Set account (index = 0)
 [[test.validator.clone]]
 address = "C7RmcKdjeFscYSyekkmCjvHcnBQd7qJDkeB9RmRtuB3L"
+
+# Wormhole Guardian Set account (index = 1)
+[[test.validator.clone]]
+address = "8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5"
 # END guardian-sets
 
 # Pyth Config account

--- a/crates/sdk/src/client/pyth/pull_oracle/pull_oracle_impl.rs
+++ b/crates/sdk/src/client/pyth/pull_oracle/pull_oracle_impl.rs
@@ -184,9 +184,10 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> PostPullOraclePrices<'a, C>
             let draft_vaa = pubkey;
             // The split exists because a VAA can exceed what one transaction can carry, which is
             // not a property of every VAA: the length scales with the guardian signature count,
-            // and Hermes currently serves 292-byte VAAs (guardian set 0, 3 signatures). Slicing
-            // at a fixed index panics on anything shorter than it, so only split when there is
-            // something to split.
+            // and Hermes currently serves 292-byte VAAs at 3 signatures (measured 2026-09-07, by
+            // then on guardian set 1). The set index does not enter the length, the signature
+            // count does, so a rotation alone leaves this untouched. Slicing at a fixed index
+            // panics on anything shorter than it, so only split when there is something to split.
             let split = (vaa.len() > VAA_SPLIT_INDEX).then_some(VAA_SPLIT_INDEX);
             let write_1 =
                 wormhole.write_encoded_vaa(draft_vaa, 0, &vaa[0..split.unwrap_or(vaa.len())]);


### PR DESCRIPTION
Wormhole rotated the guardian set from 0 to 1, so `Anchor.toml` clones a set the cluster has retired and the test validator cannot verify any Pyth VAA. Same shape as #423: the validator does not start, so no test runs at all rather than a test failing.

**Merge order: this one first, then #433.** `test-programs` depends on `check-guardian-set` (`justfile:49`), so until this lands, every push fails the guardian gate before a single test executes. #433 is currently red for exactly that reason and not for anything in its own diff.

Evidence, read off devnet rather than from our own xtask:

- Set 0 (`C7RmcKdjeFscYSyekkmCjvHcnBQd7qJDkeB9RmRtuB3L`, the one currently pinned) carries `expiration_time = 1788627418`, so it expired 2026-09-05T16:56:58Z.
- Set 1 (`8d9szTd157GKCLcxBqiLUgB7mek3v65rbsy2ErRyjwQ5`) carries `expiration_time = 0` and the same 5 guardian keys.
- Hermes now serves VAAs with `guardian_set_index = 1`, checked 2026-09-07 against the feed in `config/example-token-config.toml`. That is the direct confirmation that the old pin can no longer verify anything.

`main` is still green only because nothing has been pushed since #431 on 09-04; the rotation happened a few hours after that run.

**Second commit, and why it is in scope.** The VAA split comment in `pull_oracle_impl.rs` reads "292-byte VAAs (guardian set 0, 3 signatures)", which this rotation makes false. The numbers still hold, Hermes serves 292 bytes at 3 signatures today, so `VAA_SPLIT_INDEX` is unaffected. Only the set is wrong. The comment now says explicitly that the set index does not enter the length while the signature count does, so the next rotation does not re-open the question.

Bug report: CON-63.