### PR TITLE
fix(decode): register BuilderFeeSettled and BuilderFeeClaimed for typed decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - programs(utils): Added `OrderKind::is_user_initiated_position`, spelled as an explicit list of the five owner-created position kinds. `is_increase_position() || is_decrease_position()` is not equivalent: the latter also matches `Liquidation` and `AutoDeleveraging`, which must never carry a builder fee.
 - sdk(sdk): Added `BuilderFeeOps::set_builder_fee` and the `SetBuilderFee` atomic-group builder for building the instruction.
 - sdk(decode): Added `BuilderFeeFactorSet` and `BuilderFeeSet` to `GMSOLCPIEvent`, so the events decode into their typed form instead of `UnknownOwnedData`.
+- sdk(decode): Added `BuilderFeeSettled` and `BuilderFeeClaimed` to `GMSOLCPIEvent`, so the events decode into their typed form instead of `UnknownOwnedData`.
 - sdk(solana-utils): Added `Bundle::send_all_with_opts_detailed`, returning one `Result` per transaction with stable bundle indices.
 - sdk(solana-utils): Added `Error::SendAborted` for unsent transactions after an early bundle abort.
 - sdk(solana-utils): Made `compress_send_results` public so callers can map detailed results to the legacy signature list.

--- a/crates/decode/src/gmsol.rs
+++ b/crates/decode/src/gmsol.rs
@@ -9,12 +9,12 @@ pub mod programs {
             Store, UserHeader, VirtualInventory, Withdrawal,
         },
         events::{
-            BorrowingFeesUpdated, BuilderFeeCharged, BuilderFeeFactorSet, BuilderFeeSet,
-            DepositExecuted, DepositRemoved, GlvDepositRemoved, GlvPricing, GlvTokenValue,
-            GlvWithdrawalRemoved, GtBuyback, GtUpdated, InsufficientFundingFeePayment,
-            MarketFeesUpdated, MarketStateUpdated, MarketTokenValue, OrderRemoved, OrderUpdated,
-            PositionDecreased, PositionIncreased, ShiftRemoved, SwapExecuted, TradeEvent,
-            WithdrawalExecuted, WithdrawalRemoved,
+            BorrowingFeesUpdated, BuilderFeeCharged, BuilderFeeClaimed, BuilderFeeFactorSet,
+            BuilderFeeSet, BuilderFeeSettled, DepositExecuted, DepositRemoved, GlvDepositRemoved,
+            GlvPricing, GlvTokenValue, GlvWithdrawalRemoved, GtBuyback, GtUpdated,
+            InsufficientFundingFeePayment, MarketFeesUpdated, MarketStateUpdated, MarketTokenValue,
+            OrderRemoved, OrderUpdated, PositionDecreased, PositionIncreased, ShiftRemoved,
+            SwapExecuted, TradeEvent, WithdrawalExecuted, WithdrawalRemoved,
         },
     };
 
@@ -57,6 +57,8 @@ pub mod programs {
     impl_decode_for_cpi_event!(BuilderFeeCharged);
     impl_decode_for_cpi_event!(BuilderFeeFactorSet);
     impl_decode_for_cpi_event!(BuilderFeeSet);
+    impl_decode_for_cpi_event!(BuilderFeeSettled);
+    impl_decode_for_cpi_event!(BuilderFeeClaimed);
 
     untagged!(
         GMSOLAccountData,
@@ -108,6 +110,8 @@ pub mod programs {
             BuilderFeeCharged,
             BuilderFeeFactorSet,
             BuilderFeeSet,
+            BuilderFeeSettled,
+            BuilderFeeClaimed,
             UnknownOwnedData
         ]
     );


### PR DESCRIPTION
`crates/decode/src/gmsol.rs` registers three of the five builder fee events for typed decoding: `BuilderFeeCharged`, `BuilderFeeFactorSet` and `BuilderFeeSet`. `BuilderFeeSettled` and `BuilderFeeClaimed` are missing from both registration points, so they come out of the CPI event stream as `UnknownOwnedData`: a consumer can see a fee being charged but never settled or claimed, which is the half needed to reconcile what a builder is owed against what it received.

This registers the two missing events, matching the three already there: two `impl_decode_for_cpi_event!` lines and two variants in the `GMSOLCPIEvent` untagged set, ahead of the `UnknownOwnedData` catch-all. No IDL change rides along: both events are already in `gmsol_store.json`, so `declare_program!` exposes their types and only the decode registration was missing. Existing consumers are unaffected, the SDK's `GMSOLCPIEvent` matches are all non-exhaustive.

Found while preparing the v0.11 changelog (#437), which lists all five events and is what surfaced the gap.