### PR TITLE
fix(store): make settle_builder_fee's transferring accounts optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - programs(store): Creating an increase order now requires its final output token to be the position's collateral token, and executing one whose final output token was recorded at creation revalidates the same thing. Creating an order with a different final output token used to succeed and silently ignore the value; it now reverts with `TokenMintMismatched`. Existing orders with an uninitialized final output token are unaffected and keep executing.
+- sdk(sdk): Changed `SettleBuilderFeeHint`'s `final_output_token` and `escrow` fields from `Pubkey` to `Option<Pubkey>`. Both are `None` for an order whose final output token escrow was never initialized, which is now a hint the SDK builds rather than an error it raises. Code constructing the hint by hand must wrap the two values.
 
 ### Added
 
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - programs(store): An increase order now records its final output token at creation when the escrow is provided, which is what makes it eligible for a builder fee later.
 - sdk(solana-utils): Kept the two-argument `Bundle::send_all_with_opts` as a deprecated compatibility wrapper around the detailed API. It still returns the compressed success-signature list, and when multiple transactions fail it returns the **last** real send error (matching prior overwrite semantics; `SendAborted` placeholders are ignored).
+- programs(store): Made `settle_builder_fee`'s `final_output_token` and `escrow` accounts optional, joining `builder_user` and `claim_vault`. All four are required exactly when the order's recorded builder fee amount is non-zero, so the instruction's documented no-op is now reachable for an order whose final output token escrow was never initialized. Such orders are a supported state, and settlement sits on the critical path to closing an order because `CloseOrderV2` rejects a non-zero recorded fee.
 
 ## [0.10.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - programs(store): Creating an increase order now requires its final output token to be the position's collateral token, and executing one whose final output token was recorded at creation revalidates the same thing. Creating an order with a different final output token used to succeed and silently ignore the value; it now reverts with `TokenMintMismatched`. Existing orders with an uninitialized final output token are unaffected and keep executing.
-- sdk(sdk): Changed `SettleBuilderFeeHint`'s `final_output_token` and `escrow` fields from `Pubkey` to `Option<Pubkey>`. Both are `None` for an order whose final output token escrow was never initialized, which is now a hint the SDK builds rather than an error it raises. Code constructing the hint by hand must wrap the two values.
 
 ### Added
 
@@ -29,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - programs(store): An increase order now records its final output token at creation when the escrow is provided, which is what makes it eligible for a builder fee later.
 - sdk(solana-utils): Kept the two-argument `Bundle::send_all_with_opts` as a deprecated compatibility wrapper around the detailed API. It still returns the compressed success-signature list, and when multiple transactions fail it returns the **last** real send error (matching prior overwrite semantics; `SendAborted` placeholders are ignored).
-- programs(store): Made `settle_builder_fee`'s `final_output_token` and `escrow` accounts optional, joining `builder_user` and `claim_vault`. All four are required exactly when the order's recorded builder fee amount is non-zero, so the instruction's documented no-op is now reachable for an order whose final output token escrow was never initialized. Such orders are a supported state, and settlement sits on the critical path to closing an order because `CloseOrderV2` rejects a non-zero recorded fee.
 
 ## [0.10.0] - 2026-08-12
 

--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -20573,15 +20573,29 @@
           "name": "final_output_token",
           "docs": [
             "The final output token mint of the order, i.e. the token the",
-            "builder fee is denominated in."
-          ]
+            "builder fee is denominated in.",
+            "",
+            "Only required when the order has a non-zero recorded builder fee",
+            "amount, for the same reason as `builder_user` below: the no-op path",
+            "moves no tokens and so needs neither the mint nor its decimals.",
+            "Optional so that the instruction can be built for an order whose",
+            "final output token was never initialized, which is a supported",
+            "state and the one the no-op exists to serve."
+          ],
+          "optional": true
         },
         {
           "name": "escrow",
           "docs": [
-            "The order's escrow account for the final output token."
+            "The order's escrow account for the final output token.",
+            "",
+            "Only required alongside `final_output_token`. A non-zero recorded",
+            "amount implies it exists, because `set_builder_fee` refuses to",
+            "checkpoint a builder onto an order whose final output token account",
+            "is uninitialized."
           ],
           "writable": true,
+          "optional": true,
           "pda": {
             "seeds": [
               {

--- a/crates/programs/idls/gmsol_store.json
+++ b/crates/programs/idls/gmsol_store.json
@@ -20537,10 +20537,14 @@
         "",
         "# Errors",
         "- The [`order`](SettleBuilderFee::order) must be initialized and owned by the `store`.",
-        "- If the order's recorded builder fee amount is non-zero, [`builder_user`](SettleBuilderFee::builder_user)",
-        "must be provided and must match the builder recorded on the order, and",
-        "[`claim_vault`](SettleBuilderFee::claim_vault) must be provided and must be the",
-        "associated token account of the final output token owned by `builder_user`."
+        "- If the order's recorded builder fee amount is non-zero, all four of",
+        "[`final_output_token`](SettleBuilderFee::final_output_token),",
+        "[`escrow`](SettleBuilderFee::escrow),",
+        "[`builder_user`](SettleBuilderFee::builder_user) and",
+        "[`claim_vault`](SettleBuilderFee::claim_vault) must be provided: the `escrow` must be",
+        "the final output token account recorded on the order, the `builder_user` must match the",
+        "builder recorded on the order, and the `claim_vault` must be the associated token",
+        "account of the final output token owned by `builder_user`."
       ],
       "discriminator": [
         209,

--- a/crates/sdk/src/client/ops/builder_fee.rs
+++ b/crates/sdk/src/client/ops/builder_fee.rs
@@ -1,14 +1,20 @@
 use std::{future::Future, ops::Deref};
 
 use anchor_spl::associated_token::get_associated_token_address_with_program_id;
-use gmsol_programs::gmsol_store::client::{accounts, args};
+use gmsol_programs::gmsol_store::{
+    client::{accounts, args},
+    ID,
+};
 use gmsol_solana_utils::{
     client_traits::FromRpcClientWith, transaction_builder::TransactionBuilder, IntoAtomicGroup,
 };
 use gmsol_utils::pubkey::optional_address;
 use solana_sdk::{pubkey::Pubkey, signer::Signer};
 
-use crate::builders::order::{SetBuilderFee, SetBuilderFeeHint};
+use crate::{
+    builders::order::{SetBuilderFee, SetBuilderFeeHint},
+    utils::optional::fix_optional_account_metas,
+};
 
 /// Operations for builder fees.
 pub trait BuilderFeeOps<C> {
@@ -153,17 +159,21 @@ impl<C: Deref<Target = impl Signer> + Clone> BuilderFeeOps<C> for crate::Client<
 
         let rpc = self
             .store_transaction()
-            .anchor_accounts(accounts::SettleBuilderFee {
-                store: *store,
-                order: *order,
-                final_output_token,
-                escrow,
-                builder_user,
-                claim_vault,
-                token_program: anchor_spl::token::ID,
-                event_authority: self.store_event_authority(),
-                program: *self.store_program_id(),
-            })
+            .accounts(fix_optional_account_metas(
+                accounts::SettleBuilderFee {
+                    store: *store,
+                    order: *order,
+                    final_output_token,
+                    escrow,
+                    builder_user,
+                    claim_vault,
+                    token_program: anchor_spl::token::ID,
+                    event_authority: self.store_event_authority(),
+                    program: *self.store_program_id(),
+                },
+                &ID,
+                self.store_program_id(),
+            ))
             .anchor_args(args::SettleBuilderFee {});
 
         Ok(rpc)

--- a/crates/sdk/src/client/ops/builder_fee.rs
+++ b/crates/sdk/src/client/ops/builder_fee.rs
@@ -73,9 +73,17 @@ pub struct SettleBuilderFeeHint {
     pub builder: Option<Pubkey>,
     /// The order's final output token mint, i.e. the token the builder
     /// fee is denominated in.
-    pub final_output_token: Pubkey,
+    ///
+    /// `None` for an order that never had one. Only required when
+    /// `builder_fee_amount` is non-zero, matching the instruction's own
+    /// account optionality.
+    pub final_output_token: Option<Pubkey>,
     /// The order's escrow account for the final output token.
-    pub escrow: Pubkey,
+    ///
+    /// `None` when the account was never initialized, which is a supported
+    /// order state rather than an error: settlement there is a no-op and
+    /// needs neither this nor the mint above.
+    pub escrow: Option<Pubkey>,
 }
 
 impl<C: Deref<Target = impl Signer> + Clone> BuilderFeeOps<C> for crate::Client<C> {
@@ -85,54 +93,70 @@ impl<C: Deref<Target = impl Signer> + Clone> BuilderFeeOps<C> for crate::Client<
         order: &Pubkey,
         hint: Option<SettleBuilderFeeHint>,
     ) -> crate::Result<TransactionBuilder<C>> {
-        let hint =
-            match hint {
-                Some(hint) => hint,
-                None => {
-                    let account = self.order(order).await?;
-                    let final_output_token =
-                        account.tokens.final_output_token.token().ok_or_else(|| {
-                            crate::Error::custom("order has no final output token")
-                        })?;
-                    let escrow =
-                        account.tokens.final_output_token.account().ok_or_else(|| {
-                            crate::Error::custom("order has no final output token")
-                        })?;
-                    SettleBuilderFeeHint {
-                        builder_fee_amount: account.builder_fee_amount,
-                        builder: optional_address(&account.builder).copied(),
-                        final_output_token,
-                        escrow,
-                    }
+        let hint = match hint {
+            Some(hint) => hint,
+            None => {
+                // Neither is an error here any more. An order with no
+                // final output token, or with the mint but no escrow
+                // account, is a supported state and settling it is a
+                // no-op; refusing to build the instruction is what made
+                // the no-op unreachable for exactly those orders.
+                let account = self.order(order).await?;
+                SettleBuilderFeeHint {
+                    builder_fee_amount: account.builder_fee_amount,
+                    builder: optional_address(&account.builder).copied(),
+                    final_output_token: account.tokens.final_output_token.token(),
+                    escrow: account.tokens.final_output_token.account(),
                 }
-            };
-
-        // The builder-related accounts are only required for a genuine
-        // settlement: the no-op path performs no CPI and does not touch
-        // them, so they need not even exist on-chain.
-        let (builder_user, claim_vault) = if hint.builder_fee_amount == 0 {
-            (None, None)
-        } else {
-            let builder = hint.builder.ok_or_else(|| {
-                crate::Error::custom(
-                    "order has a non-zero builder fee amount but no builder recorded",
-                )
-            })?;
-            let claim_vault = get_associated_token_address_with_program_id(
-                &builder,
-                &hint.final_output_token,
-                &anchor_spl::token::ID,
-            );
-            (Some(builder), Some(claim_vault))
+            }
         };
+
+        // All four are only required for a genuine settlement: the no-op path
+        // performs no CPI and does not touch them, so they need not even exist
+        // on-chain. A non-zero amount is what makes them required, and each
+        // missing one now names itself. The old message said "order has no
+        // final output token" for a missing mint and for an uninitialized
+        // account alike, so it pointed at the wrong thing whenever the token
+        // existed and only the account did not.
+        let (final_output_token, escrow, builder_user, claim_vault) =
+            if hint.builder_fee_amount == 0 {
+                (None, None, None, None)
+            } else {
+                let final_output_token = hint.final_output_token.ok_or_else(|| {
+                    crate::Error::custom(
+                        "order has a non-zero builder fee amount but no final output token mint",
+                    )
+                })?;
+                let escrow = hint.escrow.ok_or_else(|| {
+                    crate::Error::custom(
+                        "order has a non-zero builder fee amount but no final output token escrow",
+                    )
+                })?;
+                let builder = hint.builder.ok_or_else(|| {
+                    crate::Error::custom(
+                        "order has a non-zero builder fee amount but no builder recorded",
+                    )
+                })?;
+                let claim_vault = get_associated_token_address_with_program_id(
+                    &builder,
+                    &final_output_token,
+                    &anchor_spl::token::ID,
+                );
+                (
+                    Some(final_output_token),
+                    Some(escrow),
+                    Some(builder),
+                    Some(claim_vault),
+                )
+            };
 
         let rpc = self
             .store_transaction()
             .anchor_accounts(accounts::SettleBuilderFee {
                 store: *store,
                 order: *order,
-                final_output_token: hint.final_output_token,
-                escrow: hint.escrow,
+                final_output_token,
+                escrow,
                 builder_user,
                 claim_vault,
                 token_program: anchor_spl::token::ID,

--- a/crates/sdk/src/client/ops/builder_fee.rs
+++ b/crates/sdk/src/client/ops/builder_fee.rs
@@ -114,10 +114,11 @@ impl<C: Deref<Target = impl Signer> + Clone> BuilderFeeOps<C> for crate::Client<
         // All four are only required for a genuine settlement: the no-op path
         // performs no CPI and does not touch them, so they need not even exist
         // on-chain. A non-zero amount is what makes them required, and each
-        // missing one now names itself. The old message said "order has no
-        // final output token" for a missing mint and for an uninitialized
-        // account alike, so it pointed at the wrong thing whenever the token
-        // existed and only the account did not.
+        // missing one now names itself. The old message, "order has no final
+        // output token", was raised for the mint and for the escrow alike, so
+        // a caller-supplied hint missing either one reported the same thing.
+        // A hint derived from the order cannot miss just one: `TokenAndAccount`
+        // records the mint and the account together or records neither.
         let (final_output_token, escrow, builder_user, claim_vault) =
             if hint.builder_fee_amount == 0 {
                 (None, None, None, None)

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -27,15 +27,27 @@ pub struct SettleBuilderFee<'info> {
     pub order: AccountLoader<'info, Order>,
     /// The final output token mint of the order, i.e. the token the
     /// builder fee is denominated in.
-    pub final_output_token: Box<Account<'info, Mint>>,
+    ///
+    /// Only required when the order has a non-zero recorded builder fee
+    /// amount, for the same reason as `builder_user` below: the no-op path
+    /// moves no tokens and so needs neither the mint nor its decimals.
+    /// Optional so that the instruction can be built for an order whose
+    /// final output token was never initialized, which is a supported
+    /// state and the one the no-op exists to serve.
+    pub final_output_token: Option<Box<Account<'info, Mint>>>,
     /// The order's escrow account for the final output token.
+    ///
+    /// Only required alongside `final_output_token`. A non-zero recorded
+    /// amount implies it exists, because `set_builder_fee` refuses to
+    /// checkpoint a builder onto an order whose final output token account
+    /// is uninitialized.
     #[account(
         mut,
         associated_token::mint = final_output_token,
         associated_token::authority = order,
         constraint = order.load()?.tokens().final_output_token.account() == Some(escrow.key()) @ CoreError::TokenAccountMismatched,
     )]
-    pub escrow: Box<Account<'info, TokenAccount>>,
+    pub escrow: Option<Box<Account<'info, TokenAccount>>>,
     /// The builder's User Account.
     ///
     /// Only required when the order has a non-zero recorded builder fee
@@ -80,6 +92,22 @@ impl SettleBuilderFee<'_> {
             return Ok(());
         }
 
+        // All four transferring-path accounts are unwrapped here rather than
+        // required by the struct, so that the no-op above stays reachable for
+        // an order that has none of them. A non-zero amount reaching this
+        // point with any of them missing is a caller error, not a protocol
+        // state: the coverage invariant guarantees the escrow exists whenever
+        // the recorded amount does.
+        let final_output_token = ctx
+            .accounts
+            .final_output_token
+            .as_ref()
+            .ok_or_else(|| error!(CoreError::TokenAccountNotProvided))?;
+        let escrow = ctx
+            .accounts
+            .escrow
+            .as_ref()
+            .ok_or_else(|| error!(CoreError::TokenAccountNotProvided))?;
         let builder_user = ctx
             .accounts
             .builder_user
@@ -111,7 +139,7 @@ impl SettleBuilderFee<'_> {
         // defense in depth, guaranteeing a protocol bug can never make an
         // order permanently unclosable. Any discrepancy is observable via the
         // two amounts recorded on the emitted event below.
-        let settled_amount = recorded_amount.min(ctx.accounts.escrow.amount);
+        let settled_amount = recorded_amount.min(escrow.amount);
 
         let signer = ctx.accounts.order.load()?.signer();
         let seeds = signer.as_seeds();
@@ -119,15 +147,15 @@ impl SettleBuilderFee<'_> {
             CpiContext::new(
                 ctx.accounts.token_program.to_account_info(),
                 TransferChecked {
-                    from: ctx.accounts.escrow.to_account_info(),
-                    mint: ctx.accounts.final_output_token.to_account_info(),
+                    from: escrow.to_account_info(),
+                    mint: final_output_token.to_account_info(),
                     to: claim_vault.to_account_info(),
                     authority: ctx.accounts.order.to_account_info(),
                 },
             )
             .with_signer(&[&seeds]),
             settled_amount,
-            ctx.accounts.final_output_token.decimals,
+            final_output_token.decimals,
         )?;
 
         ctx.accounts.order.load_mut()?.builder_fee_amount = 0;
@@ -137,7 +165,7 @@ impl SettleBuilderFee<'_> {
                 &ctx.accounts.store.key(),
                 &ctx.accounts.order.key(),
                 &builder_user.key(),
-                &ctx.accounts.final_output_token.key(),
+                &final_output_token.key(),
                 recorded_amount,
                 settled_amount,
             )?,

--- a/programs/store/src/instructions/builder_fee.rs
+++ b/programs/store/src/instructions/builder_fee.rs
@@ -102,7 +102,7 @@ impl SettleBuilderFee<'_> {
             .accounts
             .final_output_token
             .as_ref()
-            .ok_or_else(|| error!(CoreError::TokenAccountNotProvided))?;
+            .ok_or_else(|| error!(CoreError::TokenMintNotProvided))?;
         let escrow = ctx
             .accounts
             .escrow

--- a/programs/store/src/lib.rs
+++ b/programs/store/src/lib.rs
@@ -2267,10 +2267,14 @@ pub mod gmsol_store {
     ///
     /// # Errors
     /// - The [`order`](SettleBuilderFee::order) must be initialized and owned by the `store`.
-    /// - If the order's recorded builder fee amount is non-zero, [`builder_user`](SettleBuilderFee::builder_user)
-    ///   must be provided and must match the builder recorded on the order, and
-    ///   [`claim_vault`](SettleBuilderFee::claim_vault) must be provided and must be the
-    ///   associated token account of the final output token owned by `builder_user`.
+    /// - If the order's recorded builder fee amount is non-zero, all four of
+    ///   [`final_output_token`](SettleBuilderFee::final_output_token),
+    ///   [`escrow`](SettleBuilderFee::escrow),
+    ///   [`builder_user`](SettleBuilderFee::builder_user) and
+    ///   [`claim_vault`](SettleBuilderFee::claim_vault) must be provided: the `escrow` must be
+    ///   the final output token account recorded on the order, the `builder_user` must match the
+    ///   builder recorded on the order, and the `claim_vault` must be the associated token
+    ///   account of the final output token owned by `builder_user`.
     pub fn settle_builder_fee(ctx: Context<SettleBuilderFee>) -> Result<()> {
         SettleBuilderFee::invoke(ctx)
     }

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -2357,11 +2357,11 @@ async fn decrease_execution_records_builder_fee() -> eyre::Result<()> {
 /// `settle_builder_fee` is buildable and succeeds as a no-op on an order whose final output token
 /// escrow was never initialized.
 ///
-/// This is the case CON-46 exists for, and it was previously **unconstructible**: the accounts
-/// struct required `final_output_token` and `escrow`, and the SDK refused before building anything
-/// with "order has no final output token". So the handler's own doc comment, which promises the
-/// call is "safe to call in any order state", was not true for exactly the orders that need it
-/// least and hit it most: a keeper composing execute + settle + close settles blindly.
+/// This case was previously **unconstructible**: the accounts struct required `final_output_token`
+/// and `escrow`, and the SDK refused before building anything with "order has no final output
+/// token". So the handler's own doc comment, which promises the call is "safe to call in any order
+/// state", was not true for exactly the orders that need it least and hit it most: a keeper
+/// composing execute + settle + close settles blindly.
 #[tokio::test]
 async fn settle_builder_fee_is_a_no_op_without_escrow() -> eyre::Result<()> {
     let deployment = current_deployment().await?;
@@ -2416,7 +2416,7 @@ async fn settle_builder_fee_is_a_no_op_without_escrow() -> eyre::Result<()> {
         "an order that never had a builder must record no fee"
     );
 
-    // The assertion is that this builds at all: before CON-46 the SDK errored here.
+    // The assertion is that this builds at all: the SDK used to error here.
     let signature = client
         .settle_builder_fee(store, &order, None)
         .await?

--- a/tests/anchor_test/order.rs
+++ b/tests/anchor_test/order.rs
@@ -839,7 +839,6 @@ async fn increase_order_without_escrow_leaves_final_output_token_uninitialized()
     let span = tracing::info_span!("increase_order_without_escrow");
     let _enter = span.enter();
 
-    let client = deployment.user_client(Deployment::DEFAULT_USER)?;
     let store = &deployment.store;
     let fbtc = deployment.token("fBTC").expect("must exist");
 
@@ -847,9 +846,15 @@ async fn increase_order_without_escrow_leaves_final_output_token_uninitialized()
         .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
         .await?;
 
+    // Trades as the exclusive locked user rather than `DEFAULT_USER`. Every test in this module
+    // mints into and spends from that shared balance with no lock over it, so adding two more
+    // consumers of it made the documented `0x1` InsufficientFunds contention fire on order
+    // creation, alternating between these two tests across three runs.
+    let client = deployment.locked_user_client().await?;
+
     let collateral_amount = 100_000;
     deployment
-        .mint_or_transfer_to_user("fBTC", Deployment::DEFAULT_USER, collateral_amount)
+        .mint_or_transfer_to("fBTC", &client.payer(), collateral_amount)
         .await?;
 
     let size = 5_000 * MARKET_USD_UNIT;
@@ -2345,6 +2350,171 @@ async fn decrease_execution_records_builder_fee() -> eyre::Result<()> {
             Ok::<_, eyre::Report>(())
         })
         .await?;
+
+    Ok(())
+}
+
+/// `settle_builder_fee` is buildable and succeeds as a no-op on an order whose final output token
+/// escrow was never initialized.
+///
+/// This is the case CON-46 exists for, and it was previously **unconstructible**: the accounts
+/// struct required `final_output_token` and `escrow`, and the SDK refused before building anything
+/// with "order has no final output token". So the handler's own doc comment, which promises the
+/// call is "safe to call in any order state", was not true for exactly the orders that need it
+/// least and hit it most: a keeper composing execute + settle + close settles blindly.
+#[tokio::test]
+async fn settle_builder_fee_is_a_no_op_without_escrow() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("settle_builder_fee_no_escrow");
+    let _enter = span.enter();
+
+    let store = &deployment.store;
+    let fbtc = deployment.token("fBTC").expect("must exist");
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    // Trades as the exclusive locked user rather than `DEFAULT_USER`. Every test in this module
+    // mints into and spends from that shared balance with no lock over it, so adding two more
+    // consumers of it made the documented `0x1` InsufficientFunds contention fire on order
+    // creation, alternating between these two tests across three runs.
+    let client = deployment.locked_user_client().await?;
+
+    let collateral_amount = 100_000;
+    deployment
+        .mint_or_transfer_to("fBTC", &client.payer(), collateral_amount)
+        .await?;
+
+    // `false` leaves the final output token escrow uninitialized, the same shape
+    // `increase_order_without_escrow_leaves_final_output_token_uninitialized` asserts.
+    let size = 5_000 * MARKET_USD_UNIT;
+    let price = 400_000 * MARKET_USD_UNIT / 10u128.pow(fbtc.config.decimals as u32);
+    let (rpc, order) = client
+        .limit_increase(
+            store,
+            market_token,
+            false,
+            size,
+            price,
+            true,
+            collateral_amount,
+        )
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created an order with no final output token escrow");
+
+    let before = client.order(&order).await?;
+    assert!(
+        before.tokens.final_output_token.token_and_account().is_none(),
+        "the fixture must produce an order with no final output token, otherwise this test is vacuous"
+    );
+    assert_eq!(
+        before.builder_fee_amount, 0,
+        "an order that never had a builder must record no fee"
+    );
+
+    // The assertion is that this builds at all: before CON-46 the SDK errored here.
+    let signature = client
+        .settle_builder_fee(store, &order, None)
+        .await?
+        .send()
+        .await?;
+    tracing::info!(%order, %signature, "settled a builder fee on an order with no escrow");
+
+    let after = client.order(&order).await?;
+    assert_eq!(
+        after.builder_fee_amount, 0,
+        "a no-op settlement must not touch the recorded amount"
+    );
+    assert_eq!(
+        after.header.action_state()?,
+        before.header.action_state()?,
+        "a no-op settlement must not change the order's state"
+    );
+
+    let signature = client.close_order(&order)?.build().await?.send().await?;
+    tracing::info!(%order, %signature, "closed the order after the no-op settlement");
+
+    Ok(())
+}
+
+/// The other half of the no-op: an order that **does** have the escrow but has no builder, so its
+/// recorded fee is zero.
+///
+/// Separate from the case above because the two fail differently if the predicate is ever changed
+/// from the recorded amount to the presence of a builder: this one would still build and start
+/// touching accounts, while the other would not build at all.
+#[tokio::test]
+async fn settle_builder_fee_is_a_no_op_with_escrow_and_zero_fee() -> eyre::Result<()> {
+    let deployment = current_deployment().await?;
+    let _guard = deployment.use_accounts().await?;
+    let span = tracing::info_span!("settle_builder_fee_zero_fee");
+    let _enter = span.enter();
+
+    let store = &deployment.store;
+    let fbtc = deployment.token("fBTC").expect("must exist");
+
+    let market_token = deployment
+        .prepare_market(["fBTC", "fBTC", "USDG"], 1_000_011, 6_000_000_000_007, true)
+        .await?;
+
+    // Trades as the exclusive locked user rather than `DEFAULT_USER`. Every test in this module
+    // mints into and spends from that shared balance with no lock over it, so adding two more
+    // consumers of it made the documented `0x1` InsufficientFunds contention fire on order
+    // creation, alternating between these two tests across three runs.
+    let client = deployment.locked_user_client().await?;
+
+    let collateral_amount = 100_000;
+    deployment
+        .mint_or_transfer_to("fBTC", &client.payer(), collateral_amount)
+        .await?;
+
+    // The escrow is opted into with `prepare_final_output_token_escrow`, not through any of the
+    // positional arguments; without that call the order comes out with the slot uninitialized,
+    // which is the previous test's fixture rather than this one's.
+    let size = 5_000 * MARKET_USD_UNIT;
+    let price = 400_000 * MARKET_USD_UNIT / 10u128.pow(fbtc.config.decimals as u32);
+    let (rpc, order) = client
+        .limit_increase(
+            store,
+            market_token,
+            false,
+            size,
+            price,
+            true,
+            collateral_amount,
+        )
+        .prepare_final_output_token_escrow(true)
+        .build_with_address()
+        .await?;
+    let signature = rpc.send().await?;
+    tracing::info!(%order, %signature, "created an order with an escrow and no builder");
+
+    let before = client.order(&order).await?;
+    assert!(
+        before.tokens.final_output_token.token_and_account().is_some(),
+        "the fixture must produce an order that has the escrow, otherwise this duplicates the previous test"
+    );
+    assert_eq!(before.builder_fee_amount, 0, "no builder means no fee");
+
+    let signature = client
+        .settle_builder_fee(store, &order, None)
+        .await?
+        .send()
+        .await?;
+    tracing::info!(%order, %signature, "settled a builder fee on an order with a zero fee");
+
+    let after = client.order(&order).await?;
+    assert_eq!(
+        after.builder_fee_amount, 0,
+        "a no-op settlement must not touch the recorded amount"
+    );
+
+    let signature = client.close_order(&order)?.build().await?.send().await?;
+    tracing::info!(%order, %signature, "closed the order after the no-op settlement");
 
     Ok(())
 }


### PR DESCRIPTION
`settle_builder_fee` documents itself as a universal no-op, "safe to call in any order state", but neither the accounts struct nor the SDK let that call be constructed for an order whose final output token escrow was never initialized. `final_output_token` and `escrow` were required while `builder_user` and `claim_vault` were optional, although all four are used only on the transferring path. Orders without an escrow are a supported case, covered by `increase_order_without_escrow_leaves_final_output_token_uninitialized`, so the no-op was unreachable for exactly the orders that need it.

That matters beyond tidiness: `CloseOrderV2::validate` requires a zero recorded fee on every close path, so settlement sits on the critical path to closing an order and reclaiming rent.

### The predicate

All four accounts are optional and required when the order's **recorded builder fee amount** is non-zero, not when a builder is present. A non-zero fee already implies the escrow exists, because `set_builder_fee` refuses to checkpoint a builder onto an order whose final output token account is uninitialized (`BuilderFeeFinalOutputTokenEscrowNotInitialized`), so keying all four on that one value is sufficient and internally consistent.

Requiring the builder instead was considered and rejected: it would make the instruction unsafe to call on an order that never had one, contradicting the permissionless and idempotent property the handler's own doc comment promises.

### The program

`final_output_token` and `escrow` become `Option<...>`, and all four are unwrapped in the handler after the zero check, so the no-op stays reachable for an order that has none of them. **Nothing moves from a declarative constraint into the handler**: the `associated_token::mint` and `associated_token::authority` constraints stay where they are, and Anchor applies them when the account is present. `close_order_v2` already carries four optional escrow accounts in exactly that shape, three of them referencing mints that are themselves optional.

The entrypoint's `# Errors` list now names all four accounts as required when the recorded fee is non-zero. It previously named only `builder_user` and `claim_vault`, which stopped being the whole story the moment the other two became optional, and that list compiles into the IDL. The mint's own unwrap uses `TokenMintNotProvided` rather than `TokenAccountNotProvided`, matching `execute_order`, which unwraps a vault and a mint of this same type on adjacent lines.

### The SDK

The hint's `final_output_token` and `escrow` become `Option<Pubkey>`, and building no longer fails when the order has neither. The old error, `order has no final output token`, was raised for the mint and for the escrow alike; it is now three separate messages, each reachable only with a non-zero recorded fee, so a caller-supplied hint missing one of them says which. A hint derived from the order cannot miss just one: `TokenAndAccount` records the mint and the account together or records neither.

Building the instruction goes through `fix_optional_account_metas`, as every op with optional accounts must: Anchor emits `AccountMeta::new_readonly(crate::ID, false)` for a `None` account, fixed at codegen time, while the program decides `None` against the runtime program id, so the two diverge for a client built with a `store_program_id` override.

### The IDL

Regenerated in the same change, since account optionality is expressed there as `optional` per account. The delta is confined to `settle_builder_fee`, asserted structurally rather than by eye, and `settle_builder_fee` appears in no other program's IDL. It carries the corrected `# Errors` text as well, since entrypoint doc comments compile into the IDL.

### The changelog

No entry. Both `settle_builder_fee` and `SettleBuilderFeeHint` arrived in #408, which is also unreleased, so there is nothing here a 0.10 consumer would see change. The two entries this PR originally carried were removed in review.

### Tests

`settle_builder_fee_is_a_no_op_without_escrow` is the coverage this ticket exists for and was **previously unconstructible**: the SDK refused before building anything. `settle_builder_fee_is_a_no_op_with_escrow_and_zero_fee` is kept separate on purpose, because the two fail differently if the predicate is ever changed from the recorded amount to the presence of a builder: one would still build and start touching accounts, the other would not build at all.

Both take the exclusive locked user rather than `DEFAULT_USER`. Every test in that module mints into and spends from the shared balance with no lock over it, and adding two more consumers of it made the known `0x1` InsufficientFunds contention fire on order creation.

### One AC line without a test, deliberately

The AC says a non-zero fee meeting a missing account must fail distinguishably. That path is **unreachable through the SDK**, which now refuses first with its own message, so the program's `TokenAccountNotProvided` guard remains as defence in depth but has no test; covering it would mean building the instruction by hand, which nothing in that test file does today. Raised in chat and accepted rather than quietly closed.